### PR TITLE
Added automatic deployment to Github Pages for testing

### DIFF
--- a/.github/workflows/build-pages-test-site.yml
+++ b/.github/workflows/build-pages-test-site.yml
@@ -29,6 +29,8 @@ jobs:
               uses: actions/configure-pages@v5
             - name: Install Node.js and NPM
               uses: actions/setup-node@v4
+            - name: NPM Install
+              run: npm install
             - name: NPM Build
               run: npm run build --python
             - name: Upload artifact

--- a/.github/workflows/build-pages-test-site.yml
+++ b/.github/workflows/build-pages-test-site.yml
@@ -27,6 +27,8 @@ jobs:
               uses: actions/checkout@v4
             - name: Setup Pages
               uses: actions/configure-pages@v5
+            - name: Install Node.js and NPM
+              uses: actions/setup-node@v4
             - name: NPM Build
               run: npm run build --python
             - name: Upload artifact

--- a/.github/workflows/build-pages-test-site.yml
+++ b/.github/workflows/build-pages-test-site.yml
@@ -32,7 +32,7 @@ jobs:
             - name: NPM Install
               run: npm install
             - name: NPM Build
-              run: npm run build --python
+              run: npm run build --python --githubpages
             - name: Upload artifact
               uses: actions/upload-pages-artifact@v3
               with:

--- a/.github/workflows/build-pages-test-site.yml
+++ b/.github/workflows/build-pages-test-site.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+on:
+    # Runs on pushes targeting the default branch
+    push:
+        branches: ["main"]    
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+    group: "pages"
+    cancel-in-progress: false
+
+jobs:
+    # Build job
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup Pages
+              uses: actions/configure-pages@v5
+            - name: NPM Build
+              run: npm run build --python
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: dist/
+    
+    # Deployment job
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        needs: build
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/src/assets/style/test-watermark.scss
+++ b/src/assets/style/test-watermark.scss
@@ -4,7 +4,7 @@ body::before {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%) rotate(-45deg); /* Center and rotate diagonally */
-    font-size: 10vw; /* Adjust size relative to the viewport width */
+    font-size: 15vw; /* Adjust size relative to the viewport width */
     color: rgba(0, 0, 0, 0.1); /* Light grey and semi-transparent */
     white-space: nowrap; /* Prevent text wrapping */
     pointer-events: none; /* Allow interaction with page elements below */

--- a/src/assets/style/test-watermark.scss
+++ b/src/assets/style/test-watermark.scss
@@ -1,0 +1,13 @@
+body::before {
+    content: "TESTING"; /* The watermark text */
+    position: fixed; /* Stays in place across the viewport */
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) rotate(-45deg); /* Center and rotate diagonally */
+    font-size: 10vw; /* Adjust size relative to the viewport width */
+    color: rgba(0, 0, 0, 0.1); /* Light grey and semi-transparent */
+    white-space: nowrap; /* Prevent text wrapping */
+    pointer-events: none; /* Allow interaction with page elements below */
+    z-index: 9999; /* Ensure it stays on top without affecting others */
+    user-select: none; /* Prevent text selection */
+}

--- a/vue.config.js
+++ b/vue.config.js
@@ -96,7 +96,9 @@ module.exports = {
             scss: {
                 additionalData: `
                     @import "@/assets/style/variables.scss";
-                `,
+                ` + (process.env.npm_config_githubpages ?  `
+                    @import "@/assets/style/test-watermark.scss";
+                ` : ""),
             },
         },
     },

--- a/vue.config.js
+++ b/vue.config.js
@@ -81,7 +81,7 @@ module.exports = {
         }
     },
 
-    publicPath: (process.env.npm_config_python)?"/editor/":"/microbit/",
+    publicPath: (process.env.npm_config_githubpages) ? "/Strype/" : ((process.env.npm_config_python)?"/editor/":"/microbit/"),
     pluginOptions: {
         i18n: {
             locale: "en",


### PR DESCRIPTION
As discussed in the meeting, this adds an automatic action whenever the main branch is updated (should include PRs being merged, but we will see once we merge the next one) to build and copy it to Github Pages.  I also added a watermark on this version that says "TESTING" to discourage general use.

This turned out to be easier than expected -- Github Pages is already very well supported by Github Actions as you'll see below, so it was only following their tutorial plus getting AI to do the watermark.

You can see what it looks like on my repository where it's working already: https://neilccbrown.github.io/Strype/