### PR TITLE
Handles "try" structures wrong syntax (missing "except" or "finally")

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "sortablejs": "^1.15.0",
                 "splitpanes": "^2.4.1",
                 "textarea-caret": "^3.1.0",
-                "tigerpython-parser": "github:neilccbrown/TigerPython-Parser#fix-empty-global",
+                "tigerpython-parser": "github:Tobias-Kohn/TigerPython-Parser",
                 "ts-node": "^10.9.1",
                 "ts-node-dev": "^2.0.0",
                 "v-blur": "^1.0.4",
@@ -17123,8 +17123,8 @@
             "dev": true
         },
         "node_modules/tigerpython-parser": {
-            "version": "1.0.0",
-            "resolved": "git+ssh://git@github.com/neilccbrown/TigerPython-Parser.git#02027148cd7a0d69ca1b7281b4a285ddfbe4f213"
+            "version": "1.0.1",
+            "resolved": "git+ssh://git@github.com/Tobias-Kohn/TigerPython-Parser.git#c0e61ffe852c1120c84e84b3d5000dda824da8ff"
         },
         "node_modules/tinytim": {
             "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "sortablejs": "^1.15.0",
         "splitpanes": "^2.4.1",
         "textarea-caret": "^3.1.0",
-        "tigerpython-parser": "github:neilccbrown/TigerPython-Parser#fix-empty-global",
+        "tigerpython-parser": "github:Tobias-Kohn/TigerPython-Parser",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "v-blur": "^1.0.4",

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,6 +36,7 @@
                         <div class="row no-gutters" >
                             <Menu 
                                 :id="menuUID" 
+                                :ref="menuUID"
                                 @app-showprogress="applyShowAppProgress"
                                 @app-reset-project="resetStrypeProject"
                                 class="noselect no-print"

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -7,7 +7,7 @@
         <!-- keep the tabIndex attribute, it is necessary to handle focus with Safari -->
         <div 
             :style="frameStyle" 
-            :class="{frameDiv: true, blockFrameDiv: isBlockFrame && !isJointFrame, statementFrameDiv: !isBlockFrame && !isJointFrame}"
+            :class="{frameDiv: true, blockFrameDiv: isBlockFrame && !isJointFrame, statementFrameDiv: !isBlockFrame && !isJointFrame, error: hasParsingError}"
             :id="UID"
             @click="toggleCaret($event)"
             @contextmenu="handleClick($event)"
@@ -39,12 +39,12 @@
                 :wasLastRuntimeError="wasLastRuntimeError"
             />
             <b-popover
-                v-if="hasRuntimeError || wasLastRuntimeError"
+                v-if="hasRuntimeError || wasLastRuntimeError || hasParsingError"
                 ref="errorPopover"
                 :target="frameHeaderId"
-                :title="$t((hasRuntimeError) ? 'PEA.runtimeErrorConsole' : 'errorMessage.pastFrameErrTitle')"
+                :title="errorPopupTitle"
                 triggers="hover"
-                :content="(hasRuntimeError) ? runTimeErrorMessage : runtimeErrorAtLastRunMsg"
+                :content="errorPopupContent"
                 :custom-class="(hasRuntimeError) ? 'error-popover modified-title-popover': 'error-popover'"
                 placement="left"
             >
@@ -208,6 +208,14 @@ export default Vue.extend({
             return this.isBeingDragged || !!this.appStore.frameObjects[this.frameId].isBeingDragged;
         },
 
+        parsingErrorMessage(): string {
+            return this.appStore.frameObjects[this.frameId].atParsingError ?? "";
+        },
+
+        hasParsingError(): boolean {
+            return this.parsingErrorMessage.length > 0;
+        },
+
         runTimeErrorMessage(): string {
             return this.appStore.frameObjects[this.frameId].runTimeError ?? "";
         },
@@ -218,6 +226,14 @@ export default Vue.extend({
 
         wasLastRuntimeError(): boolean {
             return this.appStore.wasLastRuntimeErrorFrameId == this.frameId;
+        },
+
+        errorPopupTitle(): string {
+            return this.$t((this.hasParsingError) ? "errorMessage.errorTitle" : ((this.hasRuntimeError) ? "PEA.runtimeErrorConsole" : "errorMessage.pastFrameErrTitle")) as string;
+        },
+
+        errorPopupContent(): string {
+            return (this.hasParsingError) ? this.parsingErrorMessage : ((this.hasRuntimeError) ? this.runTimeErrorMessage : this.runtimeErrorAtLastRunMsg);
         },
 
         deletableFrame(): boolean{

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -37,6 +37,7 @@
                 :frameAllowChildren="allowChildren"
                 :erroneous="hasRuntimeError"
                 :wasLastRuntimeError="wasLastRuntimeError"
+                :onFocus="showFrameParseErrorPopupOnHeaderFocus"
             />
             <b-popover
                 v-if="hasRuntimeError || wasLastRuntimeError || hasParsingError"
@@ -45,7 +46,7 @@
                 :title="errorPopupTitle"
                 triggers="hover"
                 :content="errorPopupContent"
-                :custom-class="(hasRuntimeError) ? 'error-popover modified-title-popover': 'error-popover'"
+                :custom-class="(hasRuntimeError || hasParsingError) ? 'error-popover modified-title-popover': 'error-popover'"
                 placement="left"
             >
             </b-popover>
@@ -1066,6 +1067,14 @@ export default Vue.extend({
 
         deleteOuter(): void {
             this.appStore.deleteOuterFrames(this.frameId);
+        },
+
+        showFrameParseErrorPopupOnHeaderFocus(isFocusing: boolean): void{
+            // We need to be able to show the frame error popup programmatically
+            // (if applies) when we navigate to the error.
+            if(this.hasParsingError){
+                (this.$refs.errorPopover as InstanceType<typeof BPopover>).$emit((isFocusing) ? "open" : "close");
+            }
         },
     },
 });

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -1071,8 +1071,8 @@ export default Vue.extend({
 
         showFrameParseErrorPopupOnHeaderFocus(isFocusing: boolean): void{
             // We need to be able to show the frame error popup programmatically
-            // (if applies) when we navigate to the error.
-            if(this.hasParsingError){
+            // (if applies) when we navigate to the error - we make sure the frame still exists.
+            if(this.appStore.frameObjects[this.frameId] && this.hasParsingError){
                 (this.$refs.errorPopover as InstanceType<typeof BPopover>).$emit((isFocusing) ? "open" : "close");
             }
         },

--- a/src/components/FrameHeader.vue
+++ b/src/components/FrameHeader.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div tabindex="-1" @focus="onFocus(true)" @blur="onFocus(false)" style="outline: none;">
         <div class="frame-header-div">
             <div
                 class="next-to-eachother label-slots-struct-wrapper"
@@ -56,6 +56,7 @@ export default Vue.extend({
         frameAllowChildren: Boolean,
         erroneous: Boolean,
         wasLastRuntimeError: Boolean,
+        onFocus: Function, // Handler for focus/blur the header (see Frame.vue)
     },
 
     computed:{

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -790,10 +790,11 @@ export default Vue.extend({
         },
 
         
-        goToError(event: MouseEvent, toNext: boolean){
+        goToError(event: MouseEvent | null, toNext: boolean){
             // Move to the next error (if toNext is true) or the previous error (if toNext is false) when the user clicks on the navigation icon.
             // If the icon is "disabled" we do nothing.
-            if(!(event.target as HTMLElement).classList.contains("error-nav-disabled")){
+            // Note that a null event is set by a programmatical call of this method.
+            if(event == null || !(event.target as HTMLElement).classList.contains("error-nav-disabled")){
                 this.$nextTick(() => {
                     // If we are currently in a slot, we need to make sure that that slot gets notified of the caret lost
                     if(this.appStore.focusSlotCursorInfos){

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -130,8 +130,8 @@
 import Vue from "vue";
 import { useStore } from "@/store/store";
 import {saveContentToFile, readFileContent, fileNameRegex, strypeFileExtension, isMacOSPlatform} from "@/helpers/common";
-import { AppEvent, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, Locale, MessageDefinitions, MIMEDesc, PythonExecRunningState, SaveRequestReason, SlotCoreInfos, SlotCursorInfos, SlotType, StrypeSyncTarget } from "@/types/types";
-import { countEditorCodeErrors, CustomEventTypes, fileImportSupportedFormats, getAppSimpleMsgDlgId, getEditorCodeErrorsHTMLElements, getEditorMenuUID, getFrameUID, getLabelSlotUID, getNearestErrorIndex, getSaveAsProjectModalDlg, isElementEditableLabelSlotInput, isElementUIDFrameHeader, parseFrameHeaderUID, parseLabelSlotUID, setDocumentSelection } from "@/helpers/editor";
+import { AppEvent, CaretPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, Locale, MessageDefinitions, MIMEDesc, PythonExecRunningState, SaveRequestReason, SlotCoreInfos, SlotCursorInfos, SlotType, StrypeSyncTarget } from "@/types/types";
+import { countEditorCodeErrors, CustomEventTypes, fileImportSupportedFormats, getAppSimpleMsgDlgId, getEditorCodeErrorsHTMLElements, getEditorMenuUID, getFrameHeaderUID, getFrameUID, getLabelSlotUID, getNearestErrorIndex, getSaveAsProjectModalDlg, isElementEditableLabelSlotInput, isElementUIDFrameHeader, isIdAFrameId, parseFrameHeaderUID, parseFrameUID, parseLabelSlotUID, setDocumentSelection } from "@/helpers/editor";
 import { Slide } from "vue-burger-menu";
 import { mapStores } from "pinia";
 import GoogleDrive from "@/components/GoogleDrive.vue";
@@ -143,6 +143,7 @@ import { watch } from "@vue/composition-api";
 import { cloneDeep } from "lodash";
 import App from "@/App.vue";
 import appPackageJson from "@/../package.json";
+import { getAboveFrameCaretPosition } from "@/helpers/storeMethods";
 
 //////////////////////
 //     Component    //
@@ -806,21 +807,37 @@ export default Vue.extend({
                     const isFullIndex = ((this.currentErrorNavIndex % 1) == 0);
                     this.currentErrorNavIndex += (((toNext) ? 1 : -1) / ((isFullIndex) ? 1 : 2));
                     const errorElement = getEditorCodeErrorsHTMLElements()[this.currentErrorNavIndex];
-                    // We focus on the slot of the error -- if the erroneous HTML is a slot, we just give it focus. If the error is at the frame scope
+                    // The error can be in a slot or it can be for a whole frame. By convention, the location for a frame error is the caret above it.
+                    // For errors in a slot: we focus on the slot of the error -- if the erroneous HTML is a slot, we just give it focus. If the error is at the frame scope
                     // we put the focus in the first slot that is editable.
-                    const errorSlotInfos: SlotCoreInfos = (isElementEditableLabelSlotInput(errorElement))
-                        ? parseLabelSlotUID(errorElement.id)
-                        : {frameId: parseFrameHeaderUID(errorElement.id), labelSlotsIndex: 0, slotId: "0", slotType: SlotType.code};
-                    const errorSlotCursorInfos: SlotCursorInfos = {slotInfos: errorSlotInfos, cursorPos: 0}; 
-                    this.appStore.setSlotTextCursors(errorSlotCursorInfos, errorSlotCursorInfos);
-                    setDocumentSelection(errorSlotCursorInfos, errorSlotCursorInfos);  
-                    // It's necessary to programmatically click the slot we gave focus to, so we can toggle the edition mode event chain
-                    if(isElementUIDFrameHeader(errorElement.id)){
-                        document.getElementById(getLabelSlotUID(errorSlotInfos))?.click();
+                    if(isIdAFrameId(errorElement.id)){
+                        // Error on a whole frame - the error message will be on the header so we need to focus it to trigger the popup.
+                        if(this.appStore.isEditing) {
+                            this.appStore.isEditing = false;
+                            this.appStore.setSlotTextCursors(undefined, undefined);
+                            document.getSelection()?.removeAllRanges(); 
+                        }
+                        const caretPosAboveFrame = getAboveFrameCaretPosition(parseFrameUID(errorElement.id));
+                        this.appStore.setCurrentFrame({id: caretPosAboveFrame.frameId, caretPosition: caretPosAboveFrame.caretPosition as CaretPosition});
+                        document.getElementById(getFrameHeaderUID(parseFrameUID(errorElement.id)))?.focus();
                     }
                     else{
-                        errorElement.click();
+                        // Error on a slot
+                        const errorSlotInfos: SlotCoreInfos = (isElementEditableLabelSlotInput(errorElement))
+                            ? parseLabelSlotUID(errorElement.id)
+                            : {frameId: parseFrameHeaderUID(errorElement.id), labelSlotsIndex: 0, slotId: "0", slotType: SlotType.code};
+                        const errorSlotCursorInfos: SlotCursorInfos = {slotInfos: errorSlotInfos, cursorPos: 0}; 
+                        this.appStore.setSlotTextCursors(errorSlotCursorInfos, errorSlotCursorInfos);
+                        setDocumentSelection(errorSlotCursorInfos, errorSlotCursorInfos);  
+                        // It's necessary to programmatically click the slot we gave focus to, so we can toggle the edition mode event chain
+                        if(isElementUIDFrameHeader(errorElement.id)){
+                            document.getElementById(getLabelSlotUID(errorSlotInfos))?.click();
+                        }
+                        else{
+                            errorElement.click();
+                        }
                     }
+                   
                     this.navigateToErrorRequested = false;
                 });
             }     

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -564,10 +564,13 @@ export function getNearestErrorIndex(): number {
                     && navPos.slotType == slotInfos.slotType));
             }
             else if(isElementWholeFrame){
-                // Get the caret position above the frame
+                // Get the caret position above the frame - if that frame still exists !
+                // (when deleting it from the body, the frame may be gone but the errors still not updated)
                 const frameId = parseFrameUID(elementId);
                 const caretPosAbove = getAboveFrameCaretPosition(frameId);
-                allPosIndexes.push(allCaretPositions.findIndex((navPos) => !navPos.isSlotNavigationPosition && navPos.frameId == caretPosAbove.frameId && navPos.caretPosition == caretPosAbove.caretPosition));
+                if(caretPosAbove) {
+                    allPosIndexes.push(allCaretPositions.findIndex((navPos) => !navPos.isSlotNavigationPosition && navPos.frameId == caretPosAbove.frameId && navPos.caretPosition == caretPosAbove.caretPosition));
+                }
             }
             // Look for the position of the current focused blue caret (because if we have an element that is the caret it can only be the current blue caret, there is no errors on a blue caret...)
             else{

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1,7 +1,7 @@
 import i18n from "@/i18n";
 import { useStore } from "@/store/store";
 import { AddFrameCommandDef, AddShorthandFrameCommandDef, AllFrameTypesIdentifier, areSlotCoreInfosEqual, BaseSlot, CaretPosition, FrameContextMenuActionName, FrameContextMenuShortcut, FramesDefinitions, getFrameDefType, isFieldBracketedSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, ModifierKeyCode, NavigationPosition, Position, SelectAllFramesFuncDefScope, SlotCoreInfos, SlotCursorInfos, SlotsStructure, SlotType, StringSlot } from "@/types/types";
-import { getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFrameSectionIdFromFrameId } from "./storeMethods";
+import { getAboveFrameCaretPosition, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFrameBelowCaretPosition, getFrameSectionIdFromFrameId } from "./storeMethods";
 import { strypeFileExtension } from "./common";
 import {getContentForACPrefix} from "@/autocompletion/acManager";
 import scssVars  from "@/assets/style/_export.module.scss";
@@ -88,8 +88,16 @@ export function getImportDiffVersionModalDlgId(): string {
     return "importDiffVersionModalDlg";
 }
 
+const frameUIDRegex = /^frame_id_(\d+)$/;
 export function isIdAFrameId(id: string): boolean {
-    return id.match(/^frame_id_\d+$/) !== null;
+    return id.match(frameUIDRegex) !== null;
+}
+
+// Parse a frameUID to retrieve the frame ID. 
+// As finding the match against the regex may fail, we need a fallout value: -100;
+export function parseFrameUID(frameUID: string): number {
+    const frameUIDMatch = frameUID.match(frameUIDRegex);
+    return (frameUIDMatch) ? parseInt(frameUIDMatch[1]) : -100;
 }
 
 const labelSlotUIDRegex = /^input_frame_(\d+)_label_(\d+)_slot_([0-7]{4})_(\d+(,\d+)*)$/;
@@ -464,10 +472,21 @@ export function checkEditorCodeErrors(): void{
     const erroneousHTMLElements = [...document.getElementsByClassName("error"), ...document.getElementsByClassName("errorSlot")];
     if(erroneousHTMLElements.length > 0){
         for(const erroneousHTMLElement of erroneousHTMLElements) {
-            if(erroneousHTMLElement.classList.contains("labelSlot-input") || erroneousHTMLElement.classList.contains("frame-header")){
+            if(erroneousHTMLElement.classList.contains("labelSlot-input") || erroneousHTMLElement.classList.contains("frame-header") || erroneousHTMLElement.classList.contains("frameDiv")){
                 errorHTMLElements.push(erroneousHTMLElement as HTMLElement);
             }
         }
+
+        // The elements NEED to be in order so we can navigate through them.
+        // In other words, we sort out the elements based on their vertical position first, then horizontal position.
+        errorHTMLElements.sort((el1, el2) => {
+            if(el1.getBoundingClientRect().y != el2.getBoundingClientRect().y){
+                return el1.getBoundingClientRect().y - el2.getBoundingClientRect().y;
+            }
+            else{
+                return el1.getBoundingClientRect().x - el2.getBoundingClientRect().x;
+            }
+        });
     }
 }
 
@@ -496,7 +515,7 @@ export function hasPrecompiledCodeError(): boolean {
     return hasEditorCodeErrors() && !errorHTMLElements?.some((element) => isElementUIDFrameHeader(element.id));                                                                    
 }
 
-// This methods checks for the relative positions of the current position (which can be a focused slot or a blue caret) towards the positions of the errors (slots or 1st slot an frame header)
+// This methods checks for the relative positions of the current position (which can be a focused slot or a blue caret) towards the positions of the errors (slots or 1st slot in frame header or a frame)
 // We return the "full" index (of the error list) if the current position is ON an error, otherwise "semi" indexes that will allow navigating the errors properly:
 // for example if the current position is before the first error, the index is -0.5 so we can still go down and reach error indexed 0
 export function getNearestErrorIndex(): number {
@@ -508,14 +527,23 @@ export function getNearestErrorIndex(): number {
     const errorsElmtIds = (errorHTMLElements as HTMLElement[]).flatMap((elmt) => elmt.id);
     const isEditing = useStore().isEditing;
 
-    // Get the slot currently being edited: we check first if that's one of the error so it would be a "real" index of the error array
+    // Three situations can happen: we have an error in a slot (the most common case) or we have an error for the whole frame
+    // (this is rare but can happen, for example in the situation of a wrongly constructed "try" structure (TP error)).
+
+    // Get the slot currently being edited OR the current caret position : we check first if that's one of the error so it would be a "real" index of the error array
     // if it's not, then we'll find in between which 2 errors we're in and use a "semi" index
+    const currentFrame = useStore().currentFrame;
     const currentFocusedElementId = (isEditing && useStore().focusSlotCursorInfos != undefined) 
         ? getLabelSlotUID(useStore().focusSlotCursorInfos?.slotInfos as SlotCoreInfos) 
-        : getCaretUID(useStore().currentFrame.caretPosition, useStore().currentFrame.id);
+        : getCaretUID(currentFrame.caretPosition, currentFrame.id);
+    const belowCurrentCaretFrameId = (!isEditing) ? getFrameBelowCaretPosition({frameId: currentFrame.id, caretPosition: currentFrame.caretPosition, isSlotNavigationPosition: false}) : null;
     // Case 1: we are in a slot that is erroneous, or in a slot of an erroneous frame
     if(errorsElmtIds.includes(currentFocusedElementId) || (isEditing && errorsElmtIds.includes(getFrameHeaderUID(useStore().focusSlotCursorInfos?.slotInfos.frameId as number)))){
         return errorsElmtIds.indexOf((errorsElmtIds.includes(currentFocusedElementId)) ? currentFocusedElementId : getFrameHeaderUID(useStore().focusSlotCursorInfos?.slotInfos.frameId as number));
+    }
+    // Case 2: we are not editing and the caret position is above an erroneous frame (by convention)
+    else if(!isEditing && belowCurrentCaretFrameId && errorsElmtIds.includes(getFrameUID(belowCurrentCaretFrameId))) {
+        return errorsElmtIds.indexOf(getFrameUID(belowCurrentCaretFrameId));
     }
     else{
         // Case 2: not in an error, we find out our relative position to the list of errors
@@ -525,22 +553,29 @@ export function getNearestErrorIndex(): number {
         [...errorsElmtIds, currentFocusedElementId].forEach((elementId) => {
             const isElementEditableSlot = isElementEditableLabelSlotInput(document.getElementById(elementId));
             const isElementFrameHeader = isElementUIDFrameHeader(elementId);
+            const isElementWholeFrame = isIdAFrameId(elementId);
             // Look the position of a slot (an error or the currently focused slot, or the first slot of an erroneous frame)
             if(isElementEditableSlot || isElementFrameHeader){
                 const slotInfos: SlotCoreInfos = (isElementEditableSlot) 
                     ? parseLabelSlotUID(elementId)
                     : {frameId: parseFrameHeaderUID(elementId), slotId: "0", labelSlotsIndex: 0, slotType: SlotType.code};
                 allPosIndexes.push(allCaretPositions.findIndex((navPos) => navPos.isSlotNavigationPosition && navPos.frameId == slotInfos.frameId 
-                && navPos.labelSlotsIndex == slotInfos.labelSlotsIndex && navPos.slotId == slotInfos.slotId 
-                && navPos.slotType == slotInfos.slotType));
+                    && navPos.labelSlotsIndex == slotInfos.labelSlotsIndex && navPos.slotId == slotInfos.slotId 
+                    && navPos.slotType == slotInfos.slotType));
+            }
+            else if(isElementWholeFrame){
+                // Get the caret position above the frame
+                const frameId = parseFrameUID(elementId);
+                const caretPosAbove = getAboveFrameCaretPosition(frameId);
+                allPosIndexes.push(allCaretPositions.findIndex((navPos) => !navPos.isSlotNavigationPosition && navPos.frameId == caretPosAbove.frameId && navPos.caretPosition == caretPosAbove.caretPosition));
             }
             // Look for the position of the current focused blue caret (because if we have an element that is the caret it can only be the current blue caret, there is no errors on a blue caret...)
             else{
-                allPosIndexes.push(allCaretPositions.findIndex((navPos) => !navPos.isSlotNavigationPosition && navPos.frameId == useStore().currentFrame.id && navPos.caretPosition == useStore().currentFrame.caretPosition));
+                allPosIndexes.push(allCaretPositions.findIndex((navPos) => !navPos.isSlotNavigationPosition && navPos.frameId == currentFrame.id && navPos.caretPosition == currentFrame.caretPosition));
             }
         });
         
-        // If we are not editing, we add the position of the caret at the end of the array (since we would have skipped pushing a value as currentFocusedElementId would be empty)
+        // Now we can find the relative position of the current position with regards to the errors' positions
         const currentFocusedPosIndex = allPosIndexes.pop() as number;
         if(currentFocusedPosIndex < allPosIndexes[0]){
             return -0.5;

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -833,14 +833,19 @@ export function checkPrecompiledErrorsForFrame(frameId: number): void {
 }
 
 export function checkCodeErrors(frameIdForPrecompiled?: number): void {
-    // Clear all errors first.
-    // We do this in two pass: 
+    // We check errors in in three passes (all code errors are cleared in 1) and 2)): 
     //   1) check for the UI pre-compiled errors for each frame unless if a specific frame is specified, then we check that frame only
     const frameArray = ((frameIdForPrecompiled) ? [frameIdForPrecompiled.toString()] : Object.keys(useStore().frameObjects));
     for(const frameId of frameArray){
         checkPrecompiledErrorsForFrame(parseInt(frameId));
     } 
-    //  2) check for TP errors for the whole code
+
+    //  2) clear all frame parsing (TP) errors explicitly
+    Object.keys(useStore().frameObjects).forEach((frameId) => {
+        useStore().setFrameErroneous(parseInt(frameId),"");
+    });
+
+    //  3) check for TP errors for the whole code
     // We don't want to crash the application if something isn't handled correctly in TP.
     // So in case of an error, we catch it to allow the rest of the code to execute...
     try{

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -701,6 +701,22 @@ export const getAboveFrameCaretPosition = function (frameId: number): Navigation
     return prevCaretPos;
 };
 
+// This method is the opposite of getAboveFrameCaretPosition: it looks for what frame is immediately below a given caret position.
+// Returns: the frameId of the frame below the given position or NULL if there is no frame (case of empty body or end of container)
+export const getFrameBelowCaretPosition = function (caretPosition: NavigationPosition): number | null {
+    if(caretPosition.caretPosition == CaretPosition.body){
+        // In a body, we look at the first child frame of the body (if any)
+        const firstChildId = useStore().frameObjects[caretPosition.frameId].childrenIds.at(0);
+        return firstChildId ?? null;
+    }
+    else{
+        // Below a frame, we need find the position of the frame above (i.e. frame of that caret) in the parent, and get the next
+        // sibling (if any). Note that joint frames (like "else") can't have a caret below.
+        const nextFrameId = getNextSibling(caretPosition.frameId);
+        return (nextFrameId > 0) ? nextFrameId : null;
+    }
+};
+
 // This method returns a boolean value indicating whether the caret (current position) is contained
 // within one of the frame types specified in "containerTypes"
 export const isContainedInFrame = function (currFrameId: number, caretPosition: CaretPosition, containerTypes: string[]): boolean {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -162,11 +162,12 @@ export default class Parser {
                 break;
             }
             //if the frame is disabled and we were not in a disabled group of frames, add the comments flag
+            //(to avoid weird Python code, if that first disabled frame is a joint frame (like "else") then we align the comment with the other joint/root bodies)
             let disabledFrameBlockFlag = "";
             if(frame.isDisabled ? !this.isDisabledFramesTriggered : this.isDisabledFramesTriggered) {
                 this.isDisabledFramesTriggered = !this.isDisabledFramesTriggered;
                 if(frame.isDisabled) {
-                    this.disabledBlockIndent = indentation;
+                    this.disabledBlockIndent = (indentation + (frame.frameType.isJointFrame) ? INDENT : "");
                 }
                 disabledFrameBlockFlag = this.disabledBlockIndent + DISABLEDFRAMES_FLAG +"\n";
                 //and also increment the line number that we use for mapping frames and code lines (even if the disabled frames don't map exactly, 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -248,7 +248,7 @@ export default class Parser {
         let errorString = "";
         if (errors.length > 0) {
             errorString = `${errors.map((e: any) => {
-                return `\n${e.Ltigerpython_parser_ErrorInfo__f_line}:${e.Ltigerpython_parser_ErrorInfo__f_offset} | ${e.Ltigerpython_parser_ErrorInfo__f_msg}`;
+                return `\n${e.line}:${e.offset} | ${e.msg}`;
             })}`;
 
             

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -228,7 +228,10 @@ export default class Parser {
     }
 
     public getErrors(inputCode = ""): ErrorInfo[] {
-        TPyParser.setLanguage("en");
+        // If TigerPython offers errors in the same locale that Strype (and their locale code matches) we use that locale,
+        // otherwise, English is used. The check is done in Strype when the locale is changed so we don't always check the
+        // locale again and again when parsing the code...
+        TPyParser.setLanguage(useStore().tigerPythonLang??"en");
         TPyParser.warningAsErrors = false;
         let code: string = inputCode;
         if (!inputCode) {
@@ -276,7 +279,7 @@ export default class Parser {
                             }
                         }));
 
-                    // Only show error if we have found the slot
+                    // Only show error if we have found the slot (slot errors) or if the error is on the frame (example: "try")
                     if(labelSlotsIndex > -1 && slotId !== undefined && useStore().lastAddedFrameIds != this.framePositionMap[error.line].frameId){
                         useStore().setSlotErroneous({
                             frameId: this.framePositionMap[error.line].frameId,
@@ -289,6 +292,15 @@ export default class Parser {
                             initCode: "",
                             isFirstChange: true,
                         });
+                    }
+                    else {
+                        // There can be situations where the error is on the frame itself, 
+                        // for example a try that has an incomplete structure.
+                        // In order to make sure we don't display a frame error when we shouldn't,
+                        // we explicitly only show a frame error for some specific TigerPython errors.
+                        if(error.code == ""){
+                            console.log("a");
+                        }
                     }
                 }
             });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1093,6 +1093,10 @@ export const useStore = defineStore("app", {
             return {newSlotId: "", cursorPosOffset: 0};
         },
 
+        setFrameErroneous(frameId: number, errMsg: string) {
+            Vue.set(this.frameObjects[frameId], "atParsingError", errMsg);
+        },
+
         setSlotErroneous(frameSlotInfos: SlotInfos) {
             const slotObject = (retrieveSlotFromSlotInfos(frameSlotInfos) as BaseSlot);
             const existingError =  slotObject.error??"";

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -14,6 +14,7 @@ import {cloneDeep, isEqual} from "lodash";
 import $ from "jquery";
 import { BvModalEvent } from "bootstrap-vue";
 import { nextTick } from "@vue/composition-api";
+import { TPyParser } from "tigerpython-parser";
 
 let initialState: StateAppObject = initialStates["initialPythonState"];
 /* IFTRUE_isMicrobit */
@@ -146,6 +147,8 @@ export const useStore = defineStore("app", {
             selectedFrames: [] as number[],
 
             appLang: "en",
+
+            tigerPythonLang: "en", // The locale for TigerPython, see parser.ts as to why it's here
 
             isAppMenuOpened: false,
 
@@ -623,11 +626,15 @@ export const useStore = defineStore("app", {
     
     actions:{
         setAppLang(lang: string) {
-            //set the language in the store first
+            // Set the language in the store first
             this.appLang = lang;
 
-            //then change the UI via i18n
+            // Then change the UI via i18n
             i18n.locale = lang;
+
+            // And also change TigerPython locale -- if Strype locale is not available in TigerPython, we use English instead
+            const tpLangs = TPyParser.getLanguages();
+            this.tigerPythonLang = (tpLangs.includes(lang)) ? lang : "en";
 
             // Change all frame definition types to update the localised bits
             generateAllFrameDefinitionTypes(true);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -124,6 +124,7 @@ export interface FrameObject {
     jointFrameIds: number[]; //this contains the IDs of the joint frames
     caretVisibility: CaretPosition;
     labelSlotsDict: { [index: number]: LabelSlotsContent}; //this contains the label input slots data listed as a key value pairs array (key = index of the slot)
+    atParsingError ?: string //this contains the error message for a parsing error (from TigerPython) that can't be associated to a slot (e.g. wrong try structure)
     runTimeError?: string; //this contains the error message for a runtime error, as the granularity of the Skulpt doesn't go beyond the line number
 }
 


### PR DESCRIPTION
This PR mainly addresses issue #243, and it relies on the support of a new TigerPython version (1.0.1) which handles the detection of problematic "try" structures.

However, supporting the error at parsing means that we also now need to display errors in Strype at the frame level rather than just slot, so the PR also handles that.

The PR also contains support for using available matching locales in TigerPython (v1.0.2), and rebase the npm package to the upstream version in our Strype package.json.