### PR TITLE
Paste frames over a frame selection

### DIFF
--- a/src/components/Caret.vue
+++ b/src/components/Caret.vue
@@ -69,12 +69,12 @@ export default Vue.extend({
 }
 
 .caret-cross-forbidden-dnd-arm1 {
-    transform: translateY(((-$strype-frame-caret-forbidden-dnd-cross-height-notransform-value+$caret-height-value)/2) + px) rotate(-45deg) ;
+    transform: translateY(calc((-#{$strype-frame-caret-forbidden-dnd-cross-height-notransform-value}px + #{$caret-height-value}px) / 2)) rotate(-45deg) ;
     left: 50%;
 }
 
 .caret-cross-forbidden-dnd-arm2 {
-    transform: translateY(((-$strype-frame-caret-forbidden-dnd-cross-height-notransform-value+$caret-height-value)/2) + px) rotate(45deg);
+    transform: translateY(calc((-#{$strype-frame-caret-forbidden-dnd-cross-height-notransform-value}px + #{$caret-height-value}px) / 2)) rotate(45deg);
     left: 50%;
 }
 

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -270,7 +270,7 @@ export default Vue.extend({
 
         doPaste(skipDisableCheck?: boolean) : void {
             let pasteDestination: CurrentFrame = {id: this.frameId, caretPosition: this.caretAssignedPosition};            
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.appStore.$state));
+            const stateBeforeChanges = cloneDeep(this.appStore.$state);
 
             // If we currently have a selection of frames, the pasted frame should replace the selection, so we delete that selection.
             // (it should be fine regarding the grammar check because the caret will be at the same level whether it's before or after the selection)

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -40,11 +40,12 @@ import Vue, { PropType } from "vue";
 import VueContext, { VueContextConstructor } from "vue-context";
 import { useStore } from "@/store/store";
 import Caret from"@/components/Caret.vue";
-import {AllFrameTypesIdentifier, CaretPosition, Position, MessageDefinitions, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, PythonExecRunningState, FrameContextMenuActionName} from "@/types/types";
+import {AllFrameTypesIdentifier, CaretPosition, Position, MessageDefinitions, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, PythonExecRunningState, FrameContextMenuActionName, CurrentFrame} from "@/types/types";
 import { getCaretUID, adjustContextMenuPosition, setContextMenuEventClientXY, getAddFrameCmdElementUID, CustomEventTypes } from "@/helpers/editor";
 import { mapStores } from "pinia";
 import {copyFramesFromParsedPython, findCurrentStrypeLocation} from "@/helpers/pythonToFrames";
 import { cloneDeep } from "lodash";
+import { getAboveFrameCaretPosition } from "@/helpers/storeMethods";
 
 //////////////////////
 //     Component    //
@@ -266,13 +267,32 @@ export default Vue.extend({
                 this.doPaste();
             }
         },
-        
+
         doPaste(skipDisableCheck?: boolean) : void {
+            let pasteDestination: CurrentFrame = {id: this.frameId, caretPosition: this.caretAssignedPosition};            
+            const stateBeforeChanges = JSON.parse(JSON.stringify(this.appStore.$state));
+
+            // If we currently have a selection of frames, the pasted frame should replace the selection, so we delete that selection.
+            // (it should be fine regarding the grammar check because the caret will be at the same level whether it's before or after the selection)
+            if(this.appStore.selectedFrames.length > 0){
+                // The key doesn't actually matter here, the method handles it already by doing a backspace deletion.
+                // However, we need to know where was the caret with regards to the selection:
+                // if it was below the selection, it means the deletion will change the current caret
+                // and therefore we need to amend this as a new paste destination (i.e. top of selection).
+                if(pasteDestination.id == this.appStore.selectedFrames.at(-1) as number){
+                    const topOfSelectionPos = getAboveFrameCaretPosition(this.appStore.selectedFrames[0]);
+                    pasteDestination.id = topOfSelectionPos.frameId;
+                    pasteDestination.caretPosition = topOfSelectionPos.caretPosition as CaretPosition;
+                }
+                this.appStore.deleteFrames("backspace", true);
+            }   
+
             if(this.appStore.isSelectionCopied){
                 this.appStore.pasteSelection(
                     {
-                        clickedFrameId: this.frameId,
-                        caretPosition: this.caretAssignedPosition,
+                        clickedFrameId: pasteDestination.id,
+                        caretPosition: pasteDestination.caretPosition,
+                        ignoreStateBackup: true,
                     },
                     skipDisableCheck
                 );
@@ -280,12 +300,15 @@ export default Vue.extend({
             else {
                 this.appStore.pasteFrame(
                     {
-                        clickedFrameId: this.frameId,
-                        caretPosition: this.caretAssignedPosition,
+                        clickedFrameId: pasteDestination.id,
+                        caretPosition: pasteDestination.caretPosition,
+                        ignoreStateBackup: true,
                     },
                     skipDisableCheck
                 );
             }
+
+            this.appStore.saveStateChanges(stateBeforeChanges);
         },
     
         prepareInsertFrameSubMenu(): void {

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -471,7 +471,7 @@ export default Vue.extend({
             // Duplication allowance should be examined based on whether we are talking about a single frame or a selection frames
             const canDuplicate = (this.isPartOfSelection) ?
                 this.appStore.isPositionAllowsSelectedFrames(targetFrameId, CaretPosition.below, false) : 
-                this.appStore.isPositionAllowsFrame(targetFrameId, CaretPosition.below, this.frameId); 
+                this.appStore.isPositionAllowsFrame(targetFrameId, CaretPosition.below, false, this.frameId); 
             if(!canDuplicate){
                 const duplicateOptionContextMenuPos = this.frameContextMenuItems.findIndex((entry) => entry.method === this.duplicate);
                 //We don't need the duplication option: remove it from the menu options if not present

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -803,7 +803,7 @@ export default Vue.extend({
                     this.$nextTick(() => {    
                         this.appStore.leftRightKey({key: "ArrowRight"})
                             // In order to get undo/redo dealing with the change of slot structure properly
-                            .then(() => this.appStore.saveStateChanges(stateBeforeChanges as Record<string, any>));    
+                            .then(() => this.appStore.saveStateChanges(stateBeforeChanges));    
                     });               
                     event.preventDefault();
                     event.stopPropagation();

--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -1,4 +1,5 @@
 import {ObjectPropertyDiff} from "@/types/types";
+import { cloneDeep } from "lodash";
 import hash from "object-hash";
 
 //Function to get the difference between two states (properties) of an object.
@@ -81,7 +82,7 @@ export const getObjectPropertiesDifferences = (obj1: {[id: string]: any}, obj2: 
     const result = [] as ObjectPropertyDiff[];
     
     //To find the differences, we'll remove objects from obj2 ---> so we use a copy
-    const obj2copy = JSON.parse(JSON.stringify(obj2));
+    const obj2copy = cloneDeep(obj2);
 
     //we then parse through all properties to find a difference
     //if there is a difference, we add it in the result and remove the property from obj2copy (to keep only additions)

--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -1,5 +1,4 @@
 import {ObjectPropertyDiff} from "@/types/types";
-import { cloneDeep } from "lodash";
 import hash from "object-hash";
 
 //Function to get the difference between two states (properties) of an object.
@@ -82,7 +81,7 @@ export const getObjectPropertiesDifferences = (obj1: {[id: string]: any}, obj2: 
     const result = [] as ObjectPropertyDiff[];
     
     //To find the differences, we'll remove objects from obj2 ---> so we use a copy
-    const obj2copy = cloneDeep(obj2);
+    const obj2copy = JSON.parse(JSON.stringify(obj2));
 
     //we then parse through all properties to find a difference
     //if there is a difference, we add it in the result and remove the property from obj2copy (to keep only additions)

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -6,6 +6,7 @@ import { AllFrameTypesIdentifier, BaseSlot, CaretPosition, CurrentFrame, EditorF
 import Vue from "vue";
 import { checkEditorCodeErrors, countEditorCodeErrors, getLabelSlotUID, getMatchingBracket, parseLabelSlotUID } from "./editor";
 import { nextTick } from "@vue/composition-api";
+import { cloneDeep } from "lodash";
 
 export const retrieveSlotFromSlotInfos = (slotCoreInfos: SlotCoreInfos): FieldSlot => {
     // Retrieve the slot from its id (used for UI), check generateFlatSlotBases() for IDs explanation    
@@ -388,8 +389,7 @@ export const cloneFrameAndChildren = function(listOfFrames: EditorFrameObjects, 
     // enable Pass-By-Reference whenever it is increased.
     
     // first copy the current frame
-    // You can also use Lodash's "_.cloneDeep" in case JSON.parse(JSON.stringify()) has a problem on Mac
-    const frame: FrameObject = JSON.parse(JSON.stringify(listOfFrames[currentFrameId])) as FrameObject;
+    const frame: FrameObject = cloneDeep(listOfFrames[currentFrameId]) as FrameObject;
 
     frame.id = nextAvailableId.id;
     frame.caretVisibility = CaretPosition.none;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -124,7 +124,7 @@ export const useStore = defineStore("app", {
             isWrappingFrame: false, // Flag to know when we are doing a frame wrapping action
 
             // Keeps a copy of the state when 2-steps operations are performed and we need to know the previous state (to clear after use!)
-            stateBeforeChanges : {} as  {[id: string]: any}, 
+            stateBeforeChanges : {} as any, 
 
             contextMenuShownId: "",
 
@@ -389,7 +389,7 @@ export const useStore = defineStore("app", {
                 );
             }
             const addCommandsDefs = getAddCommandsDefs();
-            const filteredCommands: {[id: string]: AddFrameCommandDef[]} = JSON.parse(JSON.stringify(addCommandsDefs));
+            const filteredCommands: {[id: string]: AddFrameCommandDef[]} = cloneDeep(addCommandsDefs);
             const allowedJointCommand: {[id: string]: AddFrameCommandDef[]} = {};
 
             // for each shortcut we get a list of the corresponding commands
@@ -656,7 +656,7 @@ export const useStore = defineStore("app", {
             Vue.set(
                 this,
                 "stateBeforeChanges",
-                (release) ? {} : JSON.parse(JSON.stringify(this.$state))
+                (release) ? {} : cloneDeep(this.$state)
             );
         },
 
@@ -1262,7 +1262,7 @@ export const useStore = defineStore("app", {
             }); 
         },
 
-        saveStateChanges(previousState: Record<string, unknown>) {
+        saveStateChanges(previousState: (typeof this.$state)) {
             this.isEditorContentModified = true;
             // Saves the state changes in diffPreviousState.
             // We do not simply save the differences between the state and the previous state, because when undo/redo will be invoked, we cannot know what will be 
@@ -1340,7 +1340,7 @@ export const useStore = defineStore("app", {
                 this.diffToNextStateCounter--;
             }
             
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
             if(changeList.length > 0){
                 // This flag stores the arrays that need to be "cleaned" (i.e., removing the null elements)
                 const arraysToClean = [] as {[id: string]: any}[];                
@@ -1615,7 +1615,6 @@ export const useStore = defineStore("app", {
             //This action is called EVERY time a unitary change is made on the editable slot.
             //We save changes at the entire slot level: therefore, we need to remove the last
             //previous state to replace it with the difference between the state even before and now;            
-            let stateBeforeChanges = {};
             if(!frameSlotInfos.isFirstChange){
                 diffToPreviousState.pop();
                 this.diffToPreviousStateCounter--;
@@ -1623,7 +1622,7 @@ export const useStore = defineStore("app", {
             }
 
             //save the previous state
-            stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
 
             (retrieveSlotFromSlotInfos(frameSlotInfos) as BaseSlot).code = frameSlotInfos.code;
 
@@ -1712,7 +1711,7 @@ export const useStore = defineStore("app", {
         },
 
         async addFrameWithCommand(frame: FramesDefinitions, hiddenShorthandFrameDetails?: AddShorthandFrameCommandDef) {
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
             const currentFrame = this.frameObjects[this.currentFrame.id];
             const addingJointFrame = frame.isJointFrame;
 
@@ -1759,7 +1758,7 @@ export const useStore = defineStore("app", {
                 nextAvailableId++;
             }
             const newFrame: FrameObject = {
-                ...JSON.parse(JSON.stringify(EmptyFrameObject)),
+                ...cloneDeep(EmptyFrameObject),
                 frameType: frame,
                 caretVisibility: (frame.isJointFrame || frame.allowChildren) ? CaretPosition.body : CaretPosition.below,
                 id: nextAvailableId,
@@ -1938,7 +1937,7 @@ export const useStore = defineStore("app", {
         },
 
         deleteFrames(key: string, ignoreBackState?: boolean){
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
 
             // we remove the editable slots from the available positions
             let availablePositions = getAvailableNavigationPositions();
@@ -2088,7 +2087,7 @@ export const useStore = defineStore("app", {
             // Delete the outer frame(s), the frameId argument only makes sense for deletion without multi-selection
             // We delete outer frame(s) by getting inside each body, and performing a standard "backspace" delete
            
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
 
             // Prepare a list of ids for the frame to delete
             const framesToDelete: number[] = [];
@@ -2420,7 +2419,7 @@ export const useStore = defineStore("app", {
         // This method can be used to copy a frame to a position.
         // This can be a paste event or a duplicate event.
         copyFrameToPosition(payload: {frameId?: number; newParentId: number; newIndex: number}, ignoreStateBackup?: boolean, skipDisableCheck?: boolean) {
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
             
             const isPasteOperation: boolean = (payload.frameId === undefined);
             payload.frameId = payload.frameId ?? this.copiedFrameId;
@@ -2486,7 +2485,7 @@ export const useStore = defineStore("app", {
         // This method can be used to copy the selected frames to a position.
         // This can be a paste event or a duplicate event.
         copySelectedFramesToPosition(payload: {newParentId: number; newIndex?: number}, ignoreStateBackup?: boolean, skipDisableCheck?: boolean) {
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
             // -100 is chosen so that TS won't complain for non-initialised variable
             let newIndex = payload.newIndex??-100;
             const areWeDuplicating = newIndex === -100;
@@ -2692,7 +2691,7 @@ export const useStore = defineStore("app", {
         },
 
         changeDisableFrame(payload: {frameId: number; isDisabling: boolean}) {
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
 
             this.doChangeDisableFrame(payload);
             
@@ -2703,7 +2702,7 @@ export const useStore = defineStore("app", {
         },
 
         changeDisableSelection(isDisabling: boolean) {
-            const stateBeforeChanges = JSON.parse(JSON.stringify(this.$state));
+            const stateBeforeChanges = cloneDeep(this.$state);
 
             this.selectedFrames.forEach( (id) =>
                 this.doChangeDisableFrame(

--- a/tests/cypress/e2e/autocomplete.cy.ts
+++ b/tests/cypress/e2e/autocomplete.cy.ts
@@ -109,7 +109,7 @@ const BUILTIN = "Python";
 // themselves are in the correct order.
 function checkAutocompleteSorted(acIDSel: string) : void {
     // The autocomplete only updates after 500ms:
-    cy.wait(600);
+    cy.wait(1000);
     // Other items (like the names of variables when you do var.) will come out as -1,
     // which works nicely because they should be first:
     const intendedOrder : string[] = [MYVARS, MYFUNCS, "microbit", "microbit.accelerometer", "time", BUILTIN];


### PR DESCRIPTION
This PR implements one of the functionality listed for 1.0.1 (#252).

While working on that functionality, I realised I missed one case for handling the listing of allowed frames at a given position when we had a selection at the moment of pasting (regardless it was overwriting the frames or not), and we had copied or cut the frames from the context menu. The list of frames was the wrapping frames instead of the frames allowed at that position regardless the selection.

I've added a change of timeout value in this PR, as suggested by Neil to see if that helps passing the tests.