### PR TITLE
More work on canvas graphics

### DIFF
--- a/public/public_libraries/strype/graphics.py
+++ b/public/public_libraries/strype/graphics.py
@@ -6,13 +6,13 @@ import time as _time
 
 def in_bounds(x, y):
     """
-    Checks if the given X, Y position is in the visible bounds of (-400,-300) inclusive to (400, 300) exclusive.
+    Checks if the given X, Y position is in the visible bounds of (-399,-299) inclusive to (400, 300) exclusive.
     
     :param x: The x position to check
     :param y: The y position to check
     :return: A boolean indicating whether it is in the visible bounds: True if it is in bounds, False if it is not.
     """
-    return -400 <= x < 400 and -300 <= y < 300
+    return -399 <= x < 400 and -299 <= y < 300
 
 class Actor:
     """
@@ -63,7 +63,7 @@ class Actor:
         """
         Sets the position of the actor to be the given x, y position.
         
-        If the position is outside the bounds of the world (X: -400 to +400, Y: -300 to +300) the position
+        If the position is outside the bounds of the world (X: -399 to +400, Y: -299 to +300) the position
         will be adjusted to the nearest point inside the world.
         
         :param x: The new X position of the actor

--- a/public/public_libraries/strype/graphics.py
+++ b/public/public_libraries/strype/graphics.py
@@ -120,14 +120,6 @@ class Actor:
         :return: The name of this actor, as passed to the constructor or `set_name()` call.
         """
         return self.__name
-    def set_name(self, name):
-        """
-        Sets the name of this actor.  Actor names are typically strings, but they do not
-        have to be.
-        
-        :param name: The new name of the actor
-        """
-        self.__name = name
     
     def remove(self):
         """

--- a/public/public_libraries/strype/graphics.py
+++ b/public/public_libraries/strype/graphics.py
@@ -233,10 +233,13 @@ class Actor:
             return False
         return x < -399 or x > 399 or y < -299 or y > 299
         
-    def is_touching(self, actor):
+    def is_touching(self, actor_or_name):
         """
         Checks if this actor is touching the given actor.  Two actors are deemed to be touching if the
         rectangles of their images are overlapping (even if the actor is transparent at that point).
+        
+        You can either pass an actor, or an actor's name to check for collisions.  If you pass a name,
+        it will check whether any actor touching the current actor has that name.
         
         Note that if either this actor or the given actor has had collisions turned off with
         `set_can_touch(false)` then this function will return False even if they touch.
@@ -244,7 +247,12 @@ class Actor:
         :param actor: The actor to check for overlap
         :return: True if this actor overlaps that actor, False if it does not 
         """
-        return _strype_input_internal.checkCollision(self.__id, actor.__id)
+        if isinstance(actor_or_name, Actor):
+            return _strype_input_internal.checkCollision(self.__id, actor_or_name.__id)
+        else:
+            # All other types are assumed to be a name.
+            # We have no way to look up from a name, so we check everything that is touching us:
+            return any(a.get_name() == actor_or_name for a in self.get_all_touching())
     
     def set_can_touch(self, can_touch):
         """

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -586,6 +586,9 @@ export default Vue.extend({
             // When the graphics tab has never been selected, the off-screen image can be empty
             // which gives an error:
             if (c.width > 0 && c.height > 0) {
+                // Important on Safari to clear the canvas first, otherwise the new frame
+                // gets blended on top.  Firefox and Chrome don't do this by default (different alpha blending mode?):
+                domContext?.clearRect(0, 0, c.width, c.height);
                 domContext?.drawImage(c, 0, 0);
             }
         },

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -539,12 +539,14 @@ export default Vue.extend({
             
             // The HTML canvas has 0,0 in the top left and 800, 600 in the bottom right (i.e. positive Y downward)
             // Our actors have positions where 0,0 is in the middle, and positive Y upward
+            // with a bounds from -399, -299 to 400, 300.  0,0 in actor coordinates is actually 399, 300 in the canvas
+            // because of this translation.
             // We can't do this by using translate etc on targetContent because to flip the Y axis we'd need to
             // use scale() which would flip the Y axis and thus mirror all the images vertically.  So we need to
             // translate ourselves.  All the examples here assume a width of 800 but we don't hardcode it.
             const mapX = function(x : number) : number {
-                // Maps e.g. -50 to 350, 0 to 400, 50 to 450,
-                return x + graphicsCanvasLogicalWidth / 2;
+                // Maps e.g. -50 to 349, 0 to 399, 50 to 449,
+                return x + graphicsCanvasLogicalWidth / 2 - 1;
             };
             const mapY = function(y : number) : number {
                 // Maps e.g. -50 to 450, 0 to 400, 50 to 350,
@@ -637,9 +639,9 @@ export default Vue.extend({
             // The canvas might be e.g. 200 x 160 (with positive Y down) and we need to translate to the 800x600
             // logical canvas (with 0, 0 centre) and positive U upwards.
             // So we first divide by the width or height to get to a 0->1 value (where 0, 0 is top-left), then
-            // we subtract 0.5 to get to -0.5->0.5.  We multiply by 800 or 600 to get us to -400 to 400 (or -300 to 300),
+            // we subtract 0.5 to get to -0.5->0.5.  We multiply by 800 or 600 to get us to -399 to 400 (or -299 to 300),
             // and for Y we also multiply by -1 to flip it:
-            const adjustedX = ((event.offsetX / domCanvas.getBoundingClientRect().width) - 0.5) * graphicsCanvasLogicalWidth;
+            const adjustedX = ((event.offsetX / domCanvas.getBoundingClientRect().width) - 0.5) * graphicsCanvasLogicalWidth + 1;
             // We have to invert the Y axis because positive is up there, hence * -1 on the end:
             const adjustedY = ((event.offsetY / domCanvas.getBoundingClientRect().height) - 0.5) * graphicsCanvasLogicalHeight * -1;
             mostRecentClickedItems = this.getPersistentImageManager().calculateAllOverlappingAtPos(adjustedX, adjustedY);

--- a/src/stryperuntime/image_and_collisions.ts
+++ b/src/stryperuntime/image_and_collisions.ts
@@ -63,8 +63,8 @@ export class PersistentImageManager {
     public setPersistentImageLocation(id: number, x: number, y: number): void {
         const obj = this.persistentImages.get(id);
         if (obj != undefined && (obj.x != x || obj.y != y)) {
-            obj.x = Math.max(-WORLD_WIDTH/2, Math.min(x, WORLD_WIDTH/2));
-            obj.y = Math.max(-WORLD_HEIGHT/2, Math.min(y, WORLD_HEIGHT/2));
+            obj.x = Math.max(-WORLD_WIDTH/2 + 1, Math.min(x, WORLD_WIDTH/2));
+            obj.y = Math.max(-WORLD_HEIGHT/2 + 1, Math.min(y, WORLD_HEIGHT/2));
             obj.dirty = true;
             obj.collisionBox?.setPosition(x, y);
             obj.collisionBox?.updateBody();


### PR DESCRIPTION
Not an urgent PR, I can deploy the graphics test without waiting for the merge.  This is various changes Michael suggested for the graphics API, mainly around the collision detection (which now uses the actor name everywhere, which has been renamed "tag" here).  Also a couple of fixes to make the world bounds -399, -299 to 400, 300 as just discussed.  Probably easiest to view all at once rather than by individual commit (because some things changed twice).