### PR TITLE
Drag and Drop improvemements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1118,6 +1118,7 @@ $divider-grey: darken($background-grey, 15%);
     z-index: 20;
     border-radius: 8px;
     border: 1px solid #8e8e8e;
+    background-color: #BBB;
 }
 
 /* 

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -365,7 +365,11 @@ export default Vue.extend({
         document.getElementById(this.frameHeaderId)?.removeEventListener(CustomEventTypes.frameContentEdited, this.onFrameContentEdited);
         
         // Remove the registration of the caret container component at the upmost level for drag and drop
-        delete this.$root.$refs[getCaretUID(this.caretPosition.below, this.frameId)];
+        // ONLY if the frame is really removed from the state (because for a very strange reason, when reloading
+        // a page and overwriting the frames with a state, the initial state's frame are destroyed after registered).
+        if(this.appStore.frameObjects[this.frameId] == undefined){
+            delete this.$root.$refs[getCaretUID(this.caretPosition.below, this.frameId)];
+        }
     },
 
     methods: {

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -9,6 +9,8 @@
             @click.stop="onGetCaret"
             @slotGotCaret="onGetCaret"
             @slotLostCaret="onLoseCaret"
+            @mouseenter="handleMouseEnterLeave(true)"
+            @mouseleave="handleMouseEnterLeave(false)"
             @keydown.up="onUDKeyDown($event)"
             @keydown.down="onUDKeyDown($event)"
             @keydown.prevent.stop.esc
@@ -425,6 +427,20 @@ export default Vue.extend({
             if(this.erroneous()){
                 (this.$refs.errorPopover as InstanceType<typeof BPopover>).$emit("open");
             }
+        },
+        
+        handleMouseEnterLeave(isEntering: boolean) {
+            // There is a bug with how Firefox handles editable text HTML elements contained in a draggable div.
+            // We need to detect when the mouse is entering/leaving the text element to disable/enable the div's
+            // draggable attribute. 
+            // Because the frames are imbricated, we need to do that for all the frames hierarchy up ot the frames container.
+            // see https://stackoverflow.com/questions/21680363/prevent-drag-event-to-interfere-with-input-elements-in-firefox-using-html5-drag
+            let frameId = this.frameId;
+            do{
+                (document.getElementById(getFrameUID(frameId)) as HTMLDivElement).draggable = !isEntering;
+                frameId = this.appStore.frameObjects[frameId].parentId;
+            } 
+            while(frameId > 0);
         },
         
         updateAC() : void {

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -433,7 +433,7 @@ export default Vue.extend({
             // There is a bug with how Firefox handles editable text HTML elements contained in a draggable div.
             // We need to detect when the mouse is entering/leaving the text element to disable/enable the div's
             // draggable attribute. 
-            // Because the frames are imbricated, we need to do that for all the frames hierarchy up ot the frames container.
+            // Because the frames are nested, we need to do that for all the frames hierarchy up ot the frames container.
             // see https://stackoverflow.com/questions/21680363/prevent-drag-event-to-interfere-with-input-elements-in-firefox-using-html5-drag
             let frameId = this.frameId;
             do{

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -419,13 +419,14 @@ export default Vue.extend({
                 // However, with Firefox, there is an issue* if we also call that to go from one frame's slot to another frame's slot directly.
                 // We can know we are in this situation by comparing the current document selection and our focus infos: if they match,
                 // we are leaving a slot to be in non-edition mode, if they don't we are going from one slot to another frame's slot.
+                // In the case we don't have a selection (in an empty slot) we can still dispatch the event.
                 // (*) it seems that with Firefox, the actual document selection is already changed before we blurred.
                 const documentNodeSelectedId = (document.getSelection()?.focusNode?.parentElement?.id) ?? "";
                 const documentNodeSelectedSlotInfos = (documentNodeSelectedId.length > 0) ? parseLabelSlotUID(documentNodeSelectedId) : null;
                 const documentNodeSelectionFocusOffset = (document.getSelection()?.focusOffset) ?? -1;
-                if(documentNodeSelectedSlotInfos != null && documentNodeSelectionFocusOffset > -1 
+                if(documentNodeSelectedSlotInfos == null || (documentNodeSelectedSlotInfos != null && documentNodeSelectionFocusOffset > -1 
                     && areSlotCoreInfosEqual(this.appStore.focusSlotCursorInfos.slotInfos, documentNodeSelectedSlotInfos) 
-                    && this.appStore.focusSlotCursorInfos.cursorPos == documentNodeSelectionFocusOffset){
+                    && this.appStore.focusSlotCursorInfos.cursorPos == documentNodeSelectionFocusOffset)){
                     document.getElementById(getLabelSlotUID(this.appStore.focusSlotCursorInfos.slotInfos))
                         ?.dispatchEvent(new CustomEvent(CustomEventTypes.editableSlotLostCaret));
                 }

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -415,8 +415,20 @@ export default Vue.extend({
             this.appStore.ignoreKeyEvent = false;
             if(this.appStore.focusSlotCursorInfos && this.appStore.focusSlotCursorInfos.slotInfos.frameId == this.frameId 
                 && this.appStore.focusSlotCursorInfos.slotInfos.labelSlotsIndex == this.labelIndex){
-                document.getElementById(getLabelSlotUID(this.appStore.focusSlotCursorInfos.slotInfos))
-                    ?.dispatchEvent(new CustomEvent(CustomEventTypes.editableSlotLostCaret));
+                // This call is necessary for when the focus is lost in a slot to get back on non-edition mode (seeing the blue caret).
+                // However, with Firefox, there is an issue* if we also call that to go from one frame's slot to another frame's slot directly.
+                // We can know we are in this situation by comparing the current document selection and our focus infos: if they match,
+                // we are leaving a slot to be in non-edition mode, if they don't we are going from one slot to another frame's slot.
+                // (*) it seems that with Firefox, the actual document selection is already changed before we blurred.
+                const documentNodeSelectedId = (document.getSelection()?.focusNode?.parentElement?.id) ?? "";
+                const documentNodeSelectedSlotInfos = (documentNodeSelectedId.length > 0) ? parseLabelSlotUID(documentNodeSelectedId) : null;
+                const documentNodeSelectionFocusOffset = (document.getSelection()?.focusOffset) ?? -1;
+                if(documentNodeSelectedSlotInfos != null && documentNodeSelectionFocusOffset > -1 
+                    && areSlotCoreInfosEqual(this.appStore.focusSlotCursorInfos.slotInfos, documentNodeSelectedSlotInfos) 
+                    && this.appStore.focusSlotCursorInfos.cursorPos == documentNodeSelectionFocusOffset){
+                    document.getElementById(getLabelSlotUID(this.appStore.focusSlotCursorInfos.slotInfos))
+                        ?.dispatchEvent(new CustomEvent(CustomEventTypes.editableSlotLostCaret));
+                }
             }
 
             // When the label slots structure loses focus, we may need to check the errors. 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -992,6 +992,8 @@ export function notifyDragStarted(frameId?: number):void {
     // Add companion "image" (canvas) to the cursor - we use HTML2Canvas. 
     // The element to generate an image of is either the frame passed as argument
     // or the selected frame's parent which will be cropped.
+    // HTML2Canvas has a few performance issues, we try to help the fluidity of the interaction during drag and drop by having a setTimeout
+    // to let Javascript renderning the grey blank companion image first and force the generation of the actual companion image later.
     setTimeout(() => {
         const draggingEl = document.getElementById(getFrameUID(frameId??(useStore().frameObjects[useStore().selectedFrames[0]].parentId)));
         if(draggingEl){

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -992,10 +992,13 @@ export function notifyDragStarted(frameId?: number):void {
     // Add companion "image" (canvas) to the cursor - we use HTML2Canvas. 
     // The element to generate an image of is either the frame passed as argument
     // or the selected frame's parent which will be cropped.
-    const draggingEl = document.getElementById(getFrameUID(frameId??(useStore().frameObjects[useStore().selectedFrames[0]].parentId)));
-    if(draggingEl){
-        html2canvas(draggingEl, html2canvasOptions);
-    }
+    setTimeout(() => {
+        const draggingEl = document.getElementById(getFrameUID(frameId??(useStore().frameObjects[useStore().selectedFrames[0]].parentId)));
+        if(draggingEl){
+            html2canvas(draggingEl, html2canvasOptions);
+        }
+    }, 10);
+    
 }
 
 export function notifyDragEnded():void {

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -991,7 +991,7 @@ export function notifyDragStarted(frameId?: number):void {
 
     // Add companion "image" (canvas) to the cursor - we use HTML2Canvas. 
     // The element to generate an image of is either the frame passed as argument
-    // or the shadow element containing the current selection.
+    // or the selected frame's parent which will be cropped.
     const draggingEl = document.getElementById(getFrameUID(frameId??(useStore().frameObjects[useStore().selectedFrames[0]].parentId)));
     if(draggingEl){
         html2canvas(draggingEl, html2canvasOptions);


### PR DESCRIPTION
The PR contains changes for adding a greyed background in the companion image while we wait for HTML2Canvas to generate the image.
We are aware there is still an issue with lags from the library itself, but we will leave it for 1.0.1.
The PR also contains fixes with Firefox, one that is brought by the drag and drap, another that was there beforehand.