### PR TITLE
Drag and drop: improve the UI cues for "duplicate + D&D" 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -349,10 +349,10 @@ export default Vue.extend({
             }
 
             // Handling the notification for doing duplication with drag and drop.
-            // We don't really care if another key is hit along ctrl/meta, we only look that
+            // We don't really care if another key is hit along ctrl/option, we only look that
             // we are currently in a drag and drop action, and notify the current caret candidate for drop that
             // the action requires frame duplication.
-            if(this.appStore.isDraggingFrame && (event.ctrlKey || event.metaKey)){
+            if(this.appStore.isDraggingFrame && (event.ctrlKey || event.altKey)){
                 addDuplicateActionOnFramesDnD();
                 event.preventDefault();
                 event.stopImmediatePropagation();
@@ -364,10 +364,10 @@ export default Vue.extend({
         // There are only a few cases when we need to handle key up events
         window.addEventListener("keyup", (event) => {
             // Handling the notification for not doing duplication anymore with drag and drop.
-            // We don't really care if another key is hit along ctrl/meta, we only look that
+            // We don't really care if another key is hit along ctrl/option, we only look that
             // we are currently in a drag and drop action, and notify the current caret candidate for drop that
             // the action doesn't require frame duplication.
-            if(this.appStore.isDraggingFrame){
+            if(this.appStore.isDraggingFrame && (event.key == "Control" || event.key == "Alt")){
                 removeDuplicateActionOnFramesDnD();
                 event.preventDefault();
                 event.stopImmediatePropagation();

--- a/src/App.vue
+++ b/src/App.vue
@@ -95,7 +95,7 @@ import SimpleMsgModalDlg from "@/components/SimpleMsgModalDlg.vue";
 import {Splitpanes, Pane} from "splitpanes";
 import { useStore } from "@/store/store";
 import { AppEvent, AutoSaveFunction, BaseSlot, CaretPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, FrameObject, MessageDefinitions, MessageTypes, ModifierKeyCode, Position, PythonExecRunningState, SaveRequestReason, SlotCursorInfos, SlotsStructure, SlotType, StringSlot } from "@/types/types";
-import { getFrameContainerUID, getMenuLeftPaneUID, getEditorMiddleUID, getCommandsRightPaneContainerId, isElementLabelSlotInput, CustomEventTypes, getFrameUID, parseLabelSlotUID, getLabelSlotUID, getFrameLabelSlotsStructureUID, getSelectionCursorsComparisonValue, setDocumentSelection, getSameLevelAncestorIndex, autoSaveFreqMins, getImportDiffVersionModalDlgId, getAppSimpleMsgDlgId, getFrameContextMenuUID, getFrameBodyRef, getJointFramesRef, getCaretContainerRef, getActiveContextMenu, actOnTurtleImport, setPythonExecutionAreaTabsContentMaxHeight, setManuallyResizedEditorHeightFlag, setPythonExecAreaExpandButtonPos, isContextMenuItemSelected, getStrypeCommandComponentRefId, frameContextMenuShortcuts, getCompanionDndCanvasId, getStrypePEAComponentRefId, getGoogleDriveComponentRefId } from "./helpers/editor";
+import { getFrameContainerUID, getMenuLeftPaneUID, getEditorMiddleUID, getCommandsRightPaneContainerId, isElementLabelSlotInput, CustomEventTypes, getFrameUID, parseLabelSlotUID, getLabelSlotUID, getFrameLabelSlotsStructureUID, getSelectionCursorsComparisonValue, setDocumentSelection, getSameLevelAncestorIndex, autoSaveFreqMins, getImportDiffVersionModalDlgId, getAppSimpleMsgDlgId, getFrameContextMenuUID, getFrameBodyRef, getJointFramesRef, getCaretContainerRef, getActiveContextMenu, actOnTurtleImport, setPythonExecutionAreaTabsContentMaxHeight, setManuallyResizedEditorHeightFlag, setPythonExecAreaExpandButtonPos, isContextMenuItemSelected, getStrypeCommandComponentRefId, frameContextMenuShortcuts, getCompanionDndCanvasId, getStrypePEAComponentRefId, getGoogleDriveComponentRefId, addDuplicateActionOnFramesDnD, removeDuplicateActionOnFramesDnD } from "./helpers/editor";
 /* IFTRUE_isMicrobit */
 import { getAPIItemTextualDescriptions } from "./helpers/microbitAPIDiscovery";
 import { DAPWrapper } from "./helpers/partial-flashing";
@@ -346,6 +346,33 @@ export default Vue.extend({
             // Case for Windows context menu key   
             if(event.key.toLowerCase() == "contextmenu"){
                 this.appStore.isContextMenuKeyboardShortcutUsed  = true;
+            }
+
+            // Handling the notification for doing duplication with drag and drop.
+            // We don't really care if another key is hit along ctrl/meta, we only look that
+            // we are currently in a drag and drop action, and notify the current caret candidate for drop that
+            // the action requires frame duplication.
+            if(this.appStore.isDraggingFrame && (event.ctrlKey || event.metaKey)){
+                addDuplicateActionOnFramesDnD();
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                event.stopPropagation();
+                return;
+            }
+        });
+
+        // There are only a few cases when we need to handle key up events
+        window.addEventListener("keyup", (event) => {
+            // Handling the notification for not doing duplication anymore with drag and drop.
+            // We don't really care if another key is hit along ctrl/meta, we only look that
+            // we are currently in a drag and drop action, and notify the current caret candidate for drop that
+            // the action doesn't require frame duplication.
+            if(this.appStore.isDraggingFrame){
+                removeDuplicateActionOnFramesDnD();
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                event.stopPropagation();
+                return;
             }
         });
 

--- a/src/assets/images/plus.svg
+++ b/src/assets/images/plus.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="15"
+   height="15"
+   version="1.1"
+   id="svg4"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4" />
+  <circle
+     style="opacity:0.991;fill:#1cb46f;fill-opacity:1;fill-rule:evenodd;stroke-width:11.3386;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3"
+     id="path4"
+     cx="7.5"
+     cy="7.5"
+     r="7.5" />
+  <rect
+     x="6"
+     y="2.5"
+     width="3"
+     height="10"
+     fill="#ffffff"
+     id="rect3"
+     style="stroke-width:0.999992" />
+  <rect
+     x="2.5"
+     y="6"
+     width="10"
+     height="3"
+     fill="#ffffff"
+     id="rect4"
+     style="stroke-width:0.999992" />
+</svg>

--- a/src/components/Caret.vue
+++ b/src/components/Caret.vue
@@ -3,6 +3,7 @@
         <!-- The inner content of the caret is reserved for the cross (x) that is displayed during DnD when a location is forbidden for dropping -->
          <span v-if="!isInvisible && areFramesDraggedOver && !areDropFramesAllowed" class="caret-cross-forbidden-dnd caret-cross-forbidden-dnd-arm1"></span>
          <span v-if="!isInvisible && areFramesDraggedOver && !areDropFramesAllowed" class="caret-cross-forbidden-dnd caret-cross-forbidden-dnd-arm2"></span>
+         <img  v-if="!isInvisible && areFramesDraggedOver && isDuplicateDnDAction" :src="require('@/assets/images/plus.svg')" alt="+" class="caret-plus-dnd">
     </div>
 </template>
 
@@ -26,9 +27,10 @@ export default Vue.extend({
         isInvisible: Boolean,
         areFramesDraggedOver: Boolean,
         areDropFramesAllowed: Boolean,
+        isDuplicateDnDAction: Boolean,
     },
 
-    computed:{
+    computed: {
         ...mapStores(useStore),
 
         isPythonExecuting(): boolean {
@@ -76,6 +78,13 @@ export default Vue.extend({
 .caret-cross-forbidden-dnd-arm2 {
     transform: translateY(calc((-#{$strype-frame-caret-forbidden-dnd-cross-height-notransform-value}px + #{$caret-height-value}px) / 2)) rotate(45deg);
     left: 50%;
+}
+
+// Top position based on image size of 15*15
+.caret-plus-dnd {
+    position: relative;
+    left: calc(#{$caret-width} + 1px);
+    top: calc(-#{$caret-height-value}px - (15px / 2));
 }
 
 .invisible {

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -27,6 +27,7 @@
             v-blur="isCaretBlurred"
             :areFramesDraggedOver="areFramesDraggedOver"
             :areDropFramesAllowed="areDropFramesAllowed"
+            :isDuplicateDnDAction="isDuplicateDnDAction"
         />
     </div>
 </template>
@@ -127,6 +128,7 @@ export default Vue.extend({
             insertFrameMenuItems: [] as {name: string, method: VoidFunction, actionName ?: FrameContextMenuActionName}[],
             areFramesDraggedOver: false,
             areDropFramesAllowed: true,
+            isDuplicateDnDAction: false,
         };
     },
 

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -1,6 +1,6 @@
 <template>
     <div 
-        :class="{'caret-container': true, 'static-caret-container': isStaticCaretContainer}"
+        :class="{'caret-container': true, 'static-caret-container': isStaticCaretContainer, 'dragging-frames': areFramesDraggedOver}"
         @click.exact.prevent.stop="toggleCaret()"
         @contextmenu.prevent.stop="handleClick($event)"
         :key="UID"
@@ -341,7 +341,7 @@ export default Vue.extend({
     height: $caret-height-value + px;
 }
 
-.caret-container:hover{
+.caret-container:not(.dragging-frames):hover{
     cursor: pointer;
 }
 </style>

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -273,12 +273,6 @@ export default Vue.extend({
 
         isVisible(): boolean {
             return this.appStore.isFrameVisible(this.frameId);
-        },
-        
-        isDragging(): boolean{
-            // Contrary to isDragTop, this property is set whenever dragging is happening, not just for the 
-            // dragged elements. We need that to control some CSS rendering of the cursors.
-            return this.appStore.isDraggingFrame;
         },   
 
         isInFrameWithKeyboard(): boolean {            
@@ -689,7 +683,7 @@ export default Vue.extend({
 
         toggleCaret(event: MouseEvent): void {
             // When a mouseup event happens during drag and drop, we ignore the caret change, we handle with the D&D mechanism.
-            if(event.type == "mouseup" && this.isDragging){
+            if(event.type == "mouseup" && this.appStore.isDraggingFrame){
                 return;
             }
 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -879,6 +879,8 @@ const bodyMouseMoveEventHandlerForFrameDnD = (mouseEvent: MouseEvent): void => {
                 (vm.$refs[getCaretUID(currentCaretDropPosCaretPos, currentCaretDropPosFrameId)] as InstanceType<typeof CaretContainer>).areFramesDraggedOver = false;
                 // Not really required but just better to reset things properly
                 (vm.$refs[getCaretUID(currentCaretDropPosCaretPos, currentCaretDropPosFrameId)] as InstanceType<typeof CaretContainer>).areDropFramesAllowed = true;
+                // We make sure that we remove the "drag and d&d" flag on this caret since it's no longer a candidate for dropping the frames at this position...
+                removeDuplicateActionOnFramesDnD();
             }
             currentCaretDropPosId = closestCaretEl?.id??"";
             currentCaretDropPosFrameId = newCaretDropPosFrameId;
@@ -890,6 +892,20 @@ const bodyMouseMoveEventHandlerForFrameDnD = (mouseEvent: MouseEvent): void => {
     }
 };
 
+// Helpers for adding or removing the "duplicate" action on a drag an drop frames
+export function addDuplicateActionOnFramesDnD(): void {
+    if(currentCaretDropPosFrameId > 0){
+        (vm.$refs[getCaretUID(currentCaretDropPosCaretPos, currentCaretDropPosFrameId)] as InstanceType<typeof CaretContainer>).isDuplicateDnDAction = true;
+    }
+}
+
+export function removeDuplicateActionOnFramesDnD(): void {
+    // Remove the "+" symbol on the destination caret
+    if(currentCaretDropPosFrameId > 0){
+        (vm.$refs[getCaretUID(currentCaretDropPosCaretPos, currentCaretDropPosFrameId)] as InstanceType<typeof CaretContainer>).isDuplicateDnDAction = false;
+    }
+}
+
 // We need to also look for the mouseup event during Drag and Drop as we only let the browser handling "dragstart",
 // there is no "dragend" being raised by the browser consequently.
 const bodyMouseUpEventHandlerForFrameDnD = (event: MouseEvent): void => {
@@ -897,6 +913,9 @@ const bodyMouseUpEventHandlerForFrameDnD = (event: MouseEvent): void => {
         const areDropFramesAllowed = (vm.$refs[getCaretUID(currentCaretDropPosCaretPos, currentCaretDropPosFrameId)] as InstanceType<typeof CaretContainer>).areDropFramesAllowed;
         // Notify the drag even is finished
         notifyDragEnded();
+
+        // Make sure we remove the "duplicate" flag as it may have been used
+        removeDuplicateActionOnFramesDnD();
 
         // Drop the frame at the current drop caret location only if drop is allowed
         if(areDropFramesAllowed){

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -894,15 +894,26 @@ const bodyMouseMoveEventHandlerForFrameDnD = (mouseEvent: MouseEvent): void => {
 
 // Helpers for adding or removing the "duplicate" action on a drag an drop frames
 export function addDuplicateActionOnFramesDnD(): void {
+    // Add the "+" symbol
     if(currentCaretDropPosFrameId > 0){
         (vm.$refs[getCaretUID(currentCaretDropPosCaretPos, currentCaretDropPosFrameId)] as InstanceType<typeof CaretContainer>).isDuplicateDnDAction = true;
     }
+
+    // Do not blur the source frame(s)
+    const sourceFrameIds = (currentDraggedSingleFrameId) ?  [currentDraggedSingleFrameId] : [...useStore().selectedFrames];
+    sourceFrameIds.forEach((frameId) => useStore().frameObjects[frameId].isBeingDragged = false);
 }
 
 export function removeDuplicateActionOnFramesDnD(): void {
     // Remove the "+" symbol on the destination caret
     if(currentCaretDropPosFrameId > 0){
         (vm.$refs[getCaretUID(currentCaretDropPosCaretPos, currentCaretDropPosFrameId)] as InstanceType<typeof CaretContainer>).isDuplicateDnDAction = false;
+    }
+
+    // Restore the blur on the source frame(s) only if we are still dragging 
+    if(useStore().isDraggingFrame){
+        const sourceFrameIds = (currentDraggedSingleFrameId) ?  [currentDraggedSingleFrameId] : [...useStore().selectedFrames];
+        sourceFrameIds.forEach((frameId) => useStore().frameObjects[frameId].isBeingDragged = true);
     }
 }
 


### PR DESCRIPTION
These improvements include having a "+" symbol at the destination frame caret (#358) and also not blurring the souce frame(s) when "duplicate" is activated during drag and drop.

Also, for drag and drop in general, I've "forced" the mouse cursor to not be "pointer" when we are exactly at the destination caret container. 
(The "pointer" cursor at the caret container in general is questionnable, I think we did that when we systematically had a space dedicated to the caret at _every_ caret positions in earlier versions of Strype. Now that the space is collapsed most of the times, maybe it's not needed. However, I've not removed it because it might still make sense to show a different mouse cursor when we are at the blue caret.)