### PR TITLE
Small autocomplete branch fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "strype-editor",
-    "version": "1.0.0",
+    "version": "2024.12.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "strype-editor",
-            "version": "1.0.0",
+            "version": "2024.12.12",
             "dependencies": {
                 "@fortawesome/free-solid-svg-icons": "^5.15.4",
                 "@microbit/microbit-fs": "^0.9.2",
@@ -17124,8 +17124,7 @@
         },
         "node_modules/tigerpython-parser": {
             "version": "1.0.2",
-            "resolved": "git+ssh://git@github.com/Tobias-Kohn/TigerPython-Parser.git#70cadc57cefbcaad59f00373e78998f880079867",
-            "license": "MPL-2.0"
+            "resolved": "git+ssh://git@github.com/Tobias-Kohn/TigerPython-Parser.git#7b8e6d2daf96a514c4b53d59bea8ade4d8f8b849"
         },
         "node_modules/tinytim": {
             "version": "0.1.1",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -623,7 +623,7 @@ export const useStore = defineStore("app", {
             i18n.locale = lang;
 
             // And also change TigerPython locale -- if Strype locale is not available in TigerPython, we use English instead
-            const tpLangs = TPyParser.getLanguages();
+            const tpLangs = TPyParser.getLanguages as any as string[]; // TODO remove this casting once TigerPython's type for getLanguages is fixed
             this.tigerPythonLang = (tpLangs.includes(lang)) ? lang : "en";
 
             // Change all frame definition types to update the localised bits

--- a/tests/cypress/e2e/autocomplete.cy.ts
+++ b/tests/cypress/e2e/autocomplete.cy.ts
@@ -222,9 +222,7 @@ const UPPER_DOC = "Return a copy of the string with all the cased characters con
 
 describe("Behaviour with operators, brackets and complex expressions", () => {
     const prefixesWhichShouldShowBuiltins = ["0+", "1.6-", "not ", "1**(2+6)", "[a,", "array[", "~", "(1*", "{3:"];
-    const prefixesWhichShouldShowStringMembers = ["\"a\".", "'a'.upper().", "myString."];
-    // TODO restore these when TigerPython supports them in future:
-    // "(\"a\").", "(\"a\".upper()).", "[\"a\"][0]."
+    const prefixesWhichShouldShowStringMembers = ["\"a\".", "'a'.upper().", "myString.", "(\"a\").", "(\"a\".upper()).", "[\"a\"][0]."];
     const prefixesWhichShouldShowNone = ["z..", "123", "123.", "\"", "\"abc", "\"abc.", "'", "totally_unique_stem", "nonexistentvariable."];
 
     for (const prefix of prefixesWhichShouldShowBuiltins) {


### PR DESCRIPTION
I've now put back several of the tests I removed yesterday, thanks to Tobias fixing them.  I also realised he changed getLanguages from a functions to a property, so adjusted that in our code (will send him a PR to change the Typescript types file to match).