### PR TITLE
Editor website fixes for Google certification

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,11 +9,10 @@
   <link rel="apple-touch-icon" href="<%= BASE_URL %>favicon.png">
   <link rel="apple-touch-startup-image" href="<%= BASE_URL %>favicon.png">
   <!-- Import for the fontawesome icons -->
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css">
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/v4-shims.css">
-  <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wdth,wght@50..200,200..900" rel="stylesheet">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" integrity="sha256-rx5u3IdaOCszi7Jb18XD9HSn8bNiEgAqWJbdBvIYYyU=" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/v4-shims.css" integrity="sha256-/aMDUDDThDwnUdwNpl+4AiMOwApACK7tg93dx7l8vJM=" crossorigin="anonymous">
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet" integrity="sha256-jkBR6JJ1emALogLUCoTtJTTHbehAoS/O4KM5jcS320w=" crossorigin="anonymous">
+  <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wdth,wght@50..200,200..900" rel="stylesheet" integrity="sha256-Ztq7VVBS+MxkzxYLduHb9M+aelJS5I9ctCQj1k4a9jE=" crossorigin="anonymous">
   <script src="<%= BASE_URL %>js/skulpt.min.js"></script>
   <script src="<%= BASE_URL %>js/skulpt-stdlib.js"></script>
   


### PR DESCRIPTION
This PR concerns changes made in Strype.org/editor/ and Styrpe.org/microbit/ to address the issues found by the audit towards the Google CASA certification.

Note that we may have some issues with the Google Fonts, but I have tested with Edge, Chrome and Firefox and there was no rejection.

All other changes towards resolving the issues found by the audit are changes on the server direct, in the Apache configuration file for Strype.org