### PR TITLE
New handling of disabled frames (UI wise)

### DIFF
--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -687,9 +687,16 @@ export default Vue.extend({
             if(!this.isPythonExecuting) { 
                 // The value to give to frameId in notifyDragStarted() depends on the situation:
                 // when it's a selection of frames, we don't provide it, when it's a frame itself,
-                // the value is the id of that dragged frame unless it's a joint frame: we use the
-                // while frame structure and therefore us the id of the structure's root.
-                notifyDragStarted((this.isPartOfSelection)? undefined : ((this.isJointFrame) ? getParentOrJointParent(this.frameId) : this.frameId));
+                // the value is the id of that dragged frame unless A) it's a joint frame: we use the
+                // while frame structure and therefore us the id of the structure's root - or B) it's
+                // a disabled frame: we need to check the outmost disabled ancestor to that frame ("unit")
+                notifyDragStarted((this.isPartOfSelection)
+                    ? undefined 
+                    : ((this.isJointFrame) 
+                        ? getParentOrJointParent(this.frameId) 
+                        : ((this.isDisabled)
+                            ? getOutmostDisabledAncestorFrameId(this.frameId)
+                            : this.frameId)));
 
                 // If the frame is being dragged (i.e. NOT part of a selection) then we should reposition the frame caret below.
                 if(!this.isPartOfSelection){

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -70,7 +70,7 @@
         </div>
         <div>
             <CaretContainer
-                v-if="!isJointFrame"
+                v-if="!isJointFrame && !isInnerDisabled"
                 :frameId="frameId"
                 :ref="getCaretContainerRef"
                 :caretVisibility="caretVisibility"
@@ -297,6 +297,12 @@ export default Vue.extend({
 
         getFrameContextMenuUID(): string {
             return getFrameContextMenuUID(this.UID);
+        },
+
+        isInnerDisabled(): boolean {
+            // This computed property indicates whether a frame is disabled as a descendant of a disabled frame.
+            // When that's the case, the whole most outer frame acts as a unit and actions/caret are for that unit.
+            return this.isDisabled && this.appStore.frameObjects[getParentOrJointParent(this.frameId)].isDisabled;
         },
     },
 

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -7,7 +7,7 @@
         <!-- keep the tabIndex attribute, it is necessary to handle focus with Safari -->
         <div 
             :style="frameStyle" 
-            :class="{frameDiv: true, blockFrameDiv: isBlockFrame && !isJointFrame, statementFrameDiv: !isBlockFrame && !isJointFrame, error: hasParsingError}"
+            :class="{frameDiv: true, blockFrameDiv: isBlockFrame && !isJointFrame, statementFrameDiv: !isBlockFrame && !isJointFrame, error: hasParsingError, disabled: isDisabled}"
             :id="UID"
             @click="toggleCaret($event)"
             @contextmenu="handleClick($event)"
@@ -1145,7 +1145,7 @@ export default Vue.extend({
     border-color: #8e8e8e;
 }
 
-.statementFrameDiv:hover {
+.statementFrameDiv:not(.disabled):hover {
     border-color: #d6d6d6;
 }
 

--- a/src/components/FrameBody.vue
+++ b/src/components/FrameBody.vue
@@ -5,6 +5,7 @@
     >
         <div>
             <CaretContainer
+            v-if="!isDisabled"
             :ref="getCaretContainerRef"
             :frameId="frameId"
             :caretVisibility="caretVisibility"

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -64,16 +64,15 @@
 import Vue, { PropType } from "vue";
 import { useStore } from "@/store/store";
 import AutoCompletion from "@/components/AutoCompletion.vue";
-import { getLabelSlotUID, CustomEventTypes, getFrameHeaderUID, closeBracketCharacters, getMatchingBracket, operators, openBracketCharacters, keywordOperatorsWithSurroundSpaces, stringQuoteCharacters, getFocusedEditableSlotTextSelectionStartEnd, parseCodeLiteral, getNumPrecedingBackslashes, setDocumentSelection, getFrameLabelSlotsStructureUID, parseLabelSlotUID, getFrameLabelSlotLiteralCodeAndFocus, stringDoubleQuoteChar, UISingleQuotesCharacters, UIDoubleQuotesCharacters, stringSingleQuoteChar, getSelectionCursorsComparisonValue, getTextStartCursorPositionOfHTMLElement, STRING_DOUBLEQUOTE_PLACERHOLDER, STRING_SINGLEQUOTE_PLACERHOLDER, checkCanReachAnotherCommentLine, getACLabelSlotUID, getFrameUID } from "@/helpers/editor";
+import { getLabelSlotUID, CustomEventTypes, getFrameHeaderUID, closeBracketCharacters, getMatchingBracket, operators, openBracketCharacters, keywordOperatorsWithSurroundSpaces, stringQuoteCharacters, getFocusedEditableSlotTextSelectionStartEnd, parseCodeLiteral, getNumPrecedingBackslashes, setDocumentSelection, getFrameLabelSlotsStructureUID, parseLabelSlotUID, getFrameLabelSlotLiteralCodeAndFocus, stringDoubleQuoteChar, UISingleQuotesCharacters, UIDoubleQuotesCharacters, stringSingleQuoteChar, getSelectionCursorsComparisonValue, getTextStartCursorPositionOfHTMLElement, STRING_DOUBLEQUOTE_PLACERHOLDER, STRING_SINGLEQUOTE_PLACERHOLDER, checkCanReachAnotherCommentLine, getACLabelSlotUID, getFrameUID, getFrameComponent } from "@/helpers/editor";
 import { CaretPosition, FrameObject, CursorPosition, AllFrameTypesIdentifier, SlotType, SlotCoreInfos, isFieldBracketedSlot, SlotsStructure, BaseSlot, StringSlot, isFieldStringSlot, SlotCursorInfos, areSlotCoreInfosEqual, FieldSlot, PythonExecRunningState, MessageDefinitions, FormattedMessage, FormattedMessageArgKeyValuePlaceholders } from "@/types/types";
 import { getCandidatesForAC } from "@/autocompletion/acManager";
 import { mapStores } from "pinia";
-import { checkCodeErrors, evaluateSlotType, getFlatNeighbourFieldSlotInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isFrameLabelSlotStructWithCodeContent, retrieveParentSlotFromSlotInfos, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
+import { checkCodeErrors, evaluateSlotType, getFlatNeighbourFieldSlotInfos, getOutmostDisabledAncestorFrameId, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isFrameLabelSlotStructWithCodeContent, retrieveParentSlotFromSlotInfos, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
 import Parser from "@/parser/parser";
 import { cloneDeep, debounce } from "lodash";
 import LabelSlotsStructure from "./LabelSlotsStructure.vue";
 import { BPopover } from "bootstrap-vue";
-import App from "@/App.vue";
 import Frame from "@/components/Frame.vue";
 
 export default Vue.extend({
@@ -342,10 +341,12 @@ export default Vue.extend({
                 event.stopImmediatePropagation();
                 event.stopPropagation();
                 event.preventDefault();
-                // Call the method which handles a click on the frame instead, we need to find the associated frame object
-                const frameDiv = document.getElementById(getFrameUID(this.frameId)) as HTMLDivElement;
+                // Call the method which handles a click on the frame instead, we need to find the associated frame object:
+                // the corresponding frame div under that click in the general case, or the outmost disabled ancester frame if the frame is disabled.
+                const outmostDisabledFrameAncestorId = getOutmostDisabledAncestorFrameId(this.frameId);
+                const frameDiv = document.getElementById(getFrameUID((this.isDisabled) ? outmostDisabledFrameAncestorId : this.frameId)) as HTMLDivElement;
                 if(frameDiv){
-                    const frameComponent = (this.$root.$children[0] as InstanceType<typeof App>).getFrameComponent(this.frameId);
+                    const frameComponent = getFrameComponent((this.isDisabled) ? outmostDisabledFrameAncestorId: this.frameId);
                     if(frameComponent){
                         // The frame component can only be a frame (and not a frame container) since we've clicked on a slot...
                         (frameComponent as InstanceType<typeof Frame>).changeToggledCaretPosition(event.clientY, frameDiv);

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1,7 +1,7 @@
 import i18n from "@/i18n";
 import { useStore } from "@/store/store";
 import { AddFrameCommandDef, AddShorthandFrameCommandDef, AllFrameTypesIdentifier, areSlotCoreInfosEqual, BaseSlot, CaretPosition, FrameContextMenuActionName, FrameContextMenuShortcut, FramesDefinitions, getFrameDefType, isFieldBracketedSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, ModifierKeyCode, NavigationPosition, Position, SelectAllFramesFuncDefScope, SlotCoreInfos, SlotCursorInfos, SlotsStructure, SlotType, StringSlot } from "@/types/types";
-import { getAboveFrameCaretPosition, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFrameBelowCaretPosition, getFrameSectionIdFromFrameId } from "./storeMethods";
+import { getAboveFrameCaretPosition, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFrameBelowCaretPosition, getFrameContainer, getFrameSectionIdFromFrameId } from "./storeMethods";
 import { strypeFileExtension } from "./common";
 import {getContentForACPrefix} from "@/autocompletion/acManager";
 import scssVars  from "@/assets/style/_export.module.scss";
@@ -9,6 +9,10 @@ import html2canvas, { Options } from "html2canvas";
 import CaretContainer from "@/components/CaretContainer.vue";
 import { vm } from "@/main";
 import Vue from "vue";
+import Frame from "@/components/Frame.vue";
+import FrameContainer from "@/components/FrameContainer.vue";
+import FrameBody from "@/components/FrameBody.vue";
+import JointFrames from "@/components/JointFrames.vue";
 
 export const undoMaxSteps = 200;
 export const autoSaveFreqMins = 2; // The number of minutes between each autosave action.
@@ -365,6 +369,65 @@ export function getStrypeCommandComponentRefId(): string {
 export function getStrypePEAComponentRefId(): string {
     return "strypePEA";
 }
+
+// The following helpers traverse the component refs to retrieve the desired component
+export function getFrameComponent(frameId: number, innerLookDetails?: {frameParentComponent: InstanceType<typeof Frame> | InstanceType<typeof FrameContainer> | InstanceType<typeof FrameBody> | InstanceType<typeof JointFrames>, listOfFrameIdToCheck: number[]}): InstanceType<typeof Frame> | InstanceType<typeof FrameContainer> | undefined {
+    // This methods gets the (Vue) reference of a frame based on its ID, or undefined if we could not find it.
+    // The logic to retrieve the reference relies on the implementation of the editor, as we look in 
+    // the frame containers which are supposed to hold the frames, and within frame body/joint when a frame can have children/joint frames.
+    // If no root is provided, we assume we search the frame reference everywhere in the editor, meaning we look into the frame containers of App (this)
+    // IMPORTANT NOTE: we are getting arrays of refs here when retrieving the refs, because the referenced elements are within a v-for
+    // https://laracasts.com/discuss/channels/vue/ref-is-an-array 
+    let result = undefined;
+    if(innerLookDetails){                
+        for(const childFrameId of innerLookDetails.listOfFrameIdToCheck){
+            const childFrameComponent = ((innerLookDetails.frameParentComponent.$refs[getFrameUID(childFrameId)] as (Vue|Element)[])[0] as InstanceType<typeof Frame>);
+            if(childFrameId == frameId){
+                // Found the frame directly inside this list of frames
+                result =  childFrameComponent;
+                break;
+            }
+            else if(useStore().frameObjects[childFrameId].childrenIds.length > 0 || useStore().frameObjects[childFrameId].jointFrameIds.length > 0){
+                // That frame isn't the one we want, but maybe it contains the one we want so we look into it.
+                // We first look into the children, the joint frames (which may have children as well)
+                const frameBodyComponent = (childFrameComponent.$refs[getFrameBodyRef()] as InstanceType<typeof FrameBody>); // There is 1 body in a frame, no v-for is used, we have 1 element
+                result = getFrameComponent(frameId, {frameParentComponent: frameBodyComponent, listOfFrameIdToCheck: useStore().frameObjects[childFrameId].childrenIds});
+
+                if(!result){
+                    // Check joints if we didn't find anything in the children
+                    const jointFramesComponent = (childFrameComponent.$refs[getJointFramesRef()] as InstanceType<typeof FrameBody>); // There is 1 joint frames strcut in a frame, no v-for is used, we have 1 element
+                    result = getFrameComponent(frameId, {frameParentComponent: jointFramesComponent, listOfFrameIdToCheck: useStore().frameObjects[childFrameId].jointFrameIds});
+                }
+
+                if(result){
+                    break;
+                }
+            }
+        }
+    }
+    else{
+        // When we look for the frame from the whole editor, we need to find in wich frame container that frame lives.
+        // We don't need to parse recursively for getting the refs/frames as we can just find out what frame container it is in first directly...
+        // And if we are already in the container (body), then we just return this component 
+        const frameContainerId = (frameId < 0) ? frameId : getFrameContainer(frameId); 
+        const containerElementRefs = vm.$root.$children[0].$refs[getFrameContainerUID(frameContainerId)] as (Vue|Element)[]; // Retrieve in App
+        if(containerElementRefs) {
+            result = (frameId < 0) 
+                ? containerElementRefs[0] as InstanceType<typeof FrameContainer>
+                : getFrameComponent(frameId,{frameParentComponent: containerElementRefs[0] as InstanceType<typeof FrameContainer>, listOfFrameIdToCheck: useStore().frameObjects[frameContainerId].childrenIds});
+        }
+    }
+
+    return result;
+}
+
+export function getCaretContainerComponent(frameComponent: InstanceType<typeof Frame> | InstanceType<typeof FrameContainer>): InstanceType<typeof CaretContainer> {
+    const caretContainerComponent = (useStore().currentFrame.id < 0 || useStore().currentFrame.caretPosition == CaretPosition.below)
+        ? (frameComponent.$refs[getCaretContainerRef()] as InstanceType<typeof CaretContainer>)
+        : ((frameComponent.$refs[getFrameBodyRef()] as InstanceType<typeof FrameBody>).$refs[getCaretContainerRef()] as InstanceType<typeof CaretContainer>); 
+    return caretContainerComponent;                              
+}
+// End for component retriever
 
 export function getSaveAsProjectModalDlg():string {
     return "save-strype-project-modal-dlg";

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,7 +2,7 @@ import Vue from "vue";
 import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot } from "@/types/types";
 import { getObjectPropertiesDifferences, getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
-import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getDisabledBlockRootFrameId, getFlatNeighbourFieldSlotInfos, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
+import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
 import { AppPlatform, AppVersion, vm } from "@/main";
 import initialStates from "@/store/initial-states";
 import { defineStore } from "pinia";
@@ -1531,13 +1531,9 @@ export const useStore = defineStore("app", {
         },  
         
         doChangeDisableFrame(payload: {frameId: number; isDisabling: boolean; ignoreEnableFromRoot?: boolean}) {
-            //if we enable, we may need to use the root frame ID instead of the frame ID where the menu has been invocked
-            //because enabling a frame enables all the frames for that disabled "block" (i.e. the top disabled frame and its children/joint frames)
-            const rootFrameID = (payload.isDisabling || (payload.ignoreEnableFromRoot??false)) ? payload.frameId : getDisabledBlockRootFrameId(payload.frameId);
-
             //When we disable or enable a frame, we also disable/enable all the sublevels (children and joint frames)
-            const allFrameIds = [rootFrameID];
-            allFrameIds.push(...getAllChildrenAndJointFramesIds(rootFrameID));
+            const allFrameIds = [payload.frameId];
+            allFrameIds.push(...getAllChildrenAndJointFramesIds(payload.frameId));
             allFrameIds.forEach((frameId) => {
                 Vue.set(
                     this.frameObjects[frameId],


### PR DESCRIPTION
In order to fix #290 , disabled frames are now seen as a "unit": a disabled block frame can't have the frame cursor set inside itself, and any click or drag on an inner element of the disabled frame will be related to that whole unit instead.

This PR contains the changes to address this. 