### PR TITLE
Fixed detection of focus in LabelSlotsStructure

### DIFF
--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -234,11 +234,7 @@ export default Vue.extend({
         },
 
         focused(): boolean {
-            // We need to keep update of the label slots structure's "isFocused" flag, because using the keyboard to navigate will not
-            // update this flag -- but we always end up here when the focus (for slots) is updated.
-            const isSlotFocused = this.appStore.isEditableFocused(this.coreSlotInfo);
-            (this.$parent as InstanceType<typeof LabelSlotsStructure>).isFocused = isSlotFocused;
-            return isSlotFocused;
+            return this.appStore.isEditableFocused(this.coreSlotInfo);
         },
 
         UID(): string {
@@ -337,6 +333,9 @@ export default Vue.extend({
         // Event callback equivalent to what would happen for a focus event callback 
         // (the spans don't get focus anymore because the containg editable div grab it)
         onGetCaret(event: MouseEvent): void {
+            let parent = this.$parent as InstanceType<typeof LabelSlotsStructure>;
+            Vue.nextTick(() => parent.updatePrependText());
+            
             // If the user's code is being executed, or if the frame is disabled, we don't focus any slot, but we make sure we show the adequate frame cursor instead.
             if(this.isPythonExecuting || this.isDisabled){
                 event.stopImmediatePropagation();
@@ -508,6 +507,9 @@ export default Vue.extend({
         // Event callback equivalent to what would happen for a blur event callback 
         // (the spans don't get focus anymore because the containg editable div grab it)
         onLoseCaret(keepIgnoreKeyEventFlagOn?: boolean): void {
+            let parent = this.$parent as InstanceType<typeof LabelSlotsStructure>;
+            Vue.nextTick(() => parent.updatePrependText());
+            
             // Before anything, we make sure that the current frame still exists.
             if(this.appStore.frameObjects[this.frameId] != undefined){
                 if(!this.debugAC) {


### PR DESCRIPTION
I need to fix this so that when focus moves in or out of an "empty" class method header, the "self" part should change to "self," if there is focus in the slot (i.e. with comma), and "self" if the focus is not there.  The existing methods weren't working right so I've made this change.... but I'm not 100% sure about it, so see what you think.  I've kept this small so that you can focus on just this change.