### PR TITLE
Change behaviour when a project, that was previously saved / opened with Google Drive, is reloaded in the browser

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -72,7 +72,7 @@
             <span v-t="'appMessage.editorFileUploadWrongVersion'" />                
         </ModalDlg>
         <ModalDlg :dlgId="resyncGDAtStartupModalDlgId" :useYesNo="true" :okCustomTitle="$t('buttonLabel.yesSign')" :cancelCustomTitle="$t('buttonLabel.noContinueWithout')">
-            <span style="white-space:pre-wrap">{{ $t('appMessage.resyncToGDAtStartup') }}</span>
+            <span style="white-space:pre-wrap" v-html="$t('appMessage.resyncToGDAtStartup')"></span>
         </ModalDlg>
         <div :id="getSkulptBackendTurtleDivId" class="hidden"></div>
         <canvas v-show="appStore.isDraggingFrame" :id="getCompanionDndCanvasId" class="companion-canvas-dnd"/>
@@ -446,8 +446,8 @@ export default Vue.extend({
                             if((event.trigger == "ok" || event.trigger=="event") && dlgId == this.resyncGDAtStartupModalDlgId){
                                 // Fetch the Google Drive component
                                 const gdVueComponent = ((this.$refs[this.menuUID] as InstanceType<typeof Menu>).$refs[getGoogleDriveComponentRefId()] as InstanceType<typeof GoogleDrive>);
-                                // Initiate a connection to Google Drive via loading mechanisms (for resync at startup)
-                                gdVueComponent.loadFile(true);
+                                // Initiate a connection to Google Drive via saving mechanisms (for updating Google Drive with local changes)
+                                gdVueComponent.saveFile(SaveRequestReason.reloadBrowser);
 
                                 this.$root.$off("bv::modal::hide", execGetGDFileFunction); 
                             }

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -681,7 +681,7 @@ export default Vue.extend({
     width: 16px;
     height: 16px;
     margin-left: 15px;
-    margin-right: 2px;
+    margin-right: 5px;
 }
 
 .gdrive-sync-label {

--- a/src/localisation/de/de_main.json
+++ b/src/localisation/de/de_main.json
@@ -63,7 +63,7 @@
     "errorUserDefinedFuncMsg": "Benutzerdefinierte Function\nDiese Funktionsdefinition enthält Fehler",
     "errorUserDefinedVarMsg": "Benutzerdefinierte Variable\nEine Zuweisung zu dieser Variablen enthält einen Fehler",
     "EOFError": "Dieser Frame kann nicht leer sein.",
-    "GDriveSaveFailed": "Strype konnte nicht auf Google Drive speichern. Automatische Speicherung ist abgeschaltet.",
+    "GDriveSaveFailed": "Strype konnte nicht auf Google Drive speichern.",
     "fileNameError": "Projekt- / Dateiname kann nur Buchstaben, Zahlen, Leerzeichen, Bindestrich oder Klammern beinhalten.",
     "gdriveConnectionSaveToLoadProjFailed": "Fehler beim Versuch, dass offene Projekt auf Google Drive zu speichern. Bitte wieder anmelden, um ein anderes Projekt zu laden.",
     "gdriveConnectionSaveToUnloadPageFailed": "Fehler beim Versuch, dass offene Projekt auf Google Drive zu speichern. Bitte wieder anmelden, um das Projekt zu speichern bevor Strype geschlossen wird.",

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -111,7 +111,7 @@
     "gdriveAllStrypeFiles": "All Strype files",
     "gdriveTab": "My Drive",
     "editorErrors": "Errors",
-    "resyncToGDAtStartup": "<b>Reconnect and <u>save</u> to Google Drive?</b>\n\nLast time you were editing, you were saving to Google Drive.\nIf you want to <u>load</u> changes from Google Drive, click 'Do not connect' and use 'Open' from the menu."
+    "resyncToGDAtStartup": "<b>Reconnect and <u>save</u> to Google Drive?</b>\n\nLast time you were editing, you were saving to Google Drive.\nIf you want to instead <u>load</u> changes from Google Drive, click 'Do not connect' and use 'Open' from the menu."
   },
   "contextMenu": {
     "ctrl": "Ctrl",

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -50,8 +50,8 @@
     "overwriteProject": "Replace",
     "saveProjectCopy": "Choose new name",
     "spaceBar": "space",
-    "yesSign" : "Yes, sign me in",
-    "noContinueWithout":"No, continue without",
+    "yesSign" : "Connect",
+    "noContinueWithout":"Do not connect",
     "saveChanges": "Save changes",
     "discardChanges": "Discard changes"
   },
@@ -67,13 +67,14 @@
     "errorUserDefinedFuncMsg": "User-defined function\nthis function definition contains errors",
     "errorUserDefinedVarMsg": "User-defined variable\none of the assignments for this variable contains errors",
     "EOFError": "This frame cannot be empty.",
-    "GDriveSaveFailed": "Could not save to Google Drive. Your latest changes may have not have been saved. Auto-save is off.",
+    "GDriveSaveFailed": "Could not save to Google Drive.",
     "fileNameError": "Project / File name can only contain letters, numbers, spaces, hyphens or parentheses",
     "gdriveConnectionSaveToLoadProjFailed": "Could not connect to Google Drive when trying to save the current project. Try to sign-in again to open another project.",
     "gdriveConnectionSaveToUnloadPageFailed": "Could not connect to Google Drive when trying to save the current project. Try to sign-in again to save the current project before leaving Strype.",
     "gdrivePermissionsNotMet": "Strype requires at least one access permission to use Google Drive.",
     "gdriveReadOnly": "This file is read-only. Auto-save is off.",
     "gdriveWrongFile": "Please select a Strype file (extension \".spy\").",
+    "gdriveNoFile": "The project does not exist in Google Drive.",
     "unexpectedCharsPython": "unexpected character(s)"
   },
   "appMessage": {
@@ -110,7 +111,7 @@
     "gdriveAllStrypeFiles": "All Strype files",
     "gdriveTab": "My Drive",
     "editorErrors": "Errors",
-    "resyncToGDAtStartup": "Last time you were editing this project, you were saving to Google Drive.\nDo you want to reconnect to Google Drive in order to synchronise your changes?\nIf you do not, you will not have the latest version from Google Drive and your changes will not be saved back there."
+    "resyncToGDAtStartup": "<b>Reconnect and <u>save</u> to Google Drive?</b>\n\nLast time you were editing, you were saving to Google Drive.\nIf you want to <u>load</u> changes from Google Drive, click 'Do not connect' and use 'Open' from the menu."
   },
   "contextMenu": {
     "ctrl": "Ctrl",

--- a/src/localisation/es/es_main.json
+++ b/src/localisation/es/es_main.json
@@ -64,7 +64,7 @@
     "errorUserDefinedFuncMsg": "Funcíon definida por el usuario\nesta definición de función contiene errores",
     "errorUserDefinedVarMsg": "Variable definida por el usuario\nuna de la asignaciones para esta variable contiene errores",
     "EOFError": "Este marco no puede estar vacío.",
-    "GDriveSaveFailed": "Strype no pudo guardar el archivo en Google Drive. Es posible que no se hayan guardado los últimos cambios y que se haya apagado la sincronización.",
+    "GDriveSaveFailed": "Strype no pudo guardar el archivo en Google Drive.",
     "fileNameError": "El nombre del proyecto/archivo solo puede contener letras, números, espacios, guiones o parêntesis.",
     "gdriveConnectionSaveToLoadProjFailed": "No se pudo conectar a Google Drive al intentar guardar el proyecto actual. Intente iniciar sesión abrir otro proyecto.",
     "gdriveConnectionSaveToUnloadPageFailed": "No se pudo conectar a Google Drive al intentar guardar el proyecto actual. Intente iniciar sesión nuevamente para guardar el proyecto actual antes de salir de Strype.",

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -49,8 +49,8 @@
     "overwriteProject": "Remplacer",
     "saveProjectCopy": "Choisir un autre nom",
     "spaceBar": "espace",
-    "yesSign" : "Oui, se connecter",
-    "noContinueWithout":"Non, continuer sans connexion",
+    "yesSign" : "Se connecter",
+    "noContinueWithout":"Ne pas se connecter",
     "saveChanges": "Enregister les modifications",
     "discardChanges": "Ignorer les modifications"
   },
@@ -66,13 +66,15 @@
     "errorUserDefinedFuncMsg": "Fonction définie par l'utilisateur\nla définition de cette fonction contient des erreurs",
     "errorUserDefinedVarMsg": "Variable définie par l'utilisateur\nune affectation de cette variable contient des erreurs",
     "EOFError": "Ce cadre ne peut pas être vide.",
-    "GDriveSaveFailed": "Enregistrement vers Googde Drive impossible. Les dernières modifications n'ont peut-être pas été enregistrées et l'enregistrement automatique est desactivé.",
+    "GDriveSaveFailed": "Enregistrement vers Googde Drive impossible.",
     "fileNameError": "Le nom de projet / fichier ne peut contenir que des lettres, des chiffres, des espaces, des tirets ou des parenthèses.",
     "gdriveConnectionSaveToLoadProjFailed": "Connexion à Google Drive impossible lors de la tentative de sauvegarde du projet actuel.\nEssayez de vous connecter de nouveau pour ouvrir un autre projet.",
     "gdriveConnectionSaveToUnloadPageFailed": "Connexion à Google Drive impossible lors de la tentative de sauvegarde du projet actuel.\nEssayez de vous connecter de nouveau pour sauvegarder le project actuel avant de quitter Strype.",
     "gdrivePermissionsNotMet": "Strype nécessite au moins une permission d'accès pour utiliser Google Drive.",
     "gdriveReadOnly": "Ce fichier Drive est en lecture seule. L'enregistrement automatique a été désactivé.",
-    "gdriveWrongFile": "Veullez sélectionner un ficher Strype (extension \".spy\")."
+    "gdriveWrongFile": "Veullez sélectionner un ficher Strype (extension \".spy\").",
+    "gdriveNoFile": "Le projet n'existe pas dans Google Drive.",
+    "unexpectedCharsPython": "caractère(s) inattendu(s)"
   },
   "appMessage": {
     "editorFileUpload": "Chargement de votre fichier dans l'éditeur...",
@@ -108,7 +110,7 @@
     "gdriveAllStrypeFiles": "Tous les fichiers Strype",
     "gdriveTab": "Mon Drive",
     "editorErrors": "Erreurs",
-    "resyncToGDAtStartup": "Précédemment, ce projet était enregistré vers Google Drive.\nVoulez-vous vous reconnecter à Google Drive pour synchroniser vos modifications ?\nSans synchronisation, ce projet ne contiendra pas la dernière version de Google Drive et vos modifications n'y seront pas enregistrées."
+    "resyncToGDAtStartup": "<b>Se reconnecter et <u>sauvegarder</u> vers Google Drive ?</b>\n\nLa dernière fois que vous éditiez ce projet, vous l'enregistriez vers Google Drive.\nSi vous souhaitez <u>charger</u> les modifications à partir de Google Drive, cliquez sur 'Ne pas se connecter' et utilisez 'Ouvrir' à partir du menu."
   },
   "contextMenu": {
     "ctrl": "Ctrl",

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -110,7 +110,7 @@
     "gdriveAllStrypeFiles": "Tous les fichiers Strype",
     "gdriveTab": "Mon Drive",
     "editorErrors": "Erreurs",
-    "resyncToGDAtStartup": "<b>Se reconnecter et <u>sauvegarder</u> vers Google Drive ?</b>\n\nLa dernière fois que vous éditiez ce projet, vous l'enregistriez vers Google Drive.\nSi vous souhaitez <u>charger</u> les modifications à partir de Google Drive, cliquez sur 'Ne pas se connecter' et utilisez 'Ouvrir' à partir du menu."
+    "resyncToGDAtStartup": "<b>Se reconnecter et <u>sauvegarder</u> vers Google Drive ?</b>\n\nLa dernière fois que vous éditiez ce projet, vous l'enregistriez vers Google Drive.\nSi vous souhaitez plutôt <u>charger</u> les modifications à partir de Google Drive, cliquez sur 'Ne pas se connecter' et utilisez 'Ouvrir' à partir du menu."
   },
   "contextMenu": {
     "ctrl": "Ctrl",

--- a/src/localisation/zh/zh_main.json
+++ b/src/localisation/zh/zh_main.json
@@ -67,7 +67,7 @@
     "errorUserDefinedFuncMsg": "用户定义函数\n此函数定义包含错误",
     "errorUserDefinedVarMsg": "用户定义变量\n此变量的一个赋值包含错误",
     "EOFError": "此框架不能为空。",
-    "GDriveSaveFailed": "无法保存到 Google Drive。您的最新更改可能尚未保存。自动保存已关闭。",
+    "GDriveSaveFailed": "无法保存到 Google Drive。",
     "fileNameError": "项目/文件名只能包含字母、数字、空格、连字符或括号",
     "gdriveConnectionSaveToLoadProjFailed": "尝试保存当前项目时无法连接到 Google Drive。请尝试重新登录以打开另一个项目。",
     "gdriveConnectionSaveToUnloadPageFailed": "尝试保存当前项目时无法连接到 Google Drive。请在离开Strype前尝试重新登录以保存当前项目 。",

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1032,6 +1032,7 @@ export enum SaveRequestReason {
     overwriteExistingProject, // explicit save overwerwriting an existing file/project (used for Google Drive only)
     loadProject,
     unloadPage,
+    reloadBrowser, // for Google Drive: when a project was previously saved in GD and the browser is reloaded and the user requested to save the local changes to GD.
 }
 
 export interface SaveExistingGDProjectInfos {


### PR DESCRIPTION
As per the title say: we used to propose users to load the current version from Google Drive in the browser when reloading a project that was previously retrieved/saved with Google Drive;
We decided to change this behaviour to propose to _save_ it instead.