### PR TITLE
Various bug fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -316,12 +316,12 @@ export default Vue.extend({
                     // We found one menu entry matching the hit keyboard shortcut, we simulate a click (which will close the menu) on the underlying <a>
                     ((menuItemForKBShortcut as HTMLLIElement).children[0] as HTMLAnchorElement)?.click();
                 }
-                else if(event.key != "Enter" || (event.key == "Enter" && !isContextMenuItemSelected())){
+                else if((!event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) && (event.key != "Enter" || (event.key == "Enter" && !isContextMenuItemSelected()))){
                     // Note: that's not an ideal way of using the Keyboard Event, but the source code for VueContext uses keycodes...
                     activeContextMenu.dispatchEvent(new KeyboardEvent("keydown", {keyCode: 27}));
                 }
                 else{
-                    // An element from the menu is activated via "Enter", we don't interfere.
+                    // An element from the menu is activated via "Enter", or a modifier key is pressed alone, we don't interfere.
                     return;
                 }
 


### PR DESCRIPTION
This is a small PR containing a fix for the frame context menu (which was closing as soon as a modifier key was hit rather than waiting for the key combination).

The other fix is for the microbit version. Two changes in Strype made the API discovery behaviour outdated: the new template for function call frames meant that adding new frames from the API discovery added extra parentheses (#353) and there was a a TODO for allowing added functions formal arguments to be selected (we left it pending because at the time we were working on multi slots in frames, whereas the API discovery was written when frame label structures could only contain a single slot).