### PR TITLE
Double operator deletion issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "strype-editor",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "strype-editor",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve --port 8081",

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -693,7 +693,7 @@ export default Vue.extend({
                     }); 
                 }
                 else{
-                // Same as hitting arrow down
+                    // Same as hitting arrow down
                     const slotCursorInfo: SlotCursorInfos = {slotInfos: this.coreSlotInfo, cursorPos: this.code.length};
                     this.appStore.setSlotTextCursors(slotCursorInfo, slotCursorInfo);
                     document.getElementById(getFrameLabelSlotsStructureUID(this.frameId, this.labelSlotsIndex))?.dispatchEvent(
@@ -1240,7 +1240,10 @@ export default Vue.extend({
                             : ((neighbourOperatorSlotContent.includes(" ")) ? neighbourOperatorSlotContent.substring(0, neighbourOperatorSlotContent.indexOf(" ")) : neighbourOperatorSlotContent[0]);
                         (neighbourOperatorSlot as BaseSlot).code = newOperatorContent;
                         // We don't actually require slot to be regenerated, but we need to mark the action for undo/redo
-                        this.$nextTick(() => (this.$parent as InstanceType<typeof LabelSlotsStructure>).checkSlotRefactoring(this.UID, stateBeforeChanges));
+                        this.$nextTick(() => {
+                            this.appStore.bypassEditableSlotBlurErrorCheck = false;
+                            (this.$parent as InstanceType<typeof LabelSlotsStructure>).checkSlotRefactoring(this.UID, stateBeforeChanges);
+                        });
                     }
                     else{
                         const {newSlotId, cursorPosOffset} = this.appStore.deleteSlots(isForwardDeletion, this.coreSlotInfo);


### PR DESCRIPTION
This PR fixes the bug reported in #374 when deleting part of a double operator would keep the UI in a caret-less state.
The other commit (about the drag and drop) is Neil's fix that has been checked in a previous PR and therefore can be ignore here.