### PR TITLE
Add a dialog to support editing sound literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "@types/sortablejs": "^1.10.6",
                 "@types/splitpanes": "^2.2.6",
                 "@vue/composition-api": "^1.4.9",
+                "audiobuffer-to-wav": "^1.0.0",
                 "axios": "^0.21.4",
                 "bootstrap": "^4.6.1",
                 "bootstrap-vue": "^2.16.0",
@@ -60,6 +61,7 @@
             "devDependencies": {
                 "@pinia/testing": "^0.0.14",
                 "@testing-library/cypress": "^10.0.1",
+                "@types/audiobuffer-to-wav": "^1.0.4",
                 "@types/chai": "^4.2.11",
                 "@types/downscale": "^1.0.4",
                 "@types/file-saver": "^2.0.5",
@@ -3057,6 +3059,12 @@
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true
         },
+        "node_modules/@types/audiobuffer-to-wav": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@types/audiobuffer-to-wav/-/audiobuffer-to-wav-1.0.4.tgz",
+            "integrity": "sha512-lxIdj8z6koV3CEVW6wEXQiH2XBeTzxq1WWa3BtNtCtH++LO7ivWkciki4to0gmphhDKhSSxlce1zJaHIKJMolw==",
+            "dev": true
+        },
         "node_modules/@types/body-parser": {
             "version": "1.19.5",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -5392,6 +5400,12 @@
             "engines": {
                 "node": ">=8.0.0"
             }
+        },
+        "node_modules/audiobuffer-to-wav": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/audiobuffer-to-wav/-/audiobuffer-to-wav-1.0.0.tgz",
+            "integrity": "sha512-CAoir4NRrAzAgYo20tEMiKZR84coE8bq/L+H2kwAaULVY4+0xySsEVtNT5raqpzmH6y0pqzY6EmoViLd9W8F/w==",
+            "license": "MIT"
         },
         "node_modules/autoprefixer": {
             "version": "10.4.16",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@types/sortablejs": "^1.10.6",
         "@types/splitpanes": "^2.2.6",
         "@vue/composition-api": "^1.4.9",
+        "audiobuffer-to-wav": "^1.0.0",
         "axios": "^0.21.4",
         "bootstrap": "^4.6.1",
         "bootstrap-vue": "^2.16.0",
@@ -72,6 +73,7 @@
     "devDependencies": {
         "@pinia/testing": "^0.0.14",
         "@testing-library/cypress": "^10.0.1",
+        "@types/audiobuffer-to-wav": "^1.0.4",
         "@types/chai": "^4.2.11",
         "@types/downscale": "^1.0.4",
         "@types/file-saver": "^2.0.5",

--- a/src/components/EditImageDlg.vue
+++ b/src/components/EditImageDlg.vue
@@ -126,7 +126,7 @@ export default Vue.extend({
             this.updatePreview();
         },
         getUpdatedMedia() : Promise<{code: string, mediaType: string}> {
-            const { canvas } = (this.$refs.cropper as any).getResult() as {canvas : HTMLCanvasElement};
+            const { canvas } = (this.$refs.cropper as Cropper).getResult();
             if (!canvas) {
                 return Promise.reject("Loading");
             }

--- a/src/components/EditSoundDlg.vue
+++ b/src/components/EditSoundDlg.vue
@@ -1,0 +1,209 @@
+<template>
+    <ModalDlg :dlgId="dlgId" :dlgTitle="dlgTitle">
+        <span class="EditSoundDlg-header">{{$t("media.soundCrop")}}</span>
+        <cropper
+            ref="cropper"
+            class="edit-sound-cropper"
+            backgroundClass="edit-sound-cropper-background"
+            foregroundClass="edit-sound-cropper-foreground"
+            imageClass="edit-sound-cropper-image"
+            :src="imgPreview"
+            :resizeImage=false
+            :moveImage=false
+            :default-size="defaultSize"
+            minWidth="1"
+            minHeight="100"
+            @change="change"
+        ></cropper>
+        <span class="EditSoundDlg-header">{{$t("media.volumeScale")}}</span>
+        <div class="EditSoundDlg-scale">
+            <input v-model="volumeScaleLogPercent" type="range" id="EditSoundDlg-imageScale" min="-70" max="70" />
+            <span class="EditSoundDlg-scale-label">{{ Math.round(100.0 * (10 ** (volumeScaleLogPercent / 100.0))) }}%</span>
+        </div>
+        <span class="EditSoundDlg-header">{{$t("media.soundDetails")}}</span>
+        <span class="EditSoundDlg-sizeInfo">{{$t("media.soundChangedLength")}} {{currentSoundLength}} {{$t("media.soundSeconds")}}</span>
+        <span class="EditSoundDlg-sizeInfo">{{$t("media.soundAverageVolume")}} {{Math.round(volumeRMS * 10 * 100)}}%</span>
+        <div class="EditSoundDlg-button-wrapper">
+            <button class="EditSoundDlg-normalise-button" @click="doNormaliseVolume">{{$t("media.soundNormaliseVolume")}}</button>
+        </div>
+    </ModalDlg>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import ModalDlg from "@/components/ModalDlg.vue";
+import { Cropper } from "vue-advanced-cropper";
+import "vue-advanced-cropper/dist/style.css";
+import { useStore } from "@/store/store";
+import { mapStores } from "pinia";
+import { BvModalEvent } from "bootstrap-vue";
+import {drawSoundOnCanvas, getRMS} from "@/helpers/media";
+
+const previewImageWidth = 300;
+const previewImageHeight = 100;
+
+export default Vue.extend({
+    name: "EditSoundDlg",
+
+    components:{
+        Cropper,
+        ModalDlg,
+    },
+
+    props:{
+        dlgId: String,
+        dlgTitle: String,
+        soundToEdit: AudioBuffer,
+    },
+    
+    data: function() {
+        return {
+            imgPreview: "",
+            currentSoundLength: "Loading...",
+            // We want to allow 0.2 to 5.0 multiplier
+            // The actual value on the slider goes from -70 to +70
+            // If you put this through 10^(v/100), this turns into roughly 0.2 to 5
+            volumeScaleLogPercent: 0,
+            volumeRMS: 0,
+            crop: {firstSampleIncl: 0, lastSampleExcl: 0, leftPixel: 0, widthPixels: 0},
+        };
+    },
+
+    created() {
+        // Register the event listener for the dialog here
+        this.$root.$on("bv::modal::hide", this.onHideModalDlg);
+    },
+
+    beforeDestroy(){
+        // Remove the event listener for the dialog here, just in case...
+        this.$root.$off("bv::modal::hide", this.onHideModalDlg);
+    },
+
+    computed:{
+        ...mapStores(useStore),
+
+        dlgMsg(): string{
+            return this.appStore.simpleModalDlgMsg;
+        },
+    },
+
+    methods:{
+        onHideModalDlg(event: BvModalEvent, id: string){
+        },
+        defaultSize({imageSize, visibleArea} : { imageSize: {width: number, height: number}, visibleArea : {width: number, height: number} }) {
+            return {
+                width: (visibleArea || imageSize).width,
+                height: (visibleArea || imageSize).height,
+            };
+        },
+        change(info : {image: any, coordinates: {left: number, top: number, width: number, height: number}}) {
+            this.crop = {
+                firstSampleIncl: Math.round(info.coordinates.left / previewImageWidth * this.soundToEdit?.length),
+                lastSampleExcl: Math.round((info.coordinates.left + info.coordinates.width) / previewImageWidth * this.soundToEdit?.length),
+                leftPixel: info.coordinates.left,
+                widthPixels: info.coordinates.width,
+            };
+            // Changing the crop changes the average volume:
+            let volumeFactor = 10 ** (this.volumeScaleLogPercent / 100.0);
+            this.volumeRMS = getRMS(this.soundToEdit, volumeFactor, this.crop.firstSampleIncl, this.crop.lastSampleExcl);
+            this.currentSoundLength = ((this.crop.lastSampleExcl - this.crop.firstSampleIncl - 1) / this.soundToEdit?.sampleRate).toFixed(3);
+        },
+        doNormaliseVolume() {
+            let rms = getRMS(this.soundToEdit, 1.0, this.crop.firstSampleIncl, this.crop.lastSampleExcl);
+            this.volumeScaleLogPercent = Math.max(-70, Math.min(70, Math.round(Math.log10(rms == 0.0 ? 1 : 0.1 / rms) * 100))); 
+        },
+        getUpdatedMedia() : Promise<{code: string, mediaType: string}> {
+            const { canvas } = (this.$refs.cropper as Cropper).getResult();
+            if (!canvas) {
+                return Promise.reject("Loading");
+            }
+            return Promise.reject("TODO");
+        },
+    },
+    watch: {
+        volumeScaleLogPercent() {
+            // Redraw sound with new volume:
+            let volumeFactor = 10 ** (this.volumeScaleLogPercent / 100.0);
+            this.imgPreview = drawSoundOnCanvas(this.soundToEdit, previewImageWidth, previewImageHeight, volumeFactor);
+            this.volumeRMS = getRMS(this.soundToEdit, volumeFactor, this.crop.firstSampleIncl, this.crop.lastSampleExcl);
+            // But retain same crop (have to do this after cropper has updated the image):
+            Vue.nextTick(() => {
+                (this.$refs.cropper as Cropper).setCoordinates({
+                    left: this.crop.leftPixel,
+                    width: this.crop.widthPixels,
+                    top: 0,
+                    height: previewImageHeight,
+                });
+            });
+        },
+        soundToEdit() {
+            // When image changes (dialog being re-shown), redraw image:
+            if (this.soundToEdit != null) {
+                let volumeFactor = 10 ** (this.volumeScaleLogPercent / 100.0);
+                this.imgPreview = drawSoundOnCanvas(this.soundToEdit, previewImageWidth, previewImageHeight, volumeFactor);
+                this.volumeRMS = getRMS(this.soundToEdit, volumeFactor);
+                // Reset volume scale:
+                this.volumeScaleLogPercent = 0;
+                this.crop = {firstSampleIncl: 0, lastSampleExcl: this.soundToEdit.length, leftPixel: 0, widthPixels: previewImageWidth};
+                this.currentSoundLength = this.soundToEdit.duration.toFixed(3); 
+            }
+        },
+    },
+});
+</script>
+
+<style lang="scss">
+.edit-sound-cropper {
+    min-height: 200px;
+}
+.edit-sound-cropper, .edit-sound-cropper-background, .edit-sound-cropper-foreground {
+    background: white;
+}
+.edit-sound-cropper .vue-simple-handler {
+    background: blue;
+}
+.edit-sound-cropper .vue-simple-line {
+    border-color: blue;
+}
+// Slightly hacky way to turn off top/bottom resize handlers and cursor:
+.edit-sound-cropper .vue-handler-wrapper--north, .edit-sound-cropper .vue-handler-wrapper--south {
+    visibility: hidden;
+}
+.edit-sound-cropper .vue-line-wrapper--north, .edit-sound-cropper .vue-line-wrapper--south {
+    cursor: move;
+}
+.edit-sound-cropper-image {
+    /* Checkerboard background to reveal transparency in image: */
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAIAAADZF8uwAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAJ0lEQVQY02Pcv38/AypwcHBAE2FiIAIMRkWM////RxM6cODAcPEdAIlzCFHU4KMkAAAAAElFTkSuQmCC') repeat;
+    /* Don't smooth; we want to show the original pixelated image: */
+    image-rendering: pixelated;
+}
+.EditSoundDlg-header {
+    display: block;
+    text-align: center;
+    font-size: 100%;
+    padding-top: 15px;
+    padding-bottom: 10px;
+}
+.EditSoundDlg-header:first-child {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+.EditSoundDlg-scale > input {
+    width: 85%;
+    vertical-align: middle;
+}
+.EditSoundDlg-scale-label {
+    font-size: 80%;
+    padding-left: 10px;
+    vertical-align: middle;
+}
+.EditSoundDlg-sizeInfo {
+    font-size: 80%;
+    display: block;
+    text-align: center;
+}
+.EditSoundDlg-button-wrapper {
+    text-align: center;
+}
+</style>

--- a/src/components/MediaPreviewPopup.vue
+++ b/src/components/MediaPreviewPopup.vue
@@ -21,7 +21,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import {EditImageInDialogFunction, LoadedMedia} from "@/types/types";
+import {EditImageInDialogFunction, EditSoundInDialogFunction, LoadedMedia} from "@/types/types";
 import PythonExecutionArea from "@/components/PythonExecutionArea.vue";
 import {PersistentImageManager} from "@/stryperuntime/image_and_collisions";
 
@@ -41,7 +41,7 @@ export default Vue.extend({
         };
     },
 
-    inject: ["peaComponent", "editImageInDialog"],
+    inject: ["peaComponent", "editImageInDialog", "editSoundInDialog"],
     
     methods: {
         showPopup(event : MouseEvent, media: LoadedMedia, replaceMedia: (replacement: {code: string, mediaType: string}) => void) {
@@ -165,7 +165,9 @@ export default Vue.extend({
         },
         doEdit() {
             if (this.audioBuffer) {
-                // TODO edit sounds
+                this.doEditSoundInDialog(this.audioBuffer, (replacement : {code: string, mediaType: string}) => {
+                    this.replaceAfterEdit(replacement);
+                });
             }
             else {
                 this.doEditImageInDialog(this.imgDataURL, this.doPreviewImage, (replacement : {code: string, mediaType: string}) => {
@@ -181,6 +183,9 @@ export default Vue.extend({
         },
         doEditImageInDialog() : EditImageInDialogFunction {
             return (this as any).editImageInDialog as EditImageInDialogFunction;
+        },
+        doEditSoundInDialog() : EditSoundInDialogFunction {
+            return (this as any).editSoundInDialog as EditSoundInDialogFunction;
         },
     },
 });

--- a/src/components/MediaPreviewPopup.vue
+++ b/src/components/MediaPreviewPopup.vue
@@ -7,14 +7,18 @@
         @mouseleave="startHidePopup"
     >
         <div class="MediaPreviewPopup-header">
-            <button class="MediaPreviewPopup-header-preview-button" @click="doPreview">{{$t("media.preview")}}</button>
             <span class="MediaPreviewPopup-header-text">{{mediaInfo}}</span>
-            <button class="MediaPreviewPopup-header-edit-button" @click="doEdit">{{$t("media.edit")}}</button>
         </div>
-        <div class="MediaPreviewPopup-img-container">
-            <img :src="imgDataURL" alt="Media preview" @load="imgLoaded">
-            <!-- Style elements are dynamically set from code, don't move them to a class: -->
-            <div ref="playbackLine" class="MediaPreviewPopup-img-red-line" style="opacity: 0%; left: 0%;"></div>
+        <div class="MediaPreviewPopup-controls">
+            <b-button size="sm" variant="outline-success" class="MediaPreviewPopup-header-preview-button" @click="doPreview">{{$t("media.preview")}}</b-button>
+            <b-button size="sm" variant="outline-danger" class="MediaPreviewPopup-header-edit-button" @click="doEdit">{{$t("media.edit")}}</b-button>
+        </div>
+        <div class="MediaPreviewPopup-img-container-wrapper">
+            <div class="MediaPreviewPopup-img-container">
+                <img :src="imgDataURL" alt="Media preview" @load="imgLoaded">
+                <!-- Style elements are dynamically set from code, don't move them to a class: -->
+                <div ref="playbackLine" class="MediaPreviewPopup-img-red-line" style="opacity: 0%; left: 0%;"></div>
+            </div>
         </div>
     </div>
 </template>
@@ -214,6 +218,12 @@ export default Vue.extend({
     /* Important to make div size match img size: */
     display: inline-block;
 }
+.MediaPreviewPopup-img-container-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
 .MediaPreviewPopup-img-red-line {
     position: absolute;
     top: 0;
@@ -233,10 +243,11 @@ export default Vue.extend({
     justify-content: center;
     align-items: center;
     text-align: center;
-    color: #444;
+    color: black;
 }
-.MediaPreviewPopup-header-preview-button, .MediaPreviewPopup-header-edit-button {
-    justify-content: center;
-    align-items: center;
+.MediaPreviewPopup-controls {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 5px;
 }
 </style>

--- a/src/components/MediaPreviewPopup.vue
+++ b/src/components/MediaPreviewPopup.vue
@@ -7,7 +7,7 @@
         @mouseleave="startHidePopup"
     >
         <div class="MediaPreviewPopup-header">
-            <span class="MediaPreviewPopup-header-text">{{mediaInfo}}</span>
+            <span class="MediaPreviewPopup-header-text" v-html="mediaInfo"></span>
         </div>
         <div class="MediaPreviewPopup-controls">
             <b-button size="sm" variant="outline-success" class="MediaPreviewPopup-header-preview-button" @click="doPreview">{{$t("media.preview")}}</b-button>
@@ -61,7 +61,7 @@ export default Vue.extend({
             this.audioBuffer = media.audioBuffer;
             if (media.audioBuffer) {
                 // This is not translated because it's a class name:
-                this.mediaInfo = "Sound";
+                this.mediaInfo = `Sound<br>${media.audioBuffer.duration.toFixed(2)} ${this.$t("media.soundSeconds")}`;
                 this.imgDataURL = media.imageDataURL;
             }
             else {
@@ -75,7 +75,7 @@ export default Vue.extend({
         imgLoaded(event: Event) {
             const previewImgElement = event.target as HTMLImageElement;
             if (this.mediaType.startsWith("image/")) {
-                this.mediaInfo = `EditableImage (${this.mediaType.replace("image/", "")}), ${previewImgElement?.naturalWidth} × ${previewImgElement?.naturalHeight} ${this.$t("media.pixels")}`;
+                this.mediaInfo = `EditableImage (${this.mediaType.replace("image/", "")})<br>${previewImgElement?.naturalWidth} × ${previewImgElement?.naturalHeight} ${this.$t("media.pixels")}`;
             }
         },
         startHidePopup() {

--- a/src/helpers/media.ts
+++ b/src/helpers/media.ts
@@ -1,0 +1,47 @@
+
+// Adapted from https://stackoverflow.com/questions/66776487/how-to-convert-mp3-to-the-sound-wave-image-using-javascript
+// Returns base64 version of PNG of image
+export function drawSoundOnCanvas(audioBuffer : AudioBuffer, targetWidth: number, targetHeight: number, volumeFactor = 1.0, rescaleToMax = 1.0) : string {
+    const float32Arrays : Float32Array[] = [];
+    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+        float32Arrays.push(audioBuffer.getChannelData(ch));
+    }
+    const array = [];
+
+    let i = 0;
+    const length = audioBuffer.length;
+    const chunkSize = Math.floor(length / targetWidth);
+    while (i < length) {
+        let max = 0;
+        // We take the max out of all values in the chunk, across all channels:
+        for (const arr of float32Arrays) {
+            max = Math.max(arr.slice(i, i + chunkSize).reduce(function (total, value) {
+                return Math.max(total, Math.abs(value));
+            }));
+        }
+        array.push(max);
+        i += chunkSize;
+    }
+
+    const img = document.createElement("canvas");
+    img.width = targetWidth;
+    img.height = targetHeight;
+    const ctx = img.getContext("2d") as OffscreenCanvasRenderingContext2D | null;
+    if (ctx == null) {
+        // Shouldn't happen:
+        return "";
+    }
+    ctx.fillStyle = "black";
+    ctx.fillRect(0, 0, targetWidth, targetHeight);
+
+    for (let index = 0; index < array.length; index++) {
+        ctx.strokeStyle = "green";
+        ctx.beginPath();
+        // Most sounds don't reach max volume so we allow rescaling to give a more indicative preview:
+        ctx.moveTo(index, targetHeight/2 - Math.min(rescaleToMax, volumeFactor * Math.abs(array[index]))/rescaleToMax * targetHeight/2);
+        ctx.lineTo(index, targetHeight/2 + Math.min(rescaleToMax, volumeFactor * Math.abs(array[index]))/rescaleToMax * targetHeight/2);
+        ctx.stroke();
+    }
+    return img.toDataURL("image/png");
+}
+

--- a/src/helpers/media.ts
+++ b/src/helpers/media.ts
@@ -45,3 +45,20 @@ export function drawSoundOnCanvas(audioBuffer : AudioBuffer, targetWidth: number
     return img.toDataURL("image/png");
 }
 
+export function getRMS(audioBuffer: AudioBuffer, volumeFactor: number, firstSampleIncl?: number, lastSampleExcl?: number) : number {
+    const numChannels = audioBuffer.numberOfChannels;
+    let rms = 0;
+    let sampleCount = 0;
+
+    // Calculate RMS level
+    for (let channel = 0; channel < numChannels; channel++) {
+        const samples = audioBuffer.getChannelData(channel);
+        for (let i = firstSampleIncl ?? 0; i < (lastSampleExcl ?? samples.length); i++) {
+            rms += samples[i] * samples[i] * volumeFactor * volumeFactor; // Sum squared values
+            sampleCount++;
+        }
+    }
+
+    rms = Math.sqrt(rms / sampleCount); // Compute RMS
+    return rms;
+}

--- a/src/helpers/media.ts
+++ b/src/helpers/media.ts
@@ -1,3 +1,5 @@
+import toWav from "audiobuffer-to-wav";
+
 
 // Adapted from https://stackoverflow.com/questions/66776487/how-to-convert-mp3-to-the-sound-wave-image-using-javascript
 // Returns base64 version of PNG of image
@@ -61,4 +63,14 @@ export function getRMS(audioBuffer: AudioBuffer, volumeFactor: number, firstSamp
 
     rms = Math.sqrt(rms / sampleCount); // Compute RMS
     return rms;
+}
+
+export async function audioBufferToDataURL(audioBuffer : AudioBuffer) : Promise<string> {
+    const wavArrayBuffer = toWav(audioBuffer);
+    return new Promise((resolve) => {
+        const blob = new Blob([wavArrayBuffer], { type: "audio/wav" });
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result as string);
+        reader.readAsDataURL(blob);
+    });
 }

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -179,7 +179,9 @@
     "soundCrop": "Sound Trimming",
     "soundDetails": "Sound Details",
     "soundNormaliseVolume": "Normalise volume",
-    "soundSeconds": "seconds",
+    "soundPlay": "Play",
+    "soundSeconds": "seconds", 
+    "soundStop": "Stop",
     "volumeScale": "Volume Scaling"
   }
 }

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -173,6 +173,13 @@
     "imageOriginalSize": "Original size: ",
     "imageScale": "Image Scale",
     "pixels": "pixels",
-    "preview": "Preview"
+    "preview": "Preview",
+    "soundAverageVolume": "Average volume:",
+    "soundChangedLength": "Result length:",
+    "soundCrop": "Sound Trimming",
+    "soundDetails": "Sound Details",
+    "soundNormaliseVolume": "Normalise volume",
+    "soundSeconds": "seconds",
+    "volumeScale": "Volume Scaling"
   }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1130,3 +1130,5 @@ export interface LoadedMedia {
 }
 
 export type EditImageInDialogFunction = (imageDataURL: string, showPreview: (dataURL : string) => void, callback: (replacement: {code: string, mediaType: string}) => void) => void;
+export type EditSoundInDialogFunction = (sound: AudioBuffer, callback: (replacement: {code: string, mediaType: string}) => void) => void;
+


### PR DESCRIPTION
This adds EditSoundDlg, which is the sound equivalent of EditImageDlg.  It's very similar in structure; we use the same image cropper to provide a UI to allow trimming the sound, and we provide a slider to allow changing the volume.  There's a button to play/stop a preview of the sound, and a button to normalise volume.  Looks like this:

![image](https://github.com/user-attachments/assets/736cc8a3-681e-4ed0-b31a-bf2e0aec1726)

Also fixed up the UI on buttons in the media preview popup dialog by using b-button instead of button and laying it out slightly differently.