### PR TITLE
Save and restore the layout with the project

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -416,11 +416,13 @@ export default Vue.extend({
         // Add a listener for the mouse scroll events. We do not want to allow scrolling when the context menu is shown
         document.addEventListener("wheel", this.blockScrollOnContextMenu, {passive:false});
 
+        /* IFTRUE_isPython */
         // Add a listener for the whole window resize.
         window.addEventListener("resize",() => {
             // Re-scale the Turtle canvas.
             document.getElementById("tabContentContainerDiv")?.dispatchEvent(new CustomEvent(CustomEventTypes.pythonExecAreaSizeChanged));
         });
+        /* FITRUE_isPython */
 
         // When the page is loaded, we might load an existing code for which the caret is not visible, so we get it into view.
         setTimeout(() => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1002,10 +1002,18 @@ export default Vue.extend({
                 setManuallyResizedEditorHeightFlag(editorNewMaxHeight);
                 debounceComputeAddFrameCommandContainerSize(true);
                 // Set the editor's max height (fitting within the first pane's height); as well as the "frame commands" panel's
-                (document.getElementsByClassName(scssVars.croppedEditorDivClassName)[0] as HTMLDivElement).style.maxHeight = (editorNewMaxHeight + "px");
+                const croppedEditor = document.getElementsByClassName(scssVars.croppedEditorDivClassName);
+                if(croppedEditor.length > 0){
+                    // The "cropped editor", that is when the PEA is expanded may not exist if the PEA wasn't expanded before..
+                    (croppedEditor[0] as HTMLDivElement).style.maxHeight = (editorNewMaxHeight + "px");                      
+                }
                 (document.getElementsByClassName(scssVars.noPEACommandsClassName)[0] as HTMLDivElement).style.maxHeight = (editorNewMaxHeight + "px");
                 // Set the Python Execution Area's position
-                (document.querySelector("." + scssVars.peaContainerClassName + "." + scssVars.expandedPEAClassName) as HTMLDivElement).style.top = (editorNewMaxHeight + "px");
+                const peaWithExpandedClass = document.querySelector("." + scssVars.peaContainerClassName + "." + scssVars.expandedPEAClassName);
+                if(peaWithExpandedClass){
+                    // The "expanded PEA" may not exist if the PEA wasn't expanded before..
+                    (peaWithExpandedClass as HTMLDivElement).style.top = (editorNewMaxHeight + "px");
+                }     
                 // Set the max height of the Python Execution Area's tab content
                 setPythonExecutionAreaTabsContentMaxHeight();
                 // Trigger a resized event (for scaling the Turtle canvas properly)

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@
         <Splitpanes class="expanded-PEA-splitter-overlay strype-split-theme" v-show="isExpandedPythonExecArea" horizontal @resize=onExpandedPythonExecAreaSplitPaneResize>
             <pane key="1">
             </pane>
-            <pane key="2" min-size="20" max-size="80">
+            <pane ref="overlayExpandedPEAPane2Ref" key="2" min-size="20" max-size="80">
             </pane>
         </Splitpanes>
         FITRUE_isPython */
@@ -93,7 +93,7 @@ import Commands from "@/components/Commands.vue";
 import Menu from "@/components/Menu.vue";
 import ModalDlg from "@/components/ModalDlg.vue";
 import SimpleMsgModalDlg from "@/components/SimpleMsgModalDlg.vue";
-import {Splitpanes, Pane} from "splitpanes";
+import {Splitpanes, Pane, PaneData} from "splitpanes";
 import { useStore } from "@/store/store";
 import { AppEvent, ProjectSaveFunction, BaseSlot, CaretPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, FrameObject, MessageDefinitions, MessageTypes, ModifierKeyCode, Position, PythonExecRunningState, SaveRequestReason, SlotCursorInfos, SlotsStructure, SlotType, StringSlot, StrypeSyncTarget, GAPIState } from "@/types/types";
 import { getFrameContainerUID, getMenuLeftPaneUID, getEditorMiddleUID, getCommandsRightPaneContainerId, isElementLabelSlotInput, CustomEventTypes, getFrameUID, parseLabelSlotUID, getLabelSlotUID, getFrameLabelSlotsStructureUID, getSelectionCursorsComparisonValue, setDocumentSelection, getSameLevelAncestorIndex, autoSaveFreqMins, getImportDiffVersionModalDlgId, getAppSimpleMsgDlgId, getFrameContextMenuUID, getActiveContextMenu, actOnTurtleImport, setPythonExecutionAreaTabsContentMaxHeight, setManuallyResizedEditorHeightFlag, setPythonExecAreaLayoutButtonPos, isContextMenuItemSelected, getStrypeCommandComponentRefId, frameContextMenuShortcuts, getCompanionDndCanvasId, getPEAComponentRefId, getGoogleDriveComponentRefId, addDuplicateActionOnFramesDnD, removeDuplicateActionOnFramesDnD, getFrameComponent, getCaretContainerComponent, sharedStrypeProjectTargetKey, sharedStrypeProjectIdKey, getCaretContainerUID, getEditorID, getLoadProjectLinkId } from "./helpers/editor";
@@ -428,6 +428,12 @@ export default Vue.extend({
         /* IFTRUE_isPython */
         // Add a listener for the whole window resize.
         window.addEventListener("resize",() => {
+            // When the window is resized, the overlay expanded PEA splitter is properly updated. However, the underlying UI is not updated
+            // properly (because it isn't inside that splitter) so we need to manually update things.
+            if(this.isExpandedPythonExecArea) {
+                this.onExpandedPythonExecAreaSplitPaneResize({1: {size: ((this.$refs.overlayExpandedPEAPane2Ref as InstanceType<typeof Pane>).$data as PaneData).style.height.replace("%","")}});
+            }
+
             // Re-scale the Turtle canvas.
             document.getElementById(getPEATabContentContainerDivId())?.dispatchEvent(new CustomEvent(CustomEventTypes.pythonExecAreaSizeChanged));
         });

--- a/src/assets/style/_export.module.scss
+++ b/src/assets/style/_export.module.scss
@@ -7,6 +7,9 @@
   pythonExecutionAreaMargin: $strype-python-exec-area-margin;
   nonMainCodeContainerBackground: $strype-non-main-code-container-background;
   mainCodeContainerBackground: $strype-main-code-container-background;
+  editorCommandsSplitterPane2SizePercentValue: $editor-commands-splitter-pane2-size-value;
+  peaExpandedOverlaySplitterPane2SizePercentValue: $pea-expanded-overlay-splitter-pane2-size-value;
+  peaSplitViewSplitterPane1SizePercentValue: $pea-splitview-splitter-pane1-size-value;
 
   // These variables are used to share class names in the Strype code
   // editor related
@@ -28,6 +31,7 @@
   frameOperatorSlotClassName: $strype-classname-frame-operator-slot;
   frameCommentSlotClassName: $strype-classname-frame-comment-slot;
   frameCodeSlotClassName: $strype-classname-frame-code-slot;
+  croppedEditorDivClassName: $strype-classname-cropped-editor-code-div;
   // autocompletion related
   acPopupContainerClassName: $strype-classname-ac-popup-container;
   acPopupItemClassName: $strype-classname-ac-popup-item;

--- a/src/assets/style/variables.scss
+++ b/src/assets/style/variables.scss
@@ -10,6 +10,9 @@ $strype-non-main-code-container-background: #CBD4C8;
 $strype-main-code-container-background: #F6F2E9;
 $strype-frame-caret-forbidden-dnd-cross-height-notransform-value : 20;
 $pea-outer-background-color: rgb(240, 240, 240);
+$editor-commands-splitter-pane2-size-value: 34;
+$pea-expanded-overlay-splitter-pane2-size-value: 50;
+$pea-splitview-splitter-pane1-size-value: 50;
 
 // Class Names
 // editor related
@@ -31,6 +34,7 @@ $strype-classname-frame-string-slot: string-slot;
 $strype-classname-frame-operator-slot: operator-slot;
 $strype-classname-frame-comment-slot: comment-slot;
 $strype-classname-frame-code-slot: code-slot;
+$strype-classname-cropped-editor-code-div: cropped-editor-code-div;
 // autocompletion related
 $strype-classname-ac-popup-container: ac-popup-container;
 $strype-classname-ac-popup-item: ac-popup-item;

--- a/src/assets/style/variables.scss
+++ b/src/assets/style/variables.scss
@@ -8,3 +8,4 @@ $strype-python-exec-area-margin: 5px;
 $strype-non-main-code-container-background: #CBD4C8;
 $strype-main-code-container-background: #F6F2E9;
 $strype-frame-caret-forbidden-dnd-cross-height-notransform-value : 20;
+$pea-outer-background-color: rgb(240, 240, 240);

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -2,7 +2,7 @@
     <div class="commands">
         /* IFTRUE_isPython
         <Splitpanes horizontal :class="{[scssVars.commandsPEASplitterThemeClassName]: true, [scssVars.expandedPEAClassName]: isExpandedPEA}" @resize="onCommandsSplitterResize">
-            <pane key="1" ref="peaCommandsSplitterPane1Ref" :size="100-commandsSplitterPane2Size" :min-size="commandSplitterPane1MinSize">
+            <pane key="1" ref="peaCommandsSplitterPane1Ref" :size="100 - commandsSplitterPane2Size" :min-size="commandSplitterPane1MinSize">
         FITRUE_isPython */
                 <div :class="scssVars.noPEACommandsClassName" @wheel.stop>
                     <div :class="scssVars.strypeProjectNameContainerClassName">
@@ -89,7 +89,7 @@
 import AddFrameCommand from "@/components/AddFrameCommand.vue";
 import { computeAddFrameCommandContainerSize, CustomEventTypes, getActiveContextMenu, getAddFrameCmdElementUID, getCommandsContainerUID, getCommandsRightPaneContainerId, getCurrentFrameSelectionScope, getEditorMiddleUID, getMenuLeftPaneUID, handleContextMenuKBInteraction, hiddenShorthandFrames, notifyDragEnded } from "@/helpers/editor";
 import { useStore } from "@/store/store";
-import { AddFrameCommandDef, AllFrameTypesIdentifier, CaretPosition, FrameObject, PythonExecRunningState, SelectAllFramesFuncDefScope, StrypeSyncTarget } from "@/types/types";
+import { AddFrameCommandDef, AllFrameTypesIdentifier, CaretPosition, FrameObject, PythonExecRunningState, SelectAllFramesFuncDefScope, StrypePEALayoutMode, StrypeSyncTarget } from "@/types/types";
 import $ from "jquery";
 import Vue from "vue";
 import browserDetect from "vue-browser-detect-plugin";
@@ -644,10 +644,6 @@ export default Vue.extend({
             this.lastProjectSavedDateTooltip = toolTipVal;
         },
 
-       
-
-        
-
         /* IFTRUE_isMicrobit */
         runToMicrobit() {
             // If we can directly upload on microbit, we run the method flash().
@@ -674,7 +670,7 @@ export default Vue.extend({
         /* IFTRUE_isPython */
         onPEAMounted(){
             // Once the PEA is ready, we need to fix the splitter's position between the frame commands area and the PEA,
-            // so that the PEA stays at the bottom of the viewport as intially intented (in its intial 4/3 ratio).
+            // so that the PEA stays at the bottom of the viewport as intially intented (in its initial 4:3 ratio).
             const peaElement = (this.$refs[this.peaComponentRefId] as Vue).$el;
             const peaHeight = peaElement.getBoundingClientRect().height;
             const peaMargin = parseInt(scssVars.pythonExecutionAreaMargin.replace("px",""));
@@ -684,7 +680,6 @@ export default Vue.extend({
                 const commandsSplitterHeight = commandsSplitterDivider.getBoundingClientRect().height + parseInt(window.getComputedStyle(commandsSplitterDivider).marginTop.replace("px","")); 
                 const viewPortH = document.getElementsByTagName("body")[0].getBoundingClientRect().height;
                 this.commandsSplitterPane2Size = ((peaHeight + peaMargin ) * 100) / (viewPortH - commandsSplitterHeight);
-                
                 // The splitter's PEA pane's min size will be updated after computeAddFrameCommandContainerSize() is called
             }
 
@@ -694,11 +689,32 @@ export default Vue.extend({
             }, 200);
         },
 
-        onCommandsSplitterResize() {
+        resetPEACommmandsSplitterDefaultState(): Promise<void> {
+            // When a project is loaded, a PEA layout will be affected.
+            // We need to make sure to be "as if" we were starting from a default project layout
+            // before doing anything (otherwise we have issues with some layout related stuff that
+            // are not saved, or some styling that gets messy).
+            return new Promise((resolve) => {
+                this.hasPEAExpanded = false;
+                this.isCommandsSplitterChanged = false;               
+                (this.$refs[this.peaComponentRefId] as InstanceType<typeof PythonExecutionArea>).togglePEALayout(StrypePEALayoutMode.tabsCollapsed);
+                // Once we have the flags set, we set a timer to wait for the splitter to update before returning from the promise
+                setTimeout(() => {
+                    resolve();
+                }, 800);   
+            });            
+        },        
+
+        onCommandsSplitterResize(event: any) {
             // When the splitter is resized, we need to resize the frame commands container (wrap/unwrap)
-            // and the PEA (will take the full space in its pane, breaking the initial 4/3 ratio)
+            // and the PEA (will take the full space in its pane, breaking the initial 4:3 ratio)
             document.getElementById(getPEATabContentContainerDivId())?.dispatchEvent(new CustomEvent(CustomEventTypes.pythonExecAreaSizeChanged));
             this.isCommandsSplitterChanged = true;
+            this.commandsSplitterPane2Size = event[1].size;
+            // We also save the value in the store. We do not want to set commandsSplitterPane2Size as get/set computed property
+            // (and call the appStore change in set()) because we set the value based on other settings (the 4:3 ratio) when PEA is mounted,
+            // that value then shouldn't be saved in the store.
+            this.appStore.peaCommandsSplitterPane2Size = this.commandsSplitterPane2Size;
         },
 
         setPEACommandsSplitterPanesMinSize() {

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -100,7 +100,7 @@ import { isMacOSPlatform } from "@/helpers/common";
 /* IFTRUE_isPython */
 import {Splitpanes, Pane, PaneData} from "splitpanes";
 import PythonExecutionArea from "@/components/PythonExecutionArea.vue";
-import {getPEAConsoleId, getPEAGraphicsContainerDivId, getPEAGraphicsDivId, getPEATabContentContainerDivId, getPEAComponentRefId} from "@/helpers/editor";
+import {getPEAConsoleId, getPEAGraphicsContainerDivId, getPEAGraphicsDivId, getPEATabContentContainerDivId, getPEAComponentRefId, getPEAControlsDivId} from "@/helpers/editor";
 /* FITRUE_isPython */
 /* IFTRUE_isMicrobit */
 import APIDiscovery from "@/components/APIDiscovery.vue";
@@ -714,7 +714,7 @@ export default Vue.extend({
             if(commandsSplitterDivider) {               
                 const commandsSplitterHeight = commandsSplitterDivider.getBoundingClientRect().height; 
                 const projectNameContainerDiv = document.getElementsByClassName(scssVars.strypeProjectNameContainerClassName)?.[0];
-                const firstAddCommandDiv = document.querySelector(".frameCommands p > div");                
+                const firstAddCommandDiv = document.querySelector("." + scssVars.addFrameCommandsContainerClassName + " p > div");                
                 // Pane 1: it is possible that at some point, the frame commands panel has a x-axis scroll bar (when the commands are wrapped). 
                 // So we need to account for that in the min size.
                 const frameCommandsContainer = (document.querySelector("." + scssVars.noPEACommandsClassName) as HTMLDivElement);
@@ -736,8 +736,8 @@ export default Vue.extend({
                 }    
             
                 // Pane 2:
-                const peaHeaderHeight = (document?.getElementById("peaControlsDiv")?.getBoundingClientRect().height)??0;
-                const peaConsoleElement = document.getElementById("pythonConsole");
+                const peaHeaderHeight = (document?.getElementById(getPEAControlsDivId())?.getBoundingClientRect().height)??0;
+                const peaConsoleElement = document.getElementById(getPEAConsoleId());
                 if(peaConsoleElement){               
                     const peaConsoleLineH = parseFloat(window.getComputedStyle(peaConsoleElement).lineHeight.replace("px",""));
                     this.commandSplitterPane2MinSize = ((peaHeaderHeight + 3 * peaConsoleLineH) * 100) / (viewPortH - commandsSplitterHeight);

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -888,8 +888,7 @@ export default Vue.extend({
 .#{$strype-classname-add-frame-commands-container}.with-expanded-PEA p {
    // So that the frame commands in expanded view expands over the commands/PEA splitter,
    // the width is set programmatically
-   position: absolute; 
-  
+   position: absolute;   
 }
 
 .#{$strype-classname-pea-container} {

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -58,7 +58,7 @@
                 </div>
         /* IFTRUE_isPython
             </pane>           
-            <pane key="2" :size="commandsSplitterPane2Size" :min-size="commandSplitterPane2MinSize">
+            <pane key="2" :size="commandsSplitterPane2Size" :min-size="commandSplitterPane2MinSize" :class="{'collapsed-pea-splitter-pane': !isExpandedPEA}">
                 <python-execution-area class="python-exec-area-container" :ref="peaComponentRefId" v-on:[peaMountedEventName]="onPEAMounted" :hasDefault43Ratio="!isCommandsSplitterChanged && !hasPEAExpanded"/>
             </pane>
         </Splitpanes>
@@ -789,6 +789,10 @@ export default Vue.extend({
     width: 100% !important;
     transform: none !important;
     height: auto !important;
+}
+
+.collapsed-pea-splitter-pane {
+    background-color: $pea-outer-background-color;
 }
 /* FITRUE_isPython */
 /** End splitter classes */

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -18,7 +18,7 @@
         <div :id="tabContentContainerDivId" :class="{'pea-tab-content-container': true, 'flex-padding': true, 'pea-43-ratio': hasDefault43Ratio}">
             <!-- the SplitPanes is used in all layout configurations: for tabs, we only show 1 of the panes and disable moving the divider, and for stacked window it acts as normal -->
             <Splitpanes :class="{'strype-PEA-split-theme': true, 'with-expanded-PEA': isExpandedPEA, 'tabs-PEA': isTabsLayout}" :horizontal="!isExpandedPEA" @resize="onSplitterPane1Resize">
-                <pane :id="graphicsSplitPaneId" key="1" v-show="isGraphicsAreaShowing" :size="(isTabsLayout) ? 100 : currentSplitterPane1Size">
+                <pane :id="graphicsSplitPaneId" key="1" v-show="isGraphicsAreaShowing" :size="(isTabsLayout) ? 100 : currentSplitterPane1Size" min-size="5">
                     <div :id="graphicsContainerDivId" @wheel.stop :class="{'pea-graphics-container': true, hidden: graphicsTemporaryHidden}">
                         <div><!-- this div is a flex wrapper just to get scrolling right, see https://stackoverflow.com/questions/49942002/flex-in-scrollable-div-wrong-height-->
                             <div :id="graphicsDivId" ref="pythonTurtleDiv" class="pea-graphics-div"></div>
@@ -26,7 +26,7 @@
                         <span v-if="isGraphicsAreaShowing && !turtleGraphicsImported" class="pea-no-graphics-import-span">{{$t('PEA.importTurtle')}}</span> 
                     </div>
                 </pane>
-                <pane key="2" v-show="isConsoleAreaShowing" :size="(isTabsLayout) ? 100 : (100 - currentSplitterPane1Size)">
+                <pane key="2" v-show="isConsoleAreaShowing" :size="(isTabsLayout) ? 100 : (100 - currentSplitterPane1Size)" min-size="5">
                     <textarea 
                         :id="pythonConsoleId"
                         ref="pythonConsole"
@@ -774,5 +774,14 @@ export default Vue.extend({
     .strype-PEA-split-theme.tabs-PEA.splitpanes--vertical>.splitpanes__splitter,
     .strype-PEA-split-theme.tabs-PEA .splitpanes--vertical>.splitpanes__splitter {
         display: none;
+    }
+
+    .strype-PEA-split-theme.splitpanes--vertical > .splitpanes__splitter:before,
+    .strype-PEA-split-theme > .splitpanes--vertical > .splitpanes__splitter:before {
+        content: "";
+        position: absolute;
+        height: 100% !important;
+        width: 8px !important;
+        transform: none !important;
     }
 </style>

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -164,21 +164,31 @@ export default Vue.extend({
             // Register an observer when the tab content dimension changes: we need to reflect this on the canvas scaling (cf. above)
             // DO NOT use ResizeObserver to do so: it gets messy with the events loop ("ResizeObserver loop completed with undelivered notifications.")
             const debouncePEASizeChangedCallback = debounce(() => {
-                // We should only scale the canvas if there is at least a canvas to scale! (i.e. we show turtle graphics...)
-                if (document.querySelectorAll("#pythonTurtleDiv canvas").length > 0) {
-                    this.graphicsTemporaryHidden = true;
-                    setTimeout(() => {
-                        if(document.querySelectorAll("#pythonTurtleDiv canvas").length > 0){
-                            this.scaleTurtleCanvas(tabContentContainerDiv,graphicsSplitPaneDiv, turtlePlaceholderDiv);
-                        }
-                    }, 100);                    
+                // If Strype is shown in its default view (PEA has 4/3 ratio, we need to update the splitter so the PEA stay visible)
+                let waitSplitterToAdaptTimeout = 0;
+                if(this.hasDefault43Ratio) {
+                    waitSplitterToAdaptTimeout = 200;
+                    this.$emit(CustomEventTypes.pythonExecAreaMounted);
                 }
-                
+
                 setTimeout(() => {
-                    debounceComputeAddFrameCommandContainerSize(this.isExpandedPEA);
-                    setPythonExecAreaLayoutButtonPos();
-                }, 100);
+                    // We should only scale the canvas if there is at least a canvas to scale! (i.e. we show turtle graphics...)
+                    if (document.querySelectorAll("#pythonTurtleDiv canvas").length > 0) {
+                        this.graphicsTemporaryHidden = true;
+                        setTimeout(() => {
+                            if(document.querySelectorAll("#pythonTurtleDiv canvas").length > 0){
+                                this.scaleTurtleCanvas(tabContentContainerDiv,graphicsSplitPaneDiv, turtlePlaceholderDiv);
+                            }
+                        }, 100);                    
+                    }
+                
+                    setTimeout(() => {
+                        debounceComputeAddFrameCommandContainerSize(this.isExpandedPEA);
+                        setPythonExecAreaLayoutButtonPos();
+                    }, 100);
+                }, waitSplitterToAdaptTimeout);
             }, 100);
+            
             tabContentContainerDiv.addEventListener(CustomEventTypes.pythonExecAreaSizeChanged, debouncePEASizeChangedCallback);
 
             // Register to the window event listener for Skulpt Turtle mouse and timer events listening off notification

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -571,7 +571,7 @@ export default Vue.extend({
         display: flex;
         column-gap: 5px;        
         width:100%;
-        background-color: rgb(240,240,240);
+        background-color: $pea-outer-background-color;
         align-items: center;
     }
 
@@ -726,7 +726,7 @@ export default Vue.extend({
      * The following CSS classes are for the Splitter component in use here
      */
     .splitpanes.strype-PEA-split-theme.with-expanded-PEA {
-        background-color: rgb(240,240,240);
+        background-color: $pea-outer-background-color;
     }
     
     .strype-PEA-split-theme.splitpanes--horizontal>.splitpanes__splitter,

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1788,7 +1788,7 @@ export function computeAddFrameCommandContainerSize(isExpandedPEA?: boolean): vo
     // When we are done, we need to check again the min size of the commands/PEA splitter pane 1, since scroll bars
     // could have been added with the new change (need to wait for it to be effective though).
     setTimeout(() => {
-        (vm.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).setCommandsSplitterPanesMinSize();    
+        (vm.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).setPEACommandsSplitterPanesMinSize();    
     }, 100);    
 }
 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -13,8 +13,11 @@ import Frame from "@/components/Frame.vue";
 import FrameContainer from "@/components/FrameContainer.vue";
 import FrameBody from "@/components/FrameBody.vue";
 import JointFrames from "@/components/JointFrames.vue";
+/* IFTRUE_isPython */
+import CommandsComponent from "@/components/Commands.vue";
 import PythonExecutionArea from "@/components/PythonExecutionArea.vue";
 import { debounce } from "lodash";
+/* FITRUE_isPython */
 
 export const undoMaxSteps = 200;
 export const autoSaveFreqMins = 2; // The number of minutes between each autosave action.
@@ -1781,6 +1784,12 @@ export function computeAddFrameCommandContainerSize(isExpandedPEA?: boolean): vo
             }
         }
     }
+
+    // When we are done, we need to check again the min size of the commands/PEA splitter pane 1, since scroll bars
+    // could have been added with the new change (need to wait for it to be effective though).
+    setTimeout(() => {
+        (vm.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).setCommandsSplitterPanesMinSize();    
+    }, 100);    
 }
 
 export function getCurrentFrameSelectionScope(): SelectAllFramesFuncDefScope {

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1738,7 +1738,7 @@ export function actOnTurtleImport(): void {
 // We need to "fix" the size of the tabs container so the elements of the Exec Area, when it's enlarged, are correctly flowing in the page
 // and stay within the splitters (which are overlayed in App.vue).
 let manuallyResizedEditorHeight: number | undefined; // Flag used below and by App.vue - do not store this in store, it's session-lived only.
-export function setManuallyResizedEditorHeightFlag(value: number): void {
+export function setManuallyResizedEditorHeightFlag(value: number | undefined): void {
     manuallyResizedEditorHeight = value;
 }
 export function getManuallyResizedEditorHeightFlag(): number | undefined {
@@ -1836,13 +1836,13 @@ export function computeAddFrameCommandContainerSize(isExpandedPEA?: boolean): vo
                 }
             }
         }
+            
+        // When we are done, we need to check again the min size of the commands/PEA splitter pane 1, since scroll bars
+        // could have been added with the new change (need to wait for it to be effective though).
+        setTimeout(() => {
+            (vm.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).setPEACommandsSplitterPanesMinSize();    
+        }, 100);    
     }
-
-    // When we are done, we need to check again the min size of the commands/PEA splitter pane 1, since scroll bars
-    // could have been added with the new change (need to wait for it to be effective though).
-    setTimeout(() => {
-        (vm.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).setPEACommandsSplitterPanesMinSize();    
-    }, 100);    
 }
 /* FITRUE_isPython */
 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1790,7 +1790,6 @@ export function setPythonExecAreaLayoutButtonPos(): void{
         }
     }, 100);
 }
-/* FITRUE_isPython */
 
 /** 
  * These methods are used to control the height of the "Add frame" commands,
@@ -1845,6 +1844,8 @@ export function computeAddFrameCommandContainerSize(isExpandedPEA?: boolean): vo
         (vm.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).setPEACommandsSplitterPanesMinSize();    
     }, 100);    
 }
+/* FITRUE_isPython */
+
 
 export function getCurrentFrameSelectionScope(): SelectAllFramesFuncDefScope {
     // This method checks the current selection scope that we need to know when doing select-all (for function definitions).

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -81,9 +81,8 @@ export const useStore = defineStore("app", {
             isEditing: false,
 
             /* These state properties are for saving the layout of the UI.
-             * Some are initally set to UNDEFINED so it we can detect default state:
-             * (for example, the PEA will take its 4:3 ratio size when the commands/PEA 
-             * splitter has not changed, we it needs to be seen as such. )
+             * They are initally set to UNDEFINED so we can work out which layout changes the users have done.
+             * We always apply the changes after getting back to the default layout (when a file is loaded after first time).
              ***/ 
             editorCommandsSplitterPane2Size: undefined as number | undefined, // same as above for the divider between the editor and the commands (pane 2), default is 34%
             


### PR DESCRIPTION
The main part of this PR is about saving the layout/styling of the Strype UI and restore it on a project (re)load.
Because of timing and denouncing, a few timeouts are added but shouldn't be too problematic.
The idea is that on project load, we reset the UI to a default state and apply the changes from there on.

Other bits of the changes are for setting new minimum panel sizes for the different splitters of the UI, as well fixing a few bugs with layout / style handling.