### PR TITLE
Change how we handle keyboard input in slots to use the input event

### DIFF
--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -533,16 +533,6 @@ export default Vue.extend({
                     event.preventDefault();
                     return;
                 }
-
-                //prevent specific characters in specific frames (cf details)
-                if(isEditing){
-                    const frameType = this.appStore.getCurrentFrameObject.frameType.type;
-                    //space in import frame's editable slots
-                    if((frameType === AllFrameTypesIdentifier.import || frameType === AllFrameTypesIdentifier.fromimport) && event.key === " "){
-                        event.preventDefault();
-                        return;
-                    }
-                }
             }
         );
 

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -757,6 +757,9 @@ export default Vue.extend({
             // We capture the key shortcut for opening the a/c
             if((event.metaKey || event.ctrlKey) && event.key == " "){
                 this.acRequested = true;
+                event.preventDefault();
+                event.stopPropagation();
+                event.stopImmediatePropagation();
             }
 
             // When some text is cut through *a selection*, we need to handle it fully: we want to handle the slot changes in the store to reflect the

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -971,9 +971,13 @@ export default Vue.extend({
                             // make sure we are inside a bracketed structure and that the opening bracket is the counterpart of the key value (closing bracket)
                             && parentBracketSlot != undefined && parentBracketSlot.openingBracketValue == getMatchingBracket(inputString, false);
                         checkMultidimBrackets = !shouldMoveToNextSlot;
-                    }
-                    if(shouldMoveToNextSlot){
+
+                        // We definitely don't want to insert the closing bracket
+                        // whether we are in the middle of end of the slot:
                         this.removeLastInput(inputString);
+                    }
+                    // If we are at the end, we treat it as overtyping:
+                    if(shouldMoveToNextSlot){
                         // focus the subslot following the closing bracket, in the next tick
                         this.doArrowRightNextTick();
                     }

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1,10 +1,11 @@
 <template>
-    <div :id="'div_'+UID" :class="{'labelSlot-container': true, nohover: isDraggingFrame}">
+    <div :id="'div_'+UID" :class="{'labelSlot-container': true, nohover: isDraggingFrame}" contenteditable="false">
         <span
             autocomplete="off"
             spellcheck="false"
             :disabled="isDisabled"
             :placeholder="defaultText"
+            :empty-content="!code || code == '\u200B'"
             :contenteditable="isEditableSlot && !(isDisabled || isPythonExecuting)"
             @click.stop="onGetCaret"
             @slotGotCaret="onGetCaret"
@@ -1528,7 +1529,9 @@ export default Vue.extend({
     min-width: 3px;
 }
 
-.labelSlot-input:empty::before {
+// We can't use :empty because we use a zero-width space for the content
+// when it is empty (at which point :empty is not applied).  So we use our own version:
+.labelSlot-input[empty-content="true"]::after {
     content: attr(placeholder);
     font-style: italic;
     color: #bbb;

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1064,7 +1064,6 @@ export default Vue.extend({
                         if(!forbidOperator && planningToInsertKey){
                             plainKey = false;
                             if(isBracket || isStringQuote){
-                                insertKey = false;
                                 // When an opening bracket is typed and there is no text highlighted, we check if we need to "skipped" that input: if we are at the end of an editable slot, and the next slot is a bracketed structure
                                 // that starts with the same opening bracket that the typed one, we move to the next slot rather than adding a new bracketed structure.
                                 // (at this point of the code, we know we're not in a String slot)

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -183,7 +183,7 @@ export default Vue.extend({
                 // to those indicating there is no compulsory value
                 "background-color": ((this.focused) 
                     ? ((this.getSlotContent().trim().length > 0) ? "rgba(255, 255, 255, 0.6)" : "#FFFFFF") 
-                    : (((isStructureSingleSlot || isEmptyFunctionCallSlot) && !isSlotOptional && this.code.trim().length == 0) ? "#FFFFFF" : "rgba(255, 255, 255, 0)")) 
+                    : (((isStructureSingleSlot || isEmptyFunctionCallSlot) && !isSlotOptional && this.code.replace(/\u200B/g, "").trim().length == 0) ? "#FFFFFF" : "rgba(255, 255, 255, 0)")) 
                     + " !important", 
             };
         }, 
@@ -1300,12 +1300,12 @@ export default Vue.extend({
                 // Without selection, a slot will be removed when the text caret is at the end of a slot and there is no text selection
                 // we delete slots only when there is a single operator between the current slot, and the next flat (UI) slot.      
                 if(!isSelectingMultiSlots && (selectionStart == selectionEnd) 
-                    && ((isForwardDeletion && focusSlotCursorInfos.cursorPos == this.code.length && nextSlotInfos) || (!isForwardDeletion && focusSlotCursorInfos.cursorPos == 0 && previousSlotInfos))){
+                    && ((isForwardDeletion && focusSlotCursorInfos.cursorPos == this.code.replace(/\u200B/g, "").length && nextSlotInfos) || (!isForwardDeletion && focusSlotCursorInfos.cursorPos == 0 && previousSlotInfos))){
                     this.appStore.bypassEditableSlotBlurErrorCheck = true;
                     
                     const isDeletingFromString = (this.slotType == SlotType.string);
                     // if we are deleting from a string, we start from a reference cursor position or code length of 0 and only use offset to reposition the cursor
-                    const backDeletionCharactersToRetainCount = (isDeletingFromString) ? 0 : this.code.length;
+                    const backDeletionCharactersToRetainCount = (isDeletingFromString) ? 0 : this.code.replace(/\u200B/g, "").length;
                     const referenceCursorPos = (isDeletingFromString) 
                         ? 0 
                         : focusSlotCursorInfos.cursorPos;
@@ -1338,7 +1338,7 @@ export default Vue.extend({
                             const inputSpanField = document.getElementById(slotUID) as HTMLSpanElement;
                             const newTextCursorPos = (isForwardDeletion) 
                                 ? referenceCursorPos + cursorPosOffset 
-                                : ((inputSpanField.textContent??"").length - cursorPosOffset - backDeletionCharactersToRetainCount); 
+                                : ((inputSpanField.textContent??"").replace(/\u200B/g, "").length - cursorPosOffset - backDeletionCharactersToRetainCount); 
                             const newCurrentSlotInfoWithType = {...newCurrentSlotInfoNoType, slotType: newCurrentSlotType};
                             const slotCursorInfos: SlotCursorInfos = {slotInfos: newCurrentSlotInfoWithType, cursorPos: newTextCursorPos};
                             document.getElementById(getLabelSlotUID(newCurrentSlotInfoWithType))?.dispatchEvent(new Event(CustomEventTypes.editableSlotGotCaret));
@@ -1389,7 +1389,7 @@ export default Vue.extend({
                             });
                         }
                     }
-                    else if(!((isForwardDeletion && focusSlotCursorInfos?.cursorPos == this.code.length) || (!isForwardDeletion && focusSlotCursorInfos?.cursorPos == 0))){
+                    else if(!((isForwardDeletion && focusSlotCursorInfos?.cursorPos == this.code.replace(/\u200B/g, "").length) || (!isForwardDeletion && focusSlotCursorInfos?.cursorPos == 0))){
                         const deletionOffset = (isForwardDeletion) ? 0 : -1;
                         newTextCursorPos += deletionOffset;
                         inputSpanField.textContent = inputSpanFieldContent.substring(0, newTextCursorPos) + inputSpanFieldContent.substring(newTextCursorPos + 1);  

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -425,9 +425,6 @@ export default Vue.extend({
                 });
             }
 
-            // Reset the flag here as we have consumed the focus event (cf. directives > focus)
-            useStore().editableSlotViaKeyboard = {isKeyboard: false, direction: 1};
-
             // Make sure we're visible in the viewport properly
             document.getElementById(getLabelSlotUID(this.coreSlotInfo))?.scrollIntoView({block: "nearest"});
 
@@ -894,7 +891,6 @@ export default Vue.extend({
                             if(nextSlotInfos){
                                 // Should always find something because a bracket or a string slot are followed by a text slot
                                 const afterBracketOrStringSlotCursorInfo: SlotCursorInfos = {slotInfos: {...this.coreSlotInfo, slotId: nextSlotInfos.slotId, slotType: nextSlotInfos.slotType}, cursorPos: 0};
-                                this.appStore.editableSlotViaKeyboard.isKeyboard = true; // in order to get the focused editable subslot performing the bracket checks in onGetCaret()
                                 document.getElementById(getLabelSlotUID(afterBracketOrStringSlotCursorInfo.slotInfos))?.dispatchEvent(new Event(CustomEventTypes.editableSlotGotCaret));
                                 this.appStore.setSlotTextCursors(afterBracketOrStringSlotCursorInfo, afterBracketOrStringSlotCursorInfo);
                             }               
@@ -995,7 +991,6 @@ export default Vue.extend({
                                         // Move to next slot, as it is a bracketed structure, we need to get into the first child slot of that structure
                                         this.$nextTick(() => {
                                             const nextBrackedStructFirstSlotCursorInfos: SlotCursorInfos = {slotInfos: {...nextSlotInfos, slotId: nextSlotInfos.slotId+",0", slotType: SlotType.code}, cursorPos: 0};
-                                            this.appStore.editableSlotViaKeyboard.isKeyboard = true; // in order to get the focused editable subslot performing the bracket checks in onGetCaret()
                                             document.getElementById(getLabelSlotUID(nextBrackedStructFirstSlotCursorInfos.slotInfos))?.dispatchEvent(new Event(CustomEventTypes.editableSlotGotCaret));
                                             this.appStore.setSlotTextCursors(nextBrackedStructFirstSlotCursorInfos, nextBrackedStructFirstSlotCursorInfos);      
                                         });

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1315,7 +1315,7 @@ export default Vue.extend({
                         const newOperatorContent = (isForwardDeletion) 
                             ? ((neighbourOperatorSlotContent.includes(" ")) ? neighbourOperatorSlotContent.substring(neighbourOperatorSlotContent.indexOf(" ") + 1) : neighbourOperatorSlotContent[1])
                             : ((neighbourOperatorSlotContent.includes(" ")) ? neighbourOperatorSlotContent.substring(0, neighbourOperatorSlotContent.indexOf(" ")) : neighbourOperatorSlotContent[0]);
-                        (neighbourOperatorSlot as BaseSlot).code = newOperatorContent;
+                        (neighbourOperatorSlot as BaseSlot).code = newOperatorContent.replace(/\u200B/g, "");
                         // We don't actually require slot to be regenerated, but we need to mark the action for undo/redo
                         this.$nextTick(() => {
                             this.appStore.bypassEditableSlotBlurErrorCheck = false;
@@ -1527,7 +1527,7 @@ export default Vue.extend({
                 const typeOfSelected: string  = (this.$refs.AC as any).getTypeOfSelected(item);
                 const hasFollowingBracketSlot = (getFlatNeighbourFieldSlotInfos(this.coreSlotInfo, true, true)?.slotType == SlotType.bracket);
                 isSelectedFunction =  (this.frameType.localeCompare(AllFrameTypesIdentifier.fromimport) != 0) && (typeOfSelected.includes("function") || typeOfSelected.includes("method"));
-                newCode = this.getSlotContent().substr(0, currentTextCursorPos - (this.tokenAC?.length ?? 0))
+                newCode = this.getSlotContent().substr(0, currentTextCursorPos - (this.tokenAC?.length ?? 0)).replace(/\u200B/g, "")
                 + selectedItem.replace(new RegExp("\\(.*"), "") 
                 + ((isSelectedFunction && !hasFollowingBracketSlot)?"()":"");
             }

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1103,8 +1103,10 @@ export default Vue.extend({
                                 // Start with the closing end so cursor positions are still valid for the opening
                                 closingTokenSpanField.textContent = closingTokenSpanField.textContent?.substring(0, closingTokenSpanFieldCurosorPos) 
                                     + ((isBracket) ? getMatchingBracket(inputString, true) : ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER))
-                                    + closingTokenSpanField.textContent?.substring(closingTokenSpanFieldCurosorPos + (newBracketIsAtClosingEnd ? inputString.length : 0));
+                                    + closingTokenSpanField.textContent?.substring(closingTokenSpanFieldCurosorPos + (newBracketIsAtClosingEnd ? 0 : inputString.length));
 
+                                console.log("Closing now: \"" + closingTokenSpanField.textContent + "\"");
+                                
                                 openingTokenSpanField.textContent = openingTokenSpanField.textContent?.substring(0, openingTokenSpanFieldCurosorPos) 
                                     + ((isStringQuote) ? ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER) : inputString)
                                     + openingTokenSpanField.textContent?.substring(openingTokenSpanFieldCurosorPos + (newBracketIsAtClosingEnd ? inputString.length : 0));

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -344,7 +344,7 @@ export default Vue.extend({
             this.appStore.setFrameEditableSlotContent(
                 {
                     ...this.coreSlotInfo,
-                    code: (spanElement.textContent??""),
+                    code: (spanElement.textContent??"").replace(/\u200B/g, ""),
                     initCode: this.initCode,
                     isFirstChange: this.isFirstChange,
                 }
@@ -570,7 +570,7 @@ export default Vue.extend({
                         this.appStore.validateSlot(
                             {
                                 ...this.coreSlotInfo,
-                                code: this.getSlotContent().trim(),
+                                code: this.getSlotContent().replace(/\u200B/g, "").trim(),
                                 initCode: this.initCode,
                                 isFirstChange: this.isFirstChange,
                             }   

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -424,6 +424,20 @@ export default Vue.extend({
                     });
                     return;
                 }
+                else {
+                    const inputSpanField = document.getElementById(this.UID) as HTMLSpanElement;
+                    const inputSpanFieldContent = inputSpanField.textContent ?? "";
+                    if (inputSpanFieldContent == "\u200B") {
+                        const cursorPos = getTextStartCursorPositionOfHTMLElement(inputSpanField);
+                        if (cursorPos > 0 && this.appStore.anchorSlotCursorInfos && this.appStore.focusSlotCursorInfos) {
+                            // We maybe came here by moving left from the field after, need to set pos to before zero-width space:
+                            const slotCursorInfo: SlotCursorInfos = {slotInfos: this.coreSlotInfo, cursorPos: 0};
+                            const hasMultiSlotTextSelection = !areSlotCoreInfosEqual(this.appStore.anchorSlotCursorInfos.slotInfos, this.appStore.focusSlotCursorInfos.slotInfos);
+                            setDocumentSelection(hasMultiSlotTextSelection ? this.appStore.anchorSlotCursorInfos : slotCursorInfo, slotCursorInfo);
+                            this.appStore.setSlotTextCursors(hasMultiSlotTextSelection ? this.appStore.anchorSlotCursorInfos : slotCursorInfo, slotCursorInfo);
+                        }
+                    }
+                }
             }
             
             this.appStore.setFocusEditableSlot(

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1084,13 +1084,18 @@ export default Vue.extend({
                                 let openingTokenSpanFieldCurosorPos = selectionStart;
                                 let closingTokenSpanField = inputSpanField;
                                 let closingTokenSpanFieldCurosorPos = selectionEnd;  
-                                let closingTokenSlotInfos = this.coreSlotInfo; 
+                                let closingTokenSlotInfos = this.coreSlotInfo;
+                                // We need to know where the new bracket is to remove it, like
+                                // removeLastInput but we don't want to destroy information about selection
+                                // so we don't call that function:
+                                let newBracketIsAtClosingEnd = false;
                                 if(hasTextSelection){
                                     // Check in what direction is the selection, note that we expect the anchor and focus to be set here (we checked before), so the comparison value shouldn't be undefined.
                                     if(slotSelectionCursorComparisonValue < 0){
                                         // Anchor is before the focus: we only change the openingTokenSpanField
                                         openingTokenSpanField = (document.getElementById(getLabelSlotUID((this.appStore.anchorSlotCursorInfos as SlotCursorInfos).slotInfos)) as HTMLSpanElement);
                                         openingTokenSpanFieldCurosorPos = (this.appStore.anchorSlotCursorInfos as SlotCursorInfos).cursorPos;
+                                        newBracketIsAtClosingEnd = true;
                                     }
                                     else{
                                         // Anchor is after the focus: we only change the closingTokenSpanField
@@ -1101,13 +1106,13 @@ export default Vue.extend({
                                 }
                                 // Start with the closing end so cursor positions are still valid for the opening
                                 closingTokenSpanField.textContent = closingTokenSpanField.textContent?.substring(0, closingTokenSpanFieldCurosorPos) 
-                                    + ((isBracket) ? getMatchingBracket(event.key, true) : ((event.key == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER))
-                                    + closingTokenSpanField.textContent?.substring(closingTokenSpanFieldCurosorPos);
+                                    + ((isBracket) ? getMatchingBracket(inputString, true) : ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER))
+                                    + closingTokenSpanField.textContent?.substring(closingTokenSpanFieldCurosorPos + (newBracketIsAtClosingEnd ? inputString.length : 0));
 
                                 openingTokenSpanField.textContent = openingTokenSpanField.textContent?.substring(0, openingTokenSpanFieldCurosorPos) 
-                                    + ((isStringQuote) ? ((event.key == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER) : event.key)
-                                    + openingTokenSpanField.textContent?.substring(openingTokenSpanFieldCurosorPos);
-
+                                    + ((isStringQuote) ? ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER) : inputString)
+                                    + openingTokenSpanField.textContent?.substring(openingTokenSpanFieldCurosorPos + (newBracketIsAtClosingEnd ? inputString.length : 0));
+                 
                                 // If there is no text selection, we "autocomplete" the opening token and want to get after it, into the structure, at position 0
                                 // if there text selection, we are wrapping the text with the tokens and we want to get after the closing token
                                 const newPos = (!hasTextSelection) ? selectionStart + 1 : closingTokenSpanFieldCurosorPos + ((openingTokenSpanField.id == closingTokenSpanField.id) ? 2 : 1);

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -596,6 +596,13 @@ export default Vue.extend({
         },
 
         onUDKeyDown(event: KeyboardEvent) {
+            // We may still have the focus even when not logically editing, so we want to
+            // avoid handling the keypress in this case; let the code in Commands handle it
+            // which moves the frame cursor up and down:
+            if (!this.appStore.isEditing) {
+                return;
+            }
+            
             this.appStore.isSelectingMultiSlots = false; // reset the flag
             const isArrowUp = (event.key == "ArrowUp");
            
@@ -1417,6 +1424,13 @@ export default Vue.extend({
         },
 
         onDeleteKeyDown(event: KeyboardEvent){
+            // We may still have the focus even when not logically editing, so we want to
+            // avoid handling the keypress in this case; let the code in Commands handle it
+            // which moves the frame cursor up and down:
+            if (!this.appStore.isEditing) {
+                return;
+            }
+            
             // Be careful: the event is triggered both by backspace & delete keys ! So we need to make a clear distinction here
             if(event.key.toLowerCase() == "delete"){
                 return this.deleteSlots(event);
@@ -1424,6 +1438,13 @@ export default Vue.extend({
         },
 
         onBackSpaceKeyDown(event: KeyboardEvent){
+            // We may still have the focus even when not logically editing, so we want to
+            // avoid handling the keypress in this case; let the code in Commands handle it
+            // which moves the frame cursor up and down:
+            if (!this.appStore.isEditing) {
+                return;
+            }
+            
             // When the backspace key is hit we delete the container frame when:
             //  1) there is no text in the slots
             //  2) we are in the first slot of a frame (*first that appears in the UI*) 

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -98,20 +98,6 @@ export default Vue.extend({
         isEmphasised: Boolean,
     },
 
-    beforeUpdate(){
-        // If the text isn't set again here, despite "code" being reactive, we end up with "duplicated" insert with operators.
-        const spanElement = document.getElementById(this.UID);
-        if(spanElement && this.appStore.anchorSlotCursorInfos && this.appStore.focusSlotCursorInfos){ // Keep TS happy
-            const prevTextContent = spanElement.textContent;
-            spanElement.textContent = this.code;
-            // After changing the code here, FF requires the right caret position to be reassigned, otherwise the caret moves back to the first
-            // position. The condition ensure we do this only for the right slot, and when the text is in line with the selection we are going to set.
-            if(areSlotCoreInfosEqual(this.appStore.focusSlotCursorInfos.slotInfos, this.coreSlotInfo) && prevTextContent === this.code){
-                setDocumentSelection(this.appStore.anchorSlotCursorInfos, this.appStore.focusSlotCursorInfos);
-            }
-        }
-    },
-
     mounted(){
         // To make sure the a/c component shows just below the spans, we set its top position here based on the span height.
         const spanH = document.getElementById(this.UID)?.clientHeight;

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -650,7 +650,6 @@ export default Vue.extend({
                     })
                 );
                 this.appStore.ignoreKeyEvent = true;
-                return;
             }
             event.preventDefault();
             event.stopPropagation();

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -806,8 +806,6 @@ export default Vue.extend({
             // We need to know the current cursor pos, because inputString might appear in the slot
             // multiple times; the one we want to remove should be the one just before the cursor:
             const cursorPos = getTextStartCursorPositionOfHTMLElement(spanElement);
-            //const slotCursorInfo: SlotCursorInfos = {slotInfos: this.coreSlotInfo, cursorPos: this.textCursorPos};
-            //setDocumentSelection(slotCursorInfo, slotCursorInfo);
             let content = spanElement.textContent ?? "";
             // Check the content is present just before the cursor:
             if (content.length >= toRemove.length
@@ -858,7 +856,6 @@ export default Vue.extend({
             //   with operators and brackets which can create new slots.
             // - Delete and backspace are not input events so they happen elsewhere.
             
-            console.log("Processing input: \"" + inputString + "\" on slot: " + this.UID + " index: " + this.labelSlotsIndex);
             const stateBeforeChanges = cloneDeep(this.appStore.$state);
             const slotSelectionCursorComparisonValue = getSelectionCursorsComparisonValue() as number;
             
@@ -868,6 +865,9 @@ export default Vue.extend({
             const parentSlot = retrieveParentSlotFromSlotInfos(this.coreSlotInfo);
             const nextSlotInfos = getFlatNeighbourFieldSlotInfos(this.coreSlotInfo, true, true);
   
+            // Note: this selection is remembered from before the input we are processing, so
+            // will be different to where the cursor actually is, hence we generally add inputString.length
+            // to selectionEnd, below.
             const {selectionStart, selectionEnd} = getFocusedEditableSlotTextSelectionStartEnd(this.UID);
             const hasTextSelection = (this.appStore.anchorSlotCursorInfos && this.appStore.focusSlotCursorInfos && slotSelectionCursorComparisonValue != 0) ?? false;
             let refactorFocusSpanUID = this.UID; // by default the focus stays where we are
@@ -943,7 +943,7 @@ export default Vue.extend({
                 // we move the text cursor in the next slot, as we consider the user closed an existing already closed bracket / quote.
                 //(*) see later in this method
                 let shouldMoveToNextSlot : boolean;
-                let checkMultidimBrackets = hasTextSelection;console.log("Content: \"" + inputSpanFieldContent + "\", selStart: " + selectionStart + " end: " + isAtEndOfSlot);
+                let checkMultidimBrackets = hasTextSelection;
                 // Checking if we are escaping the quote used for this string (i.e. we are after an escaping \, and there is no quote following the caret)
                 const isEscapingString = isFieldStringSlot(currentSlot) && selectionStart > 0 && (getNumPrecedingBackslashes(inputSpanFieldContent, selectionStart) % 2) == 1
                     && ((selectionStart + inputString.length < inputSpanFieldContent.length && inputSpanFieldContent[selectionStart + inputString.length]!= inputString) || isAtEndOfSlot);
@@ -1109,8 +1109,6 @@ export default Vue.extend({
                                     + ((isBracket) ? getMatchingBracket(inputString, true) : ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER))
                                     + closingTokenSpanField.textContent?.substring(closingTokenSpanFieldCurosorPos + (newBracketIsAtClosingEnd ? 0 : inputString.length));
 
-                                console.log("Closing now: \"" + closingTokenSpanField.textContent + "\"");
-                                
                                 openingTokenSpanField.textContent = openingTokenSpanField.textContent?.substring(0, openingTokenSpanFieldCurosorPos) 
                                     + ((isStringQuote) ? ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER) : inputString)
                                     + openingTokenSpanField.textContent?.substring(openingTokenSpanFieldCurosorPos + (newBracketIsAtClosingEnd ? inputString.length : 0));

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -962,8 +962,6 @@ export default Vue.extend({
                                 // So, we just don't do anything special in that situation.
                                 return;
                             }
-                            // Otherwise, just cancel the input:
-                            this.removeLastInput(inputString);
                         }
                     }
                     else{
@@ -973,11 +971,11 @@ export default Vue.extend({
                             // make sure we are inside a bracketed structure and that the opening bracket is the counterpart of the key value (closing bracket)
                             && parentBracketSlot != undefined && parentBracketSlot.openingBracketValue == getMatchingBracket(inputString, false);
                         checkMultidimBrackets = !shouldMoveToNextSlot;
-
-                        // We definitely don't want to insert the closing bracket
-                        // whether we are in the middle of end of the slot:
-                        this.removeLastInput(inputString);
                     }
+                    // We definitely don't want to insert the closing bracket
+                    // whether we are in the middle of end of the slot:
+                    this.removeLastInput(inputString);
+                    
                     // If we are at the end, we treat it as overtyping:
                     if(shouldMoveToNextSlot){
                         // focus the subslot following the closing bracket, in the next tick

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1096,6 +1096,11 @@ export default Vue.extend({
                                         closingTokenSlotInfos = (this.appStore.anchorSlotCursorInfos as SlotCursorInfos).slotInfos;
                                     }
                                 }
+                                else {
+                                    closingTokenSpanFieldCurosorPos += inputString.length;
+                                    newBracketIsAtClosingEnd = true;
+                                }
+                                
                                 // Start with the closing end so cursor positions are still valid for the opening
                                 closingTokenSpanField.textContent = closingTokenSpanField.textContent?.substring(0, closingTokenSpanFieldCurosorPos) 
                                     + ((isBracket) ? getMatchingBracket(inputString, true) : ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER))

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1001,9 +1001,6 @@ export default Vue.extend({
                 }
             }
             else{
-                // In any other scenario, we capture the key ourselves to handle the UI changes
-                let plainKey = true;
-
                 // Check that if we are in a string slot, all characters but the quote of that string are allowed
                 // note: string quotes logic is already handled by checking the closing brackets/quotes above
                 if(isFieldStringSlot(currentSlot)) {
@@ -1055,7 +1052,6 @@ export default Vue.extend({
                                 || (this.frameType == AllFrameTypesIdentifier.import && (this.keyDownStr == "," || this.keyDownStr == "."));
                         }
                         if(!forbidOperator && planningToInsertKey){
-                            plainKey = false;
                             if(isBracket || isStringQuote){
                                 // When an opening bracket is typed and there is no text highlighted, we check if we need to "skipped" that input: if we are at the end of an editable slot, and the next slot is a bracketed structure
                                 // that starts with the same opening bracket that the typed one, we move to the next slot rather than adding a new bracketed structure.
@@ -1120,13 +1116,6 @@ export default Vue.extend({
                                 this.appStore.setSlotTextCursors(newSlotCursorInfos, newSlotCursorInfos);
                             }               
                         }
-                    }
-                    if(plainKey){
-                        // Add the typed key manually
-                        //this.insertSimpleTypedKey(inputString, stateBeforeChanges);
-                        // We leave the rest of the workflow to be handled by insertSimpleTypedKey() above,
-                        // because emitting an event for the slots to be refactored might need to be delayed (cf. insertSimpleTypedKey)
-                        return;
                     }
                 }
                 // The logic is as such, we handle the insertion in the slot (with adequate adaptation if needed, see above)

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -218,7 +218,7 @@ export default Vue.extend({
                     // Reposition the cursor now
                     labelDiv.querySelectorAll(".labelSlot-input").forEach((spanElement) => {
                         if(!foundPos){
-                            const spanContentLength = (spanElement.textContent?.length??0);
+                            const spanContentLength = (spanElement.textContent?.replace(/\u200B/g, "")?.length??0);
                             if(setInsideNextSlot || (focusCursorAbsPos <= (newUICodeLiteralLength + spanContentLength) && focusCursorAbsPos >= newUICodeLiteralLength)){
                                 if(!setInsideNextSlot && !isElementEditableLabelSlotInput(spanElement)){
                                     setInsideNextSlot = true;

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -15,6 +15,7 @@
             v-for="(slotItem, slotIndex) in subSlots" 
             :key="frameId + '_'  + labelIndex + '_' + slotIndex"
             class="next-to-eachother"
+            contenteditable="false"
         >
             <!-- Note: the default text is only showing for new slots (1 subslot), we also use unicode zero width space character for empty slots for UI -->
             <LabelSlot
@@ -126,7 +127,9 @@ export default Vue.extend({
                 // We show quotes in the UI as textual opening or closing quotes
                 return getUIQuote(slot.code, slot.type == SlotType.openingQuote);
             }
-            return slot.code;
+            // On Firefox there are problems typing into completely blank slots,
+            // so we use a zero-width space if there is no code:
+            return slot.code ? slot.code : "\u200B";
         },
 
         isSlotEmphasised(slot: FlatSlotBase): boolean{

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -361,7 +361,7 @@ export default Vue.extend({
                 // If we're trying to go off the bounds of this slot
                 // For comments, if there is a terminating line return, we do not allow the cursor to be past it (cf LabelSlot.vue onEnterOrTabKeyUp() for why)
                 if((cursorPos == 0 && event.key==="ArrowLeft") 
-                        || (((cursorPos === spanInputContent.length) || (isCommentFrame && spanInputContent.endsWith("\n") && cursorPos == spanInputContent.length - 1)) && event.key==="ArrowRight")) {
+                        || (((cursorPos >= spanInputContent.replace(/\u200B/, "").length) || (isCommentFrame && spanInputContent.endsWith("\n") && cursorPos == spanInputContent.length - 1)) && event.key==="ArrowRight")) {
                     // DO NOT request a loss of focus here, because we need to be able to know which element of the UI has focus to find the neighbour in this.appStore.leftRightKey()
                     this.appStore.isSelectingMultiSlots = event.shiftKey;
                     this.appStore.leftRightKey({key: event.key, isShiftKeyHold: event.shiftKey}).then(() => {

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -330,12 +330,6 @@ export default Vue.extend({
                     event.stopImmediatePropagation();
                 }
             }
-            // Let through various shortcuts like Ctrl-A, Ctrl-C, etc, so that they trigger the in-built
-            // actions of selectAll, copy, etc; as well as up/down and derivates keys IF WE ARE IN A COMMENT FRAME.
-            if (!event.ctrlKey && !event.metaKey && 
-                !((this.frameId in this.appStore.frameObjects) && (this.appStore.frameObjects[this.frameId].frameType.type === AllFrameTypesIdentifier.comment) && ["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End"].includes(event.key))) {
-                event.preventDefault();
-            }
         },
 
         forwardPaste(event: ClipboardEvent){

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -193,7 +193,7 @@ export default Vue.extend({
             // Comments do not need to be checked, so we do nothing special for them, but just enforce the caret to be placed at the right place and the code value to be updated
             const currentFocusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
             if(this.appStore.frameObjects[this.frameId].frameType.type == AllFrameTypesIdentifier.comment && currentFocusSlotCursorInfos){
-                (this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures.fields[0] as BaseSlot).code = document.getElementById(getLabelSlotUID(currentFocusSlotCursorInfos.slotInfos))?.textContent??"";
+                (this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures.fields[0] as BaseSlot).code = (document.getElementById(getLabelSlotUID(currentFocusSlotCursorInfos.slotInfos))?.textContent??"").replace(/\u200B/g, "");
                 this.$nextTick(() => setDocumentSelection(currentFocusSlotCursorInfos, currentFocusSlotCursorInfos));
                 return;
             }

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -202,7 +202,7 @@ export function getFocusedEditableSlotTextSelectionStartEnd(labelSlotUID: string
             }
             else{
                 // the anchor is somewhere after the focus cursor: the selection end is at the end of the slot
-                return {selectionStart: focusCursorInfos.cursorPos, selectionEnd: (document.getElementById(labelSlotUID) as HTMLSpanElement).textContent?.length??0};
+                return {selectionStart: focusCursorInfos.cursorPos, selectionEnd: (document.getElementById(labelSlotUID) as HTMLSpanElement).textContent?.replace(/\u200B/g, "")?.length??0};
             }
         }
     }
@@ -279,7 +279,7 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
                 if((spanElement.textContent?.includes(STRING_DOUBLEQUOTE_PLACERHOLDER) || spanElement.textContent?.includes(STRING_SINGLEQUOTE_PLACERHOLDER)) as boolean){
                     hasStringSlots = true;
                 }
-                uiLiteralCode += (spanElement.textContent);
+                uiLiteralCode += (spanElement.textContent??"").replace(/\u200B/g, "");
             }
         
             if(spanElement.id === currentSlotUID){
@@ -292,7 +292,7 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
                 // therefore we need to account for them when dealing with such operators;
                 // and if we parse the string quotes, we need to set the position value as if the quotes were still here (because they are in the UI)
                 let spacesOffset = 0;
-                const spanElementContentLength = (spanElement.textContent?.length??0);
+                const spanElementContentLength = (spanElement.textContent?.replace(/\u200B/g, "")?.length??0);
                 const ignoreAsKW = (spanElement.textContent == "as" && useStore().frameObjects[parseLabelSlotUID(spanElement.id).frameId].frameType.type != AllFrameTypesIdentifier.import);
                 if(!ignoreAsKW && !isSlotStringLiteralType(labelSlotCoreInfos.slotType) && (trimmedKeywordOperators.includes(spanElement.textContent??""))){
                     spacesOffset = 2;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot } from "@/types/types";
+import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot } from "@/types/types";
 import { getObjectPropertiesDifferences, getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
 import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
@@ -160,8 +160,6 @@ export const useStore = defineStore("app", {
 
             simpleModalDlgMsg: "",
 
-            editableSlotViaKeyboard: {isKeyboard: false, direction: 1} as EditableSlotReachInfos, //indicates when a slot is reached via keyboard arrows, and the direction (-1 for left/up and 1 for right/down)
-        
             /* The following wrapper is used for interacting with the microbit board via DAP*/
             DAPWrapper: {} as DAPWrapper,
 
@@ -1157,7 +1155,7 @@ export const useStore = defineStore("app", {
         setSlotTextCursors(anchorCursorInfos: SlotCursorInfos | undefined, focusCursorInfos: SlotCursorInfos | undefined){
             // If we set a new object in these properties then it causes a lot of updates throughout
             // the whole tree.  So we check if the two objects are (deep) equal before
-            // we update, to avoid unnecessary updates and rendersL
+            // we update, to avoid unnecessary updates and renders:
             if (!isEqual(this.anchorSlotCursorInfos, anchorCursorInfos)) {
                 Vue.set(this, "anchorSlotCursorInfos", anchorCursorInfos);
             }
@@ -2202,8 +2200,6 @@ export const useStore = defineStore("app", {
             // If next position is an editable slot
             if(nextPosition.isSlotNavigationPosition){
                 this.isEditing = true;
-                const slotReachInfos: EditableSlotReachInfos = {isKeyboard: true, direction: directionDelta};
-                this.editableSlotViaKeyboard = slotReachInfos;
 
                 const nextSlotCoreInfos = {
                     frameId: nextPosition.frameId,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2222,7 +2222,7 @@ export const useStore = defineStore("app", {
                 // If we are reaching a comment frame, coming from the blue caret underneath, we neeed to check if there is a terminating line return:
                 // if that's the case, we do not get just after it, but before it; see LabelSlot.vue onEnterOrTabKeyUp() for why.
                 Vue.nextTick(() => {
-                    let textCursorPos = (directionDelta == 1) ? 0 : (document.getElementById(getLabelSlotUID(nextSlotCoreInfos))?.textContent?.length)??0;
+                    let textCursorPos = (directionDelta == 1) ? 0 : (document.getElementById(getLabelSlotUID(nextSlotCoreInfos))?.textContent?.replace(/\u200B/, "")?.length)??0;
                     const isCommentFrame = this.frameObjects[nextSlotCoreInfos.frameId as number].frameType.type == AllFrameTypesIdentifier.comment;
                     if(isCommentFrame && (document.getElementById(getLabelSlotUID(nextSlotCoreInfos))?.textContent??"").endsWith("\n") && directionDelta == -1){
                         textCursorPos--;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -991,11 +991,6 @@ export const DefaultCursorPosition: CursorPosition = {
     height: 0,
 };
 
-export interface EditableSlotReachInfos {
-    isKeyboard: boolean;
-    direction: -1 | 1;
-}
-
 export interface StateAppObject {
     debugging: boolean;
     initialState: EditorFrameObjects;

--- a/tests/cypress/e2e/autocomplete.cy.ts
+++ b/tests/cypress/e2e/autocomplete.cy.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-import {cleanFromHTML} from "../support/test-support";
-
 require("cypress-terminal-report/src/installLogsCollector")();
+import {cleanFromHTML} from "../support/test-support";
 import "@testing-library/cypress/add-commands";
 // Needed for the "be.sorted" assertion:
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/tests/cypress/e2e/autocomplete.cy.ts
+++ b/tests/cypress/e2e/autocomplete.cy.ts
@@ -1,4 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+import {cleanFromHTML} from "../support/test-support";
+
 require("cypress-terminal-report/src/installLogsCollector")();
 import "@testing-library/cypress/add-commands";
 // Needed for the "be.sorted" assertion:

--- a/tests/cypress/e2e/autocomplete.cy.ts
+++ b/tests/cypress/e2e/autocomplete.cy.ts
@@ -124,7 +124,7 @@ function assertState(frameId: number, expectedState : string, expectedStateWithP
             let contentWithPlaceholders = "";
             for (let i = 0; i < parts.length; i++) {
                 const p : any = parts[i];
-                let text = p.value || p.textContent || "";
+                let text = cleanFromHTML(p.value || p.textContent || "");
 
                 // If the text for a span is blank, use the placeholder since that's what the user will be seeing:
                 if (!text) {

--- a/tests/cypress/e2e/basics.cy.ts
+++ b/tests/cypress/e2e/basics.cy.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import {expect} from "chai";
 import i18n from "@/i18n";
 import failOnConsoleError from "cypress-fail-on-console-error";
+import {cleanFromHTML} from "../support/test-support";
 failOnConsoleError();
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require("cypress-terminal-report/src/installLogsCollector")();
@@ -57,7 +58,7 @@ function matchFrameText(item : JQuery<HTMLElement>, match : CodeMatch) : void {
         for (let i = 0; i < parts.length; i++) {
             const p : any = parts[i];
 
-            const text = p.value || p.textContent || "";
+            const text = cleanFromHTML(p.value || p.textContent || "");
             
             if (text.match(/[a-zA-Z0-9]/) && !p.classList.contains("string-slot")) {
                 // Only add spaces if it has some non-punctuation characters and isn't a string:

--- a/tests/cypress/e2e/param-prompts.cy.ts
+++ b/tests/cypress/e2e/param-prompts.cy.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-import {cleanFromHTML} from "../support/test-support";
-
 require("cypress-terminal-report/src/installLogsCollector")();
+import {cleanFromHTML} from "../support/test-support";
 import "@testing-library/cypress/add-commands";
 // Needed for the "be.sorted" assertion:
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/tests/cypress/e2e/param-prompts.cy.ts
+++ b/tests/cypress/e2e/param-prompts.cy.ts
@@ -1,4 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+import {cleanFromHTML} from "../support/test-support";
+
 require("cypress-terminal-report/src/installLogsCollector")();
 import "@testing-library/cypress/add-commands";
 // Needed for the "be.sorted" assertion:
@@ -70,7 +72,7 @@ function assertState(frameId: number, expectedState : string, expectedStateWithP
             let contentWithPlaceholders = "";
             for (let i = 0; i < parts.length; i++) {
                 const p : any = parts[i];
-                let text = p.value || p.textContent || "";
+                let text = cleanFromHTML(p.value || p.textContent || "");
 
                 // If the text for a span is blank, use the placeholder since that's what the user will be seeing:
                 if (!text) {

--- a/tests/cypress/e2e/structured-expressions-brackets.cy.ts
+++ b/tests/cypress/e2e/structured-expressions-brackets.cy.ts
@@ -50,6 +50,11 @@ describe("Stride TestExpressionSlot.testBrackets()", () => {
 
     testInsert("(a+(b*c)+d)", "{}_({a}+{}_({b}*{c})_{}+{d})_{$}");
 
+
+    // Test inserting bracket later:
+    testMultiInsert("abc{(}def", "{abc$def}", "{abc}_({$})_{def}");
+
+
     testMultiInsert("({(MyWorld)}getWorld()).getWidth()",
         "{}_({$getWorld}_({})_{})_{}.{getWidth}_({})_{}",
         "{}_({}_({MyWorld})_{$getWorld}_({})_{})_{}.{getWidth}_({})_{}");

--- a/tests/cypress/e2e/structured-expressions-brackets.cy.ts
+++ b/tests/cypress/e2e/structured-expressions-brackets.cy.ts
@@ -54,6 +54,12 @@ describe("Stride TestExpressionSlot.testBrackets()", () => {
     // Test inserting bracket later:
     testMultiInsert("abc{(}def", "{abc$def}", "{abc}_({$})_{def}");
 
+    // Test inserting invalid closing bracket later:
+    testInsert(")", "{$}", false);
+    testInsert("]", "{$}", false);
+    testMultiInsert("abc{)}def", "{abc$def}", "{abc$def}");
+    testMultiInsert("abc{]}def", "{abc$def}", "{abc$def}");
+    testMultiInsert("[abc{)}def]", "{}_[{abc$def}]_{}", "{}_[{abc$def}]_{}");
 
     testMultiInsert("({(MyWorld)}getWorld()).getWidth()",
         "{}_({$getWorld}_({})_{})_{}.{getWidth}_({})_{}",

--- a/tests/cypress/support/expression-test-support.ts
+++ b/tests/cypress/support/expression-test-support.ts
@@ -11,6 +11,7 @@ Cypress.Commands.add("initialiseSupportStrypeGlobals", () => {
         });
     }
 });
+import {cleanFromHTML} from "../support/test-support";
 
 export function assertState(expectedState : string) : void {
     withSelection((info) => {

--- a/tests/cypress/support/expression-test-support.ts
+++ b/tests/cypress/support/expression-test-support.ts
@@ -1,3 +1,5 @@
+import {cleanFromHTML} from "./test-support";
+
 export function assertState(expectedState : string) : void {
     withSelection((info) => {
         cy.get("#FrameContainer_-3 .frame-header").first().within((h) => cy.get(".labelSlot-input,.frameColouredLabel").then((parts) => {
@@ -10,7 +12,7 @@ export function assertState(expectedState : string) : void {
             for (let i = 1; i < parts.length - 1; i++) {
                 const p : any = parts[i];
 
-                let text = p.value || p.textContent || "";
+                let text = cleanFromHTML(p.value || p.textContent || "");
 
                 // If we're the focused slot, put a dollar sign in to indicate the current cursor position:
                 if (info.id === p.getAttribute("id") && info.cursorPos >= 0) {

--- a/tests/cypress/support/test-support.ts
+++ b/tests/cypress/support/test-support.ts
@@ -1,0 +1,4 @@
+export function cleanFromHTML(html: string) : string {
+    // Get rid of the zero-width spaces which occur in the HTML:
+    return html.replace("\u200B", "");
+}


### PR DESCRIPTION
There are several key changes here, mainly in the giant diff for LabelSlot:

 - We change from doing the input into slots ourselves in the handling for keyboard events; instead we now let the browser's native input handling happen, and we listen to the final input/compositionend event and do any tidying up afterwards (e.g. if the user overtypes a bracket, we remove the just inserted bracket and perform the navigation).
 - This means that the existing key event handler is split into two parts.  Remaining in that method are the things explicitly about keyboard shortcuts, things like ctrl-x for cut, ctrl-space for AC, etc.
 - There is a new processInput event which does all the post-input tidy-ups, watching out for invalid characters, and characters which should perform navigation because they are counted as overtyping.
 - To make sure that certain browsers (eyes Firefox) put the cursor at the right position, the non-editable parts in a LabelSlotStructure have been explicitly marked contenteditable=false, and any empty contenteditable spans must now have a zero-width space (\u200B) to allow the cursor to be placed.  This means many places must have this character removed.  This was half the effort to be honest.

I anticipate that all tests will pass, except  structured-expressions-selection.cy.ts which will all fail.  I am going to fix selection in another PR.  The problem with dealing with selection correctly is that by default the browser deletes the selection on typing, before it sends the input event.  If we are just selecting then typing to replace it, this might work fine (but I need to look into it more, especially if the selection crosses multiple spans) but for selecting then bracketing we are probably going to need to remember the selection, let it be replaced, then restore it again.

The current PR seems to be working fine with German (with things like umlaut character entry) and Chinese IME.  I haven't yet implemented the Chinese bracket and quote mapping (i.e. mapping "（" [the single fixed-width-bracket character]  to "(") but I hope to come back to that.  We will need to test this all manually after the next PR; even if the tests all pass it doesn't mean everything is perfect!
