### PR TITLE
Save Strype locale outside the editor's state

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "cypress";
 import {rimraf} from "rimraf";
+import fs from "fs";
 
 export default defineConfig({
     downloadsFolder: "tests/cypress/downloads",
@@ -28,6 +29,10 @@ export default defineConfig({
                             resolve(null);
                         });
                     });
+                },
+                renameFile(args: {srcPath: string, destPath: string}) {
+                    fs.renameSync(args.srcPath, args.destPath);
+                    return null;
                 },
             });
             // Allow logging to console (although only the first message seems to get logged?)

--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,164 @@
   <!-- Import for the fontawesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" integrity="sha256-rx5u3IdaOCszi7Jb18XD9HSn8bNiEgAqWJbdBvIYYyU=" crossorigin="anonymous">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/v4-shims.css" integrity="sha256-/aMDUDDThDwnUdwNpl+4AiMOwApACK7tg93dx7l8vJM=" crossorigin="anonymous">
-  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet" integrity="sha256-jkBR6JJ1emALogLUCoTtJTTHbehAoS/O4KM5jcS320w=" crossorigin="anonymous">
-  <link href="https://fonts.googleapis.com/css2?family=Inconsolata:wdth,wght@50..200,200..900" rel="stylesheet" integrity="sha256-Ztq7VVBS+MxkzxYLduHb9M+aelJS5I9ctCQj1k4a9jE=" crossorigin="anonymous">
   <script src="<%= BASE_URL %>js/skulpt.min.js"></script>
   <script src="<%= BASE_URL %>js/skulpt-stdlib.js"></script>
-  
+  <!-- fonts-->
+  <style>
+    /* cyrillic-ext */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qNa7lqDY.woff2) format('woff2');
+    unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  }
+  /* cyrillic */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qPK7lqDY.woff2) format('woff2');
+    unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  }
+  /* greek-ext */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qNK7lqDY.woff2) format('woff2');
+    unicode-range: U+1F00-1FFF;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qO67lqDY.woff2) format('woff2');
+    unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+  }
+  /* vietnamese */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qN67lqDY.woff2) format('woff2');
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+  }
+  /* latin-ext */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qNq7lqDY.woff2) format('woff2');
+    unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+  /* latin */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xK3dSBYKcSV-LCoeQqfX1RYOo3qOK7l.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+  /* cyrillic-ext */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rwmhduz8A.woff2) format('woff2');
+    unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  }
+  /* cyrillic */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rwkxduz8A.woff2) format('woff2');
+    unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  }
+  /* greek-ext */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rwmxduz8A.woff2) format('woff2');
+    unicode-range: U+1F00-1FFF;
+  }
+  /* greek */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rwlBduz8A.woff2) format('woff2');
+    unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+  }
+  /* vietnamese */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rwmBduz8A.woff2) format('woff2');
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+  }
+  /* latin-ext */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rwmRduz8A.woff2) format('woff2');
+    unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+  /* latin */
+  @font-face {
+    font-family: 'Source Sans Pro';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url(https://fonts.gstatic.com/s/sourcesanspro/v22/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rwlxdu.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+  /* vietnamese */
+  @font-face {
+    font-family: 'Inconsolata';
+    font-style: normal;
+    font-weight: 200 900;
+    font-stretch: 50% 200%;
+    src: url(https://fonts.gstatic.com/s/inconsolata/v32/QldKNThLqRwH-OJ1UHjlKGlW5qhWxg.woff2) format('woff2');
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+  }
+  /* latin-ext */
+  @font-face {
+    font-family: 'Inconsolata';
+    font-style: normal;
+    font-weight: 200 900;
+    font-stretch: 50% 200%;
+    src: url(https://fonts.gstatic.com/s/inconsolata/v32/QldKNThLqRwH-OJ1UHjlKGlX5qhWxg.woff2) format('woff2');
+    unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+  /* latin */
+  @font-face {
+    font-family: 'Inconsolata';
+    font-style: normal;
+    font-weight: 200 900;
+    font-stretch: 50% 200%;
+    src: url(https://fonts.gstatic.com/s/inconsolata/v32/QldKNThLqRwH-OJ1UHjlKGlZ5qg.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+  </style>
   <!-- default title that will be updated from the Commands component-->
   <title>Strype</title>
 </head>

--- a/src/App.vue
+++ b/src/App.vue
@@ -688,8 +688,8 @@ export default Vue.extend({
             // if they want to use the detected (supported) language. 
             // If they refused or if we can't retrieve anything at all, we use English as default.
             let strypeSessionLocale = "en"; // default locale
-            let canCheckBrowserLocale = false;
-            if(typeof Storage !== undefined) {
+            let checkBrowserLocale = false;
+            if(typeof Storage !== "undefined") {
                 const savedSettingsState: typeof this.settingsStore = JSON.parse(localStorage.getItem(AutoSaveKeyNames.settingsState)??"{}");
                 if(savedSettingsState.locale) {
                     strypeSessionLocale = savedSettingsState.locale;
@@ -698,14 +698,14 @@ export default Vue.extend({
                     // There is no locale saved. Maybe the user wants to use the default English, but maybe
                     // they would like to use another language and their working environment won't save it,
                     // so we can ask them based on the browser's locale if they want to switch.
-                    canCheckBrowserLocale = true;
+                    checkBrowserLocale = true;
                 }
             }
             else{
-                canCheckBrowserLocale = true;
+                checkBrowserLocale = true;
             }
 
-            if(canCheckBrowserLocale){
+            if(checkBrowserLocale){
                 // We didn't retrieve a locale, but we can check if the browser's locale isn't English
                 // and use it for Strype if we provide that locale
                 const foundLanguange = navigator.language?.toLowerCase();

--- a/src/App.vue
+++ b/src/App.vue
@@ -94,9 +94,9 @@ import Menu from "@/components/Menu.vue";
 import ModalDlg from "@/components/ModalDlg.vue";
 import SimpleMsgModalDlg from "@/components/SimpleMsgModalDlg.vue";
 import {Splitpanes, Pane, PaneData} from "splitpanes";
-import { useStore } from "@/store/store";
+import { useStore, settingsStore } from "@/store/store";
 import { AppEvent, ProjectSaveFunction, BaseSlot, CaretPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, FrameObject, MessageDefinitions, MessageTypes, ModifierKeyCode, Position, PythonExecRunningState, SaveRequestReason, SlotCursorInfos, SlotsStructure, SlotType, StringSlot, StrypeSyncTarget, GAPIState } from "@/types/types";
-import { getFrameContainerUID, getMenuLeftPaneUID, getEditorMiddleUID, getCommandsRightPaneContainerId, isElementLabelSlotInput, CustomEventTypes, getFrameUID, parseLabelSlotUID, getLabelSlotUID, getFrameLabelSlotsStructureUID, getSelectionCursorsComparisonValue, setDocumentSelection, getSameLevelAncestorIndex, autoSaveFreqMins, getImportDiffVersionModalDlgId, getAppSimpleMsgDlgId, getFrameContextMenuUID, getActiveContextMenu, actOnTurtleImport, setPythonExecutionAreaTabsContentMaxHeight, setManuallyResizedEditorHeightFlag, setPythonExecAreaLayoutButtonPos, isContextMenuItemSelected, getStrypeCommandComponentRefId, frameContextMenuShortcuts, getCompanionDndCanvasId, getPEAComponentRefId, getGoogleDriveComponentRefId, addDuplicateActionOnFramesDnD, removeDuplicateActionOnFramesDnD, getFrameComponent, getCaretContainerComponent, sharedStrypeProjectTargetKey, sharedStrypeProjectIdKey, getCaretContainerUID, getEditorID, getLoadProjectLinkId } from "./helpers/editor";
+import { getFrameContainerUID, getMenuLeftPaneUID, getEditorMiddleUID, getCommandsRightPaneContainerId, isElementLabelSlotInput, CustomEventTypes, getFrameUID, parseLabelSlotUID, getLabelSlotUID, getFrameLabelSlotsStructureUID, getSelectionCursorsComparisonValue, setDocumentSelection, getSameLevelAncestorIndex, autoSaveFreqMins, getImportDiffVersionModalDlgId, getAppSimpleMsgDlgId, getFrameContextMenuUID, getActiveContextMenu, actOnTurtleImport, setPythonExecutionAreaTabsContentMaxHeight, setManuallyResizedEditorHeightFlag, setPythonExecAreaLayoutButtonPos, isContextMenuItemSelected, getStrypeCommandComponentRefId, frameContextMenuShortcuts, getCompanionDndCanvasId, getPEAComponentRefId, getGoogleDriveComponentRefId, addDuplicateActionOnFramesDnD, removeDuplicateActionOnFramesDnD, getFrameComponent, getCaretContainerComponent, sharedStrypeProjectTargetKey, sharedStrypeProjectIdKey, getCaretContainerUID, getEditorID, getLoadProjectLinkId, AutoSaveKeyNames } from "./helpers/editor";
 /* IFTRUE_isPython */
 import { debounceComputeAddFrameCommandContainerSize, getPEATabContentContainerDivId } from "@/helpers/editor";
 /* FITRUE_isPython */
@@ -150,7 +150,7 @@ export default Vue.extend({
     },
 
     computed: {       
-        ...mapStores(useStore),
+        ...mapStores(useStore, settingsStore),
 
         editorId(): string {
             return getEditorID();
@@ -199,10 +199,10 @@ export default Vue.extend({
             return getCommandsRightPaneContainerId();
         },
 
-        localStorageAutosaveKey(): string {
-            let storageString = "PythonStrypeSavedState";
+        localStorageAutosaveEditorKey(): string {
+            let storageString = AutoSaveKeyNames.pythonEditorState;
             /* IFTRUE_isMicrobit */
-            storageString = "MicrobitStrypeSavedState";
+            storageString = AutoSaveKeyNames.mbEditor;
             /*FITRUE_isMicrobit */
             return storageString;
         },
@@ -252,6 +252,10 @@ export default Vue.extend({
     },
 
     created() {
+        // The very first action we want to do is trying to restore the Strype settings:
+        // Strype locale:
+        this.setStrypeLocale();
+
         projectSaveFunctionsState[0] = {name: "WS", function: (reason: SaveRequestReason) => this.autoSaveStateToWebLocalStorage(reason)};
         window.addEventListener("beforeunload", (event) => {
             // No matter the choice the user will make on saving the page, and because it is not straight forward to know what action has been done,
@@ -664,19 +668,62 @@ export default Vue.extend({
         autoSaveStateToWebLocalStorage(reason: SaveRequestReason) : void {
             // save the project to the localStorage (WebStorage)
             if (!this.appStore.debugging && typeof(Storage) !== "undefined") {
-                localStorage.setItem(this.localStorageAutosaveKey, this.appStore.generateStateJSONStrWithCheckpoint(true));
-                // If that's the only element of the auto save functions, then we can notify we're done when we save for loading
-                if(reason==SaveRequestReason.loadProject && projectSaveFunctionsState.length == 1){
-                    this.$root.$emit(CustomEventTypes.saveStrypeProjectDoneForLoad);
+                if(reason == SaveRequestReason.saveSettings){
+                    // Save the settings
+                    localStorage.setItem(AutoSaveKeyNames.settingsState, JSON.stringify(this.settingsStore.$state));
+                }
+                else{
+                    localStorage.setItem(this.localStorageAutosaveEditorKey, this.appStore.generateStateJSONStrWithCheckpoint(true));
+                    // If that's the only element of the auto save functions, then we can notify we're done when we save for loading
+                    if(reason==SaveRequestReason.loadProject && projectSaveFunctionsState.length == 1){
+                        this.$root.$emit(CustomEventTypes.saveStrypeProjectDoneForLoad);
+                    }
                 }
             }
+        },
+
+        setStrypeLocale() {
+            // We need to retrieve Strype's language (session) if it exists in the localStorage.
+            // If we didn't retrieve it, we try to infer the browser's language and ask the user
+            // if they want to use the detected (supported) language. 
+            // If they refused or if we can't retrieve anything at all, we use English as default.
+            let strypeSessionLocale = "en"; // default locale
+            let canCheckBrowserLocale = false;
+            if(typeof Storage !== undefined) {
+                const savedSettingsState: typeof this.settingsStore = JSON.parse(localStorage.getItem(AutoSaveKeyNames.settingsState)??"{}");
+                if(savedSettingsState.locale) {
+                    strypeSessionLocale = savedSettingsState.locale;
+                }
+                else {
+                    // There is no locale saved. Maybe the user wants to use the default English, but maybe
+                    // they would like to use another language and their working environment won't save it,
+                    // so we can ask them based on the browser's locale if they want to switch.
+                    canCheckBrowserLocale = true;
+                }
+            }
+            else{
+                canCheckBrowserLocale = true;
+            }
+
+            if(canCheckBrowserLocale){
+                // We didn't retrieve a locale, but we can check if the browser's locale isn't English
+                // and use it for Strype if we provide that locale
+                const foundLanguange = navigator.language?.toLowerCase();
+                const languageCode = (foundLanguange && foundLanguange.length > 1) ? foundLanguange.substring(0,2) : "en";
+                if(languageCode != "en" && this.$i18n.availableLocales.includes(languageCode)) {
+                    strypeSessionLocale = languageCode;
+                }
+            }
+
+            // Now update the UI
+            this.settingsStore.setAppLang(strypeSessionLocale);
         },
 
         loadLocalStorageProjectOnStart() {
             // Check the local storage (WebStorage) to see if there is a saved project from the previous time the user entered the system
             // if browser supports localstorage
             if (typeof(Storage) !== "undefined") {
-                const savedState = localStorage.getItem(this.localStorageAutosaveKey);
+                const savedState = localStorage.getItem(this.localStorageAutosaveEditorKey);
                 if(savedState) {
                     this.appStore.setStateFromJSONStr( 
                         {
@@ -690,7 +737,7 @@ export default Vue.extend({
                         if(this.appStore.currentGoogleDriveSaveFileId) {
                             const execGetGDFileFunction = (event: BvModalEvent, dlgId: string) => {
                                 if((event.trigger == "ok" || event.trigger=="event") && dlgId == this.resyncGDAtStartupModalDlgId){
-                                // Fetch the Google Drive component
+                                    // Fetch the Google Drive component
                                     const gdVueComponent = ((this.$refs[this.menuUID] as InstanceType<typeof Menu>).$refs[getGoogleDriveComponentRefId()] as InstanceType<typeof GoogleDrive>);
                                     // Initiate a connection to Google Drive via saving mechanisms (for updating Google Drive with local changes)
                                     gdVueComponent.saveFile(SaveRequestReason.reloadBrowser);
@@ -729,7 +776,7 @@ export default Vue.extend({
             this.resetStrypeProjectFlag = true;
             // 3) delete the WebStorage key that refers to the current autosaved project
             if (typeof(Storage) !== "undefined") {
-                localStorage.removeItem(this.localStorageAutosaveKey);
+                localStorage.removeItem(this.localStorageAutosaveEditorKey);
             }
             // Finally, reload the page to reload the Strype default project (removing potential query parameters)
             window.location.href = window.location.pathname;

--- a/src/components/GoogleDriveFilePicker.vue
+++ b/src/components/GoogleDriveFilePicker.vue
@@ -3,7 +3,7 @@
 </template>
 <script lang="ts">
 import Vue from "vue";
-import {useStore} from "@/store/store";
+import {useStore, settingsStore} from "@/store/store";
 import { mapStores } from "pinia";
 import { pythonFileExtension, strypeFileExtension } from "@/helpers/common";
 import { CustomEventTypes } from "@/helpers/editor";
@@ -22,7 +22,7 @@ export default Vue.extend({
     },
 
     computed:{
-        ...mapStores(useStore),
+        ...mapStores(useStore, settingsStore),
     },
 
     data: function() {
@@ -111,7 +111,7 @@ export default Vue.extend({
             const pickerBuilder = new google.picker.PickerBuilder()
                 .disableFeature(google.picker.Feature.MULTISELECT_ENABLED)
                 .disableFeature(google.picker.Feature.NAV_HIDDEN)
-                .setLocale(useStore().appLang)
+                .setLocale(this.settingsStore.locale??"en")
                 .setOAuthToken(this.oauthToken)
                 .setDeveloperKey(this.devKey)
                 .setCallback(this.pickerCallback)

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -52,7 +52,7 @@
                                     <img :src="require('@/assets/images/logoGDrive.png')" alt="Google Drive"/> 
                                     <span>Google Drive</span>
                                 </div>
-                                <div id="saveToFSStrypeButton" tabindex="0"  @click="changeTempSyncTarget(syncFSValue, true)" @keydown.self="onTargetButtonKeyDown($event, true)"
+                                <div :id="saveToFSStrypeButtonId" tabindex="0"  @click="changeTempSyncTarget(syncFSValue, true)" @keydown.self="onTargetButtonKeyDown($event, true)"
                                     :class="{[scssVars.projectTargetButtonClassName + ' save-dlg']: true, saveTargetSelected: tempSyncTarget == syncFSValue}">
                                     <img :src="require('@/assets/images/FSicon.png')" :alt="$t('appMessage.targetFS')"/> 
                                     <span v-t="'appMessage.targetFS'"></span>
@@ -188,7 +188,7 @@ import Vue from "vue";
 import { useStore, settingsStore } from "@/store/store";
 import {saveContentToFile, readFileContent, fileNameRegex, strypeFileExtension, isMacOSPlatform} from "@/helpers/common";
 import { AppEvent, CaretPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, Locale, MessageDefinitions, MIMEDesc, PythonExecRunningState, SaveRequestReason, ShareProjectMode, SlotCoreInfos, SlotCursorInfos, SlotType, StrypeSyncTarget } from "@/types/types";
-import { countEditorCodeErrors, CustomEventTypes, fileImportSupportedFormats, getAppLangSelectId, getAppSimpleMsgDlgId, getEditorCodeErrorsHTMLElements, getEditorMenuUID, getFrameHeaderUID, getFrameUID, getGoogleDriveComponentRefId, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getNearestErrorIndex, getSaveAsProjectModalDlg, isElementEditableLabelSlotInput, isElementUIDFrameHeader, isIdAFrameId, parseFrameHeaderUID, parseFrameUID, parseLabelSlotUID, setDocumentSelection, sharedStrypeProjectIdKey, sharedStrypeProjectTargetKey } from "@/helpers/editor";
+import { countEditorCodeErrors, CustomEventTypes, fileImportSupportedFormats, getAppLangSelectId, getAppSimpleMsgDlgId, getEditorCodeErrorsHTMLElements, getEditorMenuUID, getFrameHeaderUID, getFrameUID, getGoogleDriveComponentRefId, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getNearestErrorIndex, getSaveAsProjectModalDlg, getSaveStrypeProjectToFSButtonId, getStrypeSaveProjectNameInputId, isElementEditableLabelSlotInput, isElementUIDFrameHeader, isIdAFrameId, parseFrameHeaderUID, parseFrameUID, parseLabelSlotUID, setDocumentSelection, sharedStrypeProjectIdKey, sharedStrypeProjectTargetKey } from "@/helpers/editor";
 import { Slide } from "vue-burger-menu";
 import { mapStores } from "pinia";
 import GoogleDrive from "@/components/GoogleDrive.vue";
@@ -405,9 +405,13 @@ export default Vue.extend({
         saveProjectTargetButtonGpId(): string {
             return "saveProjectProjectSelect";
         },
+
+        saveToFSStrypeButtonId(): string {
+            return getSaveStrypeProjectToFSButtonId();
+        },
         
         saveFileNameInputId(): string {
-            return "saveStrypeFileNameInput";
+            return getStrypeSaveProjectNameInputId();
         },
 
         shareProjectLinkId(): string {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -185,7 +185,7 @@
 //      Imports     //
 //////////////////////
 import Vue from "vue";
-import { useStore } from "@/store/store";
+import { useStore, settingsStore } from "@/store/store";
 import {saveContentToFile, readFileContent, fileNameRegex, strypeFileExtension, isMacOSPlatform} from "@/helpers/common";
 import { AppEvent, CaretPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, Locale, MessageDefinitions, MIMEDesc, PythonExecRunningState, SaveRequestReason, ShareProjectMode, SlotCoreInfos, SlotCursorInfos, SlotType, StrypeSyncTarget } from "@/types/types";
 import { countEditorCodeErrors, CustomEventTypes, fileImportSupportedFormats, getAppLangSelectId, getAppSimpleMsgDlgId, getEditorCodeErrorsHTMLElements, getEditorMenuUID, getFrameHeaderUID, getFrameUID, getGoogleDriveComponentRefId, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getNearestErrorIndex, getSaveAsProjectModalDlg, isElementEditableLabelSlotInput, isElementUIDFrameHeader, isIdAFrameId, parseFrameHeaderUID, parseFrameUID, parseLabelSlotUID, setDocumentSelection, sharedStrypeProjectIdKey, sharedStrypeProjectTargetKey } from "@/helpers/editor";
@@ -311,7 +311,7 @@ export default Vue.extend({
     },
 
     computed: {
-        ...mapStores(useStore),
+        ...mapStores(useStore, settingsStore),
         
         menuUID(): string {
             return getEditorMenuUID();
@@ -471,10 +471,10 @@ export default Vue.extend({
 
         appLang: {
             get(): string {
-                return this.appStore.appLang;
+                return this.settingsStore.locale??"en";
             },
-            set(lang: string) {
-                this.appStore.setAppLang(lang);
+            set(lang: string) {                                
+                this.settingsStore.setAppLang(lang);
             }, 
         },
 

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -621,6 +621,7 @@ export default Vue.extend({
         border-radius: 10px;
         border: 1px solid transparent;
         outline: none;
+        background-color: transparent;
     }
 
     .pea-controls-div button:hover {

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -503,8 +503,16 @@ export function getCaretContainerComponent(frameComponent: InstanceType<typeof F
 }
 // End for component retriever
 
-export function getSaveAsProjectModalDlg():string {
+export function getSaveAsProjectModalDlg(): string {
     return "save-strype-project-modal-dlg";
+}
+
+export function getStrypeSaveProjectNameInputId(): string {
+    return "saveStrypeFileNameInput";
+}
+
+export function getSaveStrypeProjectToFSButtonId() : string {
+    return "saveStrypeProjectToFSStrypeButton";
 }
 
 export function getEditorMiddleUID(): string {

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -27,7 +27,13 @@ export const autoSaveFreqMins = 2; // The number of minutes between each autosav
 export const sharedStrypeProjectTargetKey = "shared_proj_targ"; 
 // The URL of the project, with the URL pattern (template) for each possible target
 export const sharedStrypeProjectIdKey = "shared_proj_id";
-//export const sharedStrypeProjectURLSrcTemplates: {target: StrypeSyncTarget, URLTemplate: string}[] = [{target: StrypeSyncTarget.gd, URLTemplate: "https://drive.google.com/file/{0}"}];
+
+// LocalStorage keys used by Strype 
+export enum AutoSaveKeyNames {
+    settingsState = "StrypeSettingsState",
+    pythonEditorState = "PythonStrypeSavedState",
+    mbEditor = "MicrobitStrypeSavedState",
+}
 
 // Custom JS events in Strype
 export enum CustomEventTypes {
@@ -222,7 +228,7 @@ export function getTextStartCursorPositionOfHTMLElement(htmlElement: HTMLSpanEle
 }
 
 export function getFocusedEditableSlotTextSelectionStartEnd(labelSlotUID: string): {selectionStart: number, selectionEnd: number} {
-    // A helper function to get the selection relative to a *focused* slot: if the selection spans across several slots, we get the right boudary values for the given slot
+    // A helper function to get the selection relative to a *focused* slot: if the selection spans across several slots, we get the right boundary values for the given slot
     const focusCursorInfos = useStore().focusSlotCursorInfos;
     const anchorCursorInfos = useStore().anchorSlotCursorInfos;
     if(anchorCursorInfos != null && focusCursorInfos != null ){

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import vBlur from "v-blur";
 import { StrypePlatform } from "./types/types";
 import scssVars  from "@/assets/style/_export.module.scss";
 import { WINDOW_STRYPE_HTMLIDS_PROPNAME, WINDOW_STRYPE_SCSSVARS_PROPNAME } from "./helpers/sharedIdCssWithTests";
-import { getAppLangSelectId, getEditorID, getEditorMenuUID, getFrameBodyUID, getFrameContainerUID, getFrameHeaderUID, getFrameLabelSlotsStructureUID, getFrameUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId } from "./helpers/editor";
+import { getAppLangSelectId, getEditorID, getEditorMenuUID, getFrameBodyUID, getFrameContainerUID, getFrameHeaderUID, getFrameLabelSlotsStructureUID, getFrameUID, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getSaveStrypeProjectToFSButtonId, getStrypeSaveProjectNameInputId } from "./helpers/editor";
 
 Vue.config.productionTip = false;
 
@@ -58,6 +58,9 @@ export function getLocaleBuildDate(): string {
     getLoadProjectLinkId: getLoadProjectLinkId,
     getLoadFromFSStrypeButtonId: getLoadFromFSStrypeButtonId,
     getAppLangSelectId: getAppLangSelectId,
+    getFrameLabelSlotId: getLabelSlotUID,
+    getStrypeSaveProjectNameInputId: getStrypeSaveProjectNameInputId,
+    getSaveStrypeProjectToFSButtonId: getSaveStrypeProjectToFSButtonId,
 };
 
 // Install BootstrapVue

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot, StrypePEALayoutMode } from "@/types/types";
+import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot, StrypePEALayoutMode, SaveRequestReason } from "@/types/types";
 import { getObjectPropertiesDifferences, getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
 import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
@@ -15,8 +15,8 @@ import $ from "jquery";
 import { BvModalEvent } from "bootstrap-vue";
 import { nextTick } from "@vue/composition-api";
 import { TPyParser } from "tigerpython-parser";
-/* IFTRUE_isPython */
 import AppComponent from "@/App.vue";
+/* IFTRUE_isPython */
 import PEAComponent from "@/components/PythonExecutionArea.vue";
 import CommandsComponent from "@/components/Commands.vue";
 import { actOnTurtleImport, getPEAComponentRefId } from "@/helpers/editor";
@@ -81,9 +81,8 @@ export const useStore = defineStore("app", {
             isEditing: false,
 
             /* These state properties are for saving the layout of the UI.
-             * Some are initally set to UNDEFINED so it we can detect default state:
-             * (for example, the PEA will take its 4:3 ratio size when the commands/PEA 
-             * splitter has not changed, we it needs to be seen as such. )
+             * They are initally set to UNDEFINED so we can work out which layout changes the users have done.
+             * We always apply the changes after getting back to the default layout (when a file is loaded after first time).
              ***/ 
             editorCommandsSplitterPane2Size: undefined as number | undefined, // same as above for the divider between the editor and the commands (pane 2), default is 34%
             
@@ -172,8 +171,6 @@ export const useStore = defineStore("app", {
             projectLastSaveDate: -1, // Date ticks
 
             selectedFrames: [] as number[],
-
-            appLang: "en",
 
             tigerPythonLang: "en", // The locale for TigerPython, see parser.ts as to why it's here
 
@@ -655,29 +652,6 @@ export const useStore = defineStore("app", {
     },
     
     actions:{
-        setAppLang(lang: string) {
-            // Set the language in the store first
-            this.appLang = lang;
-
-            // Then change the UI via i18n
-            i18n.locale = lang;
-
-            // And also change TigerPython locale -- if Strype locale is not available in TigerPython, we use English instead
-            const tpLangs = TPyParser.getLanguages as any as string[]; // TODO remove this casting once TigerPython's type for getLanguages is fixed
-            this.tigerPythonLang = (tpLangs.includes(lang)) ? lang : "en";
-
-            // Change all frame definition types to update the localised bits
-            generateAllFrameDefinitionTypes(true);
-
-            // Change the frame command labels / details 
-            generateAllFrameCommandsDefs();
-
-            /* IFTRUE_isMicrobit */
-            //change the API description content here, as we don't want to construct the textual API description every time we need it
-            getAPIItemTextualDescriptions(true);
-            /* FITRUE_isMicrobit */
-        },
-        
         showMessage(newMessage: MessageDefinition, timeoutMillis: number | null) {
             this.currentMessage = newMessage;
             const ourId = ++this.currentMessageId;
@@ -2464,8 +2438,6 @@ export const useStore = defineStore("app", {
 
                 commandsComponent.resetPEACommmandsSplitterDefaultState().then(() => {
                     this.updateState(JSON.parse(JSON.stringify(newState)));
-                    // If the language has been updated, we need to also update the UI accordingly
-                    this.setAppLang(this.appLang);
                     // Wait a bit after we have reset everything for the UI to get ready, then affect backed up changes
                     setTimeout(() => {
                         let chainedTimeOuts = 400;
@@ -2514,8 +2486,6 @@ export const useStore = defineStore("app", {
                 /* FITRUE_isPython */
                 /* IFTRUE_isMicrobit */
                 this.updateState(JSON.parse(stateJSONStr));
-                // If the language has been updated, we need to also update the UI accordingly
-                this.setAppLang(this.appLang);
                 resolve();
                 /* FITRUE_isMicrobit */
             });
@@ -2909,6 +2879,46 @@ export const useStore = defineStore("app", {
                 previousFramesSelection = [...this.selectedFrames];
                 this.selectMultipleFrames(direction);
             } while (previousFramesSelection.length !== this.selectedFrames.length && !this.selectedFrames.includes(stopId));
+        },
+    },
+});
+
+export const settingsStore = defineStore("settings", {
+    state: () => {
+        return {
+            // The local in this store settings is to keep the language throught the session (i.e. localStorage)
+            // regardless the local *of the project*. When we cannot retrieve this property, we fall back
+            // on the project's locale.
+            // The default state is undefined so we can detect real undefined locale to the default English...
+            locale: undefined as undefined | string,
+        };
+    },
+
+    actions:{
+        setAppLang(lang: string) {
+            // Set the language in the store first
+            this.locale = lang;
+
+            // Then change the UI via i18n
+            i18n.locale = lang;
+
+            // And also change TigerPython locale -- if Strype locale is not available in TigerPython, we use English instead
+            const tpLangs = TPyParser.getLanguages as any as string[]; // TODO remove this casting once TigerPython's type for getLanguages is fixed
+            useStore().tigerPythonLang = (tpLangs.includes(lang)) ? lang : "en";
+
+            // Change all frame definition types to update the localised bits
+            generateAllFrameDefinitionTypes(true);
+
+            // Change the frame command labels / details 
+            generateAllFrameCommandsDefs();
+
+            /* IFTRUE_isMicrobit */
+            //change the API description content here, as we don't want to construct the textual API description every time we need it
+            getAPIItemTextualDescriptions(true);
+            /* FITRUE_isMicrobit */
+
+            // Save the settings
+            (vm.$children[0] as InstanceType<typeof AppComponent>).autoSaveStateToWebLocalStorage(SaveRequestReason.saveSettings);
         },
     },
 });

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -658,16 +658,19 @@ export function generateAllFrameDefinitionTypes(regenerateExistingFrames?: boole
     /*3) if required, update the types in all the frames existing in the editor (needed to update default texts and frame container labels) */
     if(regenerateExistingFrames){
         Object.values(useStore().frameObjects).forEach((frameObject: FrameObject) => {
-            // For containers, we just assign the label manually again here
+            // For containers, we just assign the label manually again here and change the definitons
             switch(frameObject.frameType.type){
             case ImportsContainerDefinition.type:
                 frameObject.frameType.labels[0].label = i18n.t("appMessage.importsContainer") as string;
+                ImportsContainerDefinition.labels[0].label = i18n.t("appMessage.importsContainer") as string;
                 break;
             case FuncDefContainerDefinition.type:
                 frameObject.frameType.labels[0].label = i18n.t("appMessage.funcDefsContainer") as string;
+                FuncDefContainerDefinition.labels[0].label = i18n.t("appMessage.funcDefsContainer") as string;
                 break;
             case MainFramesContainerDefinition.type:
                 frameObject.frameType.labels[0].label = i18n.t("appMessage.mainContainer") as string;
+                MainFramesContainerDefinition.labels[0].label = i18n.t("appMessage.mainContainer") as string;
                 break;
             default:
                 // For all normal frames, we rely on the frame definition type                
@@ -1044,6 +1047,7 @@ export enum SaveRequestReason {
     loadProject,
     unloadPage,
     reloadBrowser, // for Google Drive: when a project was previously saved in GD and the browser is reloaded and the user requested to save the local changes to GD.
+    saveSettings, // for saving Strype settings
 }
 
 export interface SaveExistingGDProjectInfos {

--- a/tests/cypress/e2e/translation.cy.ts
+++ b/tests/cypress/e2e/translation.cy.ts
@@ -1,4 +1,5 @@
 // Test that the translation is working properly
+import path from "path";
 import i18n from "@/i18n";
 import {expect} from "chai";
 import failOnConsoleError from "cypress-fail-on-console-error";
@@ -38,40 +39,196 @@ beforeEach(() => {
     });
 });
 
+// Helper method that needs to be called in a test before typing text in Strype
+// (not clear why, but it's just required... otherwise when a typing triggers a frame addition, following typing fails)
+function focusEditor(): void {
+    cy.get("#" + strypeElIds.getFrameUID(-3)).focus();
+}
+
+// This method expected the frame cursor to be at the start of "my code":
+// it will test the frame container labels as well as the autocompletion
+function checkTranslationsForLocale(locale: string): void {    
+    // Check that the sections are present and translated:
+    cy.get("."+ scssVars.frameContainerLabelSpanClassName).should((hs) => checkTextEquals(hs, [i18n.t("appMessage.importsContainer", locale) as string, i18n.t("appMessage.funcDefsContainer", locale) as string, i18n.t("appMessage.mainContainer", locale) as string]));
+
+    // Check that sections in the autocomplete are translated:
+    // Add a function:
+    cy.get("body").type("{uparrow}ffoo{downarrow}{downarrow}");
+    // And a variable:
+    cy.get("body").type("{downarrow}=bar=3{rightarrow}");
+    // Then trigger autocomplete:
+    cy.get("body").type(" {ctrl} ");
+    // And check the sections:
+    const expAuto = [i18n.t("autoCompletion.myVariables", locale) as string, i18n.t("autoCompletion.myFunctions", locale) as string];
+    if (Cypress.env("mode") === "microbit") {
+        expAuto.push("microbit");
+    }
+}
+
+// This method checks English (initial situation) is selected and showing, 
+// and swap Strype to a given locale, then check translations for that given locale.
+function changeLocaleAndCheckTranslations(locale: string): void {
+    // Starts as English:
+    cy.get("." + scssVars.frameContainerLabelSpanClassName).should((hs) => checkTextEquals(hs, [i18n.t("appMessage.importsContainer") as string, i18n.t("appMessage.funcDefsContainer") as string, i18n.t("appMessage.mainContainer") as string]));
+    cy.get("select#" + strypeElIds.getAppLangSelectId()).should("have.value", "en");
+
+    // Swap to another locale and check it worked:
+    cy.get("button#" + strypeElIds.getEditorMenuUID()).click();
+    cy.get("select#" + strypeElIds.getAppLangSelectId()).select(locale);
+    cy.get("select#" + strypeElIds.getAppLangSelectId()).should("have.value", locale);
+    
+    // Close the menu:
+    cy.get("body").type("{esc}");
+    cy.wait(1000);
+
+    // Check translations
+    checkTranslationsForLocale(locale);
+}
+
+// This methods edits the Strype code with the given code change (if any), then download the converted Python file.
+// The locale can be specified as we rely on a translation to find the "convert" button (English is used by default).
+// We may want to rename the downloaded file (it seems Cypress overwrites files).
+const downloadsFolder = Cypress.config("downloadsFolder");
+function changeCodeThenDownloadPy(parameters?: {locale?: string, renamedFileName?: string, codeChangeStrSequence?: string}): void {
+    const dowloadingActions = () => {
+        cy.log("deleting the python file");
+        cy.task("deleteFile", path.join(downloadsFolder, "main.py"));
+        cy.get("button#" + strypeElIds.getEditorMenuUID()).click({force: true}); 
+        cy.contains(i18n.t("appMenu.downloadPython", (parameters?.locale)??"en") as string).click({force: true});
+        // If we request the file to be renamed, we rename it after a short wait (for download to be done)
+        if(parameters?.renamedFileName) {
+            cy.wait(2000);
+            cy.task("renameFile", {srcPath: path.join(downloadsFolder, "main.py"), destPath: path.join(downloadsFolder, parameters.renamedFileName)});
+        }
+    };
+
+    
+    if(parameters?.codeChangeStrSequence){
+        cy.get("body").type(parameters.codeChangeStrSequence);
+        cy.wait(500);
+        dowloadingActions();
+    
+    }
+    else{
+        dowloadingActions();
+    }    
+}
+  
 describe("Translation tests", () => {
     it("Translates correctly", () => {
-        // Starts as English:
-        cy.get("." + scssVars.frameContainerLabelSpanClassName).should((hs) => checkTextEquals(hs, [i18n.t("appMessage.importsContainer") as string, i18n.t("appMessage.funcDefsContainer") as string, i18n.t("appMessage.mainContainer") as string]));
-        cy.get("select#" + strypeElIds.getAppLangSelectId()).should("have.value", "en");
-
-        // Swap to French and check it worked:
-        cy.get("button#" + strypeElIds.getEditorMenuUID()).click();
-        cy.get("select#" + strypeElIds.getAppLangSelectId()).select("fr");
-        cy.get("select#" + strypeElIds.getAppLangSelectId()).should("have.value", "fr");
-
-        // Check that the sections are present and translated:
-        cy.get("."+ scssVars.frameContainerLabelSpanClassName).should((hs) => checkTextEquals(hs, [i18n.t("appMessage.importsContainer", "fr") as string, i18n.t("appMessage.funcDefsContainer", "fr") as string, i18n.t("appMessage.mainContainer", "fr") as string]));
-
-        // Close the menu:
-        cy.get("body").type("{esc}");
-        cy.wait(1000);
-        
-        // Check that sections in the autocomplete are translated:
-        // Add a function:
-        cy.get("body").type("{uparrow}ffoo{downarrow}{downarrow}");
-        // And a variable:
-        cy.get("body").type("{downarrow}=bar=3{rightarrow}");
-        // Then trigger autocomplete:
-        cy.get("body").type(" {ctrl} ");
-        // And check the sections:
-        const expAuto = [i18n.t("autoCompletion.myVariables", "fr") as string, i18n.t("autoCompletion.myFunctions", "fr") as string];
-        if (Cypress.env("mode") === "microbit") {
-            expAuto.push("microbit");
-        }
+        changeLocaleAndCheckTranslations("fr");
     });
+
     it("Resets translation properly", () => {
         // Should be back to English:
-        cy.get("." + scssVars.frameContainerLabelSpanClassName).should((hs) => checkTextEquals(hs, [i18n.t("appMessage.importsContainer") as string, i18n.t("appMessage.funcDefsContainer") as string, i18n.t("appMessage.mainContainer") as string]));
+        checkTranslationsForLocale("en");
         cy.get("select#" + strypeElIds.getAppLangSelectId()).should("have.value", "en");
     });
+});
+
+describe("Locale persistence", () => {
+    // These tests are a sort of a combination of the two tests of the previous describe() BUT without a local storage clearance.
+    // We want to verify that the locale selected by a user is kept in the local storage and used properly with another Strype/project load.
+    // 3 cases are tested: resetting to a new project, reloading the current page (like refreshing the browser) and loading a project
+    // in an existing Strype session.
+
+    it("Keeps locale after resetting to new project", () => {
+        // Preparation: download the Python conversion of the intial Strype code for comparison later.
+        // It seems headless Cypress overwrites downloaded files with same name, so we rename the file for backup.
+        const initialPyFileName = "main-init.py";
+        changeCodeThenDownloadPy({renamedFileName: initialPyFileName});
+
+        // Part 1: change locale (duplicate test "Translates correctly" with another language for fun)
+        const localeForTest = "zh";
+        changeLocaleAndCheckTranslations(localeForTest);
+
+        // Part 2: resetting the editor ("New Project" in menu), the code should be in the initial state (we have changed it in part 1)
+        // but the locale should still be the same as before.
+        cy.get("button#" + strypeElIds.getEditorMenuUID()).click({force: true}); 
+        cy.contains(i18n.t("appMenu.resetProject", localeForTest) as string).click({force: true}).then(() => {
+            // Check the editor contains the initial state code: we download the conversion and compare with the backed up Python file
+            changeCodeThenDownloadPy({locale: localeForTest});
+            cy.wait(500);            
+            return cy.readFile(path.join(downloadsFolder, initialPyFileName)).then((intialPyFileContent : string) =>  {
+                return cy.readFile(path.join(downloadsFolder, "main.py")).then((newPyFileContent : string) =>  {
+                    expect(newPyFileContent, "Reset project's Python file differs from intial project's Python file").to.equal(intialPyFileContent);
+                    // Check the page is still in the previously selected locale
+                    checkTranslationsForLocale(localeForTest);
+                    // Clean up the downloads folder for the backed up file (not sure we need though)
+                    cy.task("deleteFile", path.join(downloadsFolder, initialPyFileName)); 
+                });                
+            });
+        });
+    });
+
+    
+    it("Keeps locale after reloading website", () => {
+        // Part 1: change locale (duplicate test "Translates correctly" with another language for fun)
+        const localeForTest = "zh";
+        changeLocaleAndCheckTranslations(localeForTest);
+
+        // Part 2: instead of starting off a new test state (as enforced by beforeEach()) we simply visit the page again
+        cy.visit("/").then(() => {       
+            // Check the page is still in the previously selected locale
+            checkTranslationsForLocale(localeForTest);
+        });
+    });
+
+    
+    
+    it("Keeps locale after loading a project", () => {
+        focusEditor();
+        const localeForTest = "de", englishPyFileName = "main-english.py";
+        
+        // Preparation 1 : we will need to check a file that was created while Strype was in English, later with another locale.
+        // We just edit something (remove existing code, add a varassign and a function call) and save the converted Python file for reusing it later.
+        // We make sure the frame cursor is back to the start of "my code".
+        changeCodeThenDownloadPy({renamedFileName:englishPyFileName, codeChangeStrSequence: "{del}{del}=testvar=\"this is done in English Strype.{downarrow} test{uparrow}{uparrow}"});
+        // Now save the spy project so we can reload it later. With Cypress, saving in the file system is directly saving in the download folder,
+        // with the name of the project (so we keep it as "My project").
+        cy.get("button#" + strypeElIds.getEditorMenuUID()).click({force: true}); 
+        cy.wait(200);
+        cy.contains(i18n.t("appMenu.saveProject") as string).click({force: true});
+        cy.get("#" + strypeElIds.getSaveStrypeProjectToFSButtonId()).click({force: true});
+        cy.wait(500);
+        cy.get("#" + strypeElIds.getStrypeSaveProjectNameInputId()).type("{enter}");
+        cy.wait(200);
+      
+        // Preparation 2: to make sure that later we load the right file content, we start off with an empty content
+        cy.get("body").type("{ctrl}a").type("{del}");
+        cy.wait(100);
+
+        // Part 1: change locale (duplicate test "Translates correctly" with another language for fun)
+        changeLocaleAndCheckTranslations(localeForTest);
+        cy.wait(500);
+
+        // Part 2 : open the project saved in Preparation 1 and check that content is compliant, locale isn't changed.
+        // Due to the Cypress environment, we need to by-pass Strype's mechanism that opens the file selector via the UI.
+        // Instead, we directly use Strype's input-file HTML element that would be used in a normal workflow.
+        cy.get("input." + scssVars.editorFileInputClassName).selectFile(path.join(downloadsFolder, "My project.spy"), {force: true});
+        // Wait a bit for the download, and compare that ... 
+        cy.wait(1000);
+        // 1) the file content is the same as expected (and they aren't empty!)
+        changeCodeThenDownloadPy({locale: localeForTest});
+        cy.wait(500);          
+        cy.readFile(path.join(downloadsFolder, englishPyFileName)).then((englishPyFileContent : string) => {
+            return cy.readFile(path.join(downloadsFolder, "main.py")).then((newPyFileContent : string) =>  {
+                expect(newPyFileContent, "Loaded project's Python file differs from original project's Python file.").to.equal(englishPyFileContent);   
+                expect(newPyFileContent, "Loaded project (and original project) should not be empty").to.not.empty;             
+            });
+        });        
+           
+
+        // 2) the locale is correct (usual test + the function call placeholder text, which is in frame 4 for normal editor, and 5 for microbit because of import)
+        checkTranslationsForLocale(localeForTest);
+        cy.get("#" + strypeElIds.getFrameLabelSlotId({frameId: (Cypress.env("mode") === "microbit") ? 5 : 4, slotId: "0", slotType: 7, labelSlotsIndex: 0})).then((slotElement) => {
+            // This slot should be the empty frame call: we check the placeholder text
+            expect(slotElement.attr("placeholder")??"<undefined>", "Loaded project's empty functional call prompt is not matching the expected value for the locale \" "+ localeForTest +"\"")
+                .to.equal(i18n.t("frame.defaultText.funcCall", localeForTest));           
+           
+            // Clean up the downloads folder for the backed up files (not sure we need though)
+            cy.task("deleteFile", path.join(downloadsFolder, englishPyFileName));
+            cy.task("deleteFile", path.join(downloadsFolder, "My project.spy"));
+        });
+    }); 
 });


### PR DESCRIPTION
Previously, Strype's locale was saved with the state and therefore with the project. Whenever a project was loaded, the locale it was saved with was then applied to Strype accordingly.

This change is now decoupling a project to the Strype locale and save the locale on a "session", or for a browser rather, instead.
This is how it works now:
- the language is no longer saved in the state as before, but it is set in **another state dedicated to settings**
- when Strype is loaded (with that new change), we look if the locale is saved in _the local storage of the browser_
---- if the locale was saved, we use it to update the UI's locale,
---- if the locale wasn't saved (case of first time loading Strype since the new change), we try to detect the browser's language and use it as the Strype locale (if we support it) otherwise English is set.

_Every change of the locale (programmatically or via the UI) is saved in the browser locale storage._

The other unrelated of this PR are some style fixing for Safari (not that the font change isn't too important as it will be change with Neil's changes soon), and a fix for a small issue with Googe Drive (explained in the commit's details).