### PR TITLE
Folding sections revamp

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1109,16 +1109,16 @@ export default Vue.extend({
 
                     copyFramesFromParsedPython(s.imports.join("\n"), STRYPE_LOCATION.IMPORTS_SECTION);
                     if (useStore().copiedSelectionFrameIds.length > 0) {
-                        getCaretContainerComponent(getFrameComponent(-1) as InstanceType<typeof FrameContainer>).doPaste(true);
+                        getCaretContainerComponent(getFrameComponent(this.appStore.getImportsFrameContainerId) as InstanceType<typeof FrameContainer>).doPaste(true);
                     }
                     copyFramesFromParsedPython(s.defs.join("\n"), STRYPE_LOCATION.FUNCDEF_SECTION);
                     if (useStore().copiedSelectionFrameIds.length > 0) {
-                        getCaretContainerComponent(getFrameComponent(-2) as InstanceType<typeof FrameContainer>).doPaste(true);
+                        getCaretContainerComponent(getFrameComponent(this.appStore.getFuncDefsFrameContainerId) as InstanceType<typeof FrameContainer>).doPaste(true);
                     }
                     if (s.main.length > 0) {
                         copyFramesFromParsedPython(s.main.join("\n"), STRYPE_LOCATION.MAIN_CODE_SECTION);
                         if (useStore().copiedSelectionFrameIds.length > 0) {
-                            getCaretContainerComponent(getFrameComponent(-3) as InstanceType<typeof FrameContainer>).doPaste(true);
+                            getCaretContainerComponent(getFrameComponent(this.appStore.getMainCodeFrameContainerId) as InstanceType<typeof FrameContainer>).doPaste(true);
                         }
                     }
 

--- a/src/autocompletion/acManager.ts
+++ b/src/autocompletion/acManager.ts
@@ -146,7 +146,7 @@ export function getAllUserDefinedVariablesUpTo(frameId: number) : Set<string> {
     for (;;) {
         const frame = useStore().frameObjects[curFrameId];
         const parentId = frame.parentId;
-        if (parentId == -2) {
+        if (parentId == useStore().getFuncDefsFrameContainerId) {
             // It's a user-defined function, process accordingly
             const available = getAllUserDefinedVariablesWithinUpTo(useStore().getFramesForParentId(curFrameId), frameId).found;
             // Also add any parameters from the function:

--- a/src/components/FrameContainer.vue
+++ b/src/components/FrameContainer.vue
@@ -202,7 +202,7 @@ export default Vue.extend({
         },
         
         onOuterContainerClick(event : any): void {
-            var containerFramesBounds = (this.$refs.containerFrames as HTMLElement).getBoundingClientRect();
+            const containerFramesBounds = (this.$refs.containerFrames as HTMLElement).getBoundingClientRect();
             
             // Was the click beneath the bottom of the frame container?
             if (event.clientY > containerFramesBounds.bottom) {
@@ -227,6 +227,9 @@ export default Vue.extend({
                 event.stopPropagation();
                 event.stopImmediatePropagation();
             }
+
+            // Make sure the container is expanded.
+            this.appStore.frameObjects[this.frameId].isCollapsed = false;
         },
     },
 });

--- a/src/components/FrameContainer.vue
+++ b/src/components/FrameContainer.vue
@@ -43,6 +43,7 @@ import { CaretPosition, FrameObject, DefaultFramesDefinition, FramesDefinitions,
 import { mapStores } from "pinia";
 import { getCaretContainerRef, getCaretUID, getFrameUID} from "@/helpers/editor";
 import scssVars from "@/assets/style/_export.module.scss";
+import { getFrameSectionIdFromFrameId } from "@/helpers/storeMethods";
 
 //////////////////////
 //     Component    //
@@ -175,6 +176,18 @@ export default Vue.extend({
             // Only collapse Imports and Definitions frame containers.
             if(!this.isMainCodeFrameContainer){
                 this.isCollapsed = !this.isCollapsed;
+                
+                // Also move the frame cursor to the next uncollapsed frame container
+                // if we were inside the frame container being collapsed
+                if(this.isCollapsed && getFrameSectionIdFromFrameId(this.appStore.currentFrame.id) == this.frameId) {
+                    const nextFrameContainerIndex = this.appStore.frameObjects[this.appStore.getRootFrameContainerId].childrenIds.indexOf(this.frameId) + 1;
+                    const nextFrameContainerId = this.appStore.frameObjects[this.appStore.getRootFrameContainerId].childrenIds.at(nextFrameContainerIndex);
+                    // As we have only 3 sections, if the next section is collapsed we automatically get to "My code", as this one is never collapsed.
+                    const targetFrameContainerId = (nextFrameContainerId && !this.appStore.frameObjects[nextFrameContainerId].isCollapsed)
+                        ? nextFrameContainerId
+                        : this.appStore.getMainCodeFrameContainerId;
+                    this.appStore.setCurrentFrame({id: targetFrameContainerId, caretPosition: CaretPosition.body});
+                }
             }
         },
 

--- a/src/components/FrameContainer.vue
+++ b/src/components/FrameContainer.vue
@@ -6,6 +6,7 @@
         </div>
 
         <!-- keep the tabindex attribute, it is necessary to handle focus properly -->
+        <hr v-if="isCollapsed && frames.length > 0" class="non-empty-collapsed-frame-container-hr">
         <div :id="frameUID" :style="containerStyle" class="container-frames" @click="onFrameContainerClick" tabindex="-1" ref="containerFrames">
             <CaretContainer
                 :frameId="frameId"
@@ -248,9 +249,12 @@ export default Vue.extend({
   margin-left: 4px; // 2px in place of the button border + 2px in place of the button inline padding 
 }
 
+.container-frames, .non-empty-collapsed-frame-container-hr {
+    margin-left: 10px; // 1px less than for the right margin to make the rendering neat
+    margin-right: 11px;
+}
+
 .container-frames {
-    margin-left: 14px; // 1px less than for the right margin to wake the rendering neat
-    margin-right: 15px;
     border-radius: 8px;
     border: 1px solid #B4B4B4;
     outline: none;

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -200,7 +200,7 @@ import { watch } from "@vue/composition-api";
 import { cloneDeep } from "lodash";
 import App from "@/App.vue";
 import appPackageJson from "@/../package.json";
-import { getAboveFrameCaretPosition } from "@/helpers/storeMethods";
+import { getAboveFrameCaretPosition, getFrameSectionIdFromFrameId } from "@/helpers/storeMethods";
 import { getLocaleBuildDate } from "@/main";
 import scssVars from "@/assets/style/_export.module.scss";
 
@@ -1157,38 +1157,49 @@ export default Vue.extend({
                     const isFullIndex = ((this.currentErrorNavIndex % 1) == 0);
                     this.currentErrorNavIndex += (((toNext) ? 1 : -1) / ((isFullIndex) ? 1 : 2));
                     const errorElement = getEditorCodeErrorsHTMLElements()[this.currentErrorNavIndex];
+                    // Make sure that getting to an error will result opening the container frame container (section) if it was collapsed
+                    const isErrorOnFrame = isIdAFrameId(errorElement.id);
+                    const erroneousFrameId = (isErrorOnFrame) 
+                        ? parseFrameUID(errorElement.id) 
+                        : ((isElementEditableLabelSlotInput(errorElement)) 
+                            ? parseLabelSlotUID(errorElement.id).frameId
+                            : parseFrameHeaderUID(errorElement.id));
+                    this.appStore.frameObjects[getFrameSectionIdFromFrameId(erroneousFrameId)].isCollapsed = false;
+                     
                     // The error can be in a slot or it can be for a whole frame. By convention, the location for a frame error is the caret above it.
                     // For errors in a slot: we focus on the slot of the error -- if the erroneous HTML is a slot, we just give it focus. If the error is at the frame scope
                     // we put the focus in the first slot that is editable.
-                    if(isIdAFrameId(errorElement.id)){
+                    this.$nextTick(() => {
+                        if(isErrorOnFrame){
                         // Error on a whole frame - the error message will be on the header so we need to focus it to trigger the popup.
-                        if(this.appStore.isEditing) {
-                            this.appStore.isEditing = false;
-                            this.appStore.setSlotTextCursors(undefined, undefined);
-                            document.getSelection()?.removeAllRanges(); 
-                        }
-                        const caretPosAboveFrame = getAboveFrameCaretPosition(parseFrameUID(errorElement.id));
-                        this.appStore.setCurrentFrame({id: caretPosAboveFrame.frameId, caretPosition: caretPosAboveFrame.caretPosition as CaretPosition});
-                        document.getElementById(getFrameHeaderUID(parseFrameUID(errorElement.id)))?.focus();
-                    }
-                    else{
-                        // Error on a slot
-                        const errorSlotInfos: SlotCoreInfos = (isElementEditableLabelSlotInput(errorElement))
-                            ? parseLabelSlotUID(errorElement.id)
-                            : {frameId: parseFrameHeaderUID(errorElement.id), labelSlotsIndex: 0, slotId: "0", slotType: SlotType.code};
-                        const errorSlotCursorInfos: SlotCursorInfos = {slotInfos: errorSlotInfos, cursorPos: 0}; 
-                        this.appStore.setSlotTextCursors(errorSlotCursorInfos, errorSlotCursorInfos);
-                        setDocumentSelection(errorSlotCursorInfos, errorSlotCursorInfos);  
-                        // It's necessary to programmatically click the slot we gave focus to, so we can toggle the edition mode event chain
-                        if(isElementUIDFrameHeader(errorElement.id)){
-                            document.getElementById(getLabelSlotUID(errorSlotInfos))?.click();
+                            if(this.appStore.isEditing) {
+                                this.appStore.isEditing = false;
+                                this.appStore.setSlotTextCursors(undefined, undefined);
+                                document.getSelection()?.removeAllRanges(); 
+                            }
+                            const caretPosAboveFrame = getAboveFrameCaretPosition(parseFrameUID(errorElement.id));
+                            this.appStore.setCurrentFrame({id: caretPosAboveFrame.frameId, caretPosition: caretPosAboveFrame.caretPosition as CaretPosition});
+                            document.getElementById(getFrameHeaderUID(parseFrameUID(errorElement.id)))?.focus();
                         }
                         else{
-                            errorElement.click();
+                        // Error on a slot
+                            const errorSlotInfos: SlotCoreInfos = (isElementEditableLabelSlotInput(errorElement))
+                                ? parseLabelSlotUID(errorElement.id)
+                                : {frameId: parseFrameHeaderUID(errorElement.id), labelSlotsIndex: 0, slotId: "0", slotType: SlotType.code};
+                            const errorSlotCursorInfos: SlotCursorInfos = {slotInfos: errorSlotInfos, cursorPos: 0}; 
+                            this.appStore.setSlotTextCursors(errorSlotCursorInfos, errorSlotCursorInfos);
+                            setDocumentSelection(errorSlotCursorInfos, errorSlotCursorInfos);  
+                            // It's necessary to programmatically click the slot we gave focus to, so we can toggle the edition mode event chain
+                            if(isElementUIDFrameHeader(errorElement.id)){
+                                document.getElementById(getLabelSlotUID(errorSlotInfos))?.click();
+                            }
+                            else{
+                                errorElement.click();
+                            }
                         }
-                    }
                    
-                    this.navigateToErrorRequested = false;
+                        this.navigateToErrorRequested = false;
+                    });
                 });
             }     
         },

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1182,7 +1182,7 @@ export default Vue.extend({
                             document.getElementById(getFrameHeaderUID(parseFrameUID(errorElement.id)))?.focus();
                         }
                         else{
-                        // Error on a slot
+                            // Error on a slot
                             const errorSlotInfos: SlotCoreInfos = (isElementEditableLabelSlotInput(errorElement))
                                 ? parseLabelSlotUID(errorElement.id)
                                 : {frameId: parseFrameHeaderUID(errorElement.id), labelSlotsIndex: 0, slotId: "0", slotType: SlotType.code};

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -561,7 +561,7 @@ export default Vue.extend({
         },
 
         reachFirstError(): void {
-            this.$nextTick(() => {
+            setTimeout(() => {
                 // We should get only the run time error here, or at least 1 precompiled error
                 // but for sanity check, we make sure it's still there
                 const errors = getEditorCodeErrorsHTMLElements();
@@ -570,7 +570,7 @@ export default Vue.extend({
                     (this.$root.$children[0].$refs[getMenuLeftPaneUID()] as InstanceType<typeof Menu>).currentErrorNavIndex = -1; 
                     (this.$root.$children[0].$refs[getMenuLeftPaneUID()] as InstanceType<typeof Menu>).goToError(null, true);
                 }
-            });
+            }, 200);
         },
 
         clear(): void {

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -702,7 +702,9 @@ export const isContainedInFrame = function (currFrameId: number, caretPosition: 
 
 // Instead of calculating the available caret positions through the store (where the frameObjects object is hard to use for this)
 // We get the available caret positions through the DOM, where they are all present.
-export const getAvailableNavigationPositions = function(): NavigationPosition[] {
+// If showIsInCollapsedFrameContainer is set to true, we check that the frame container (section) containing the cursor is not collapsed 
+// and add the corresponding information in the results (we do that optionally as it calls a recursive method).
+export const getAvailableNavigationPositions = function(showIsInCollapsedFrameContainer?: boolean): NavigationPosition[] {
     // We start by getting from the DOM all the available caret and editable slot positions 
     // (slots of "code" type slots, e.g. not operators -- won't appear in allCaretDOMPositions)
     const allCaretDOMpositions = document.getElementsByClassName(scssVars.navigationPositionClassName);
@@ -724,8 +726,9 @@ export const getAvailableNavigationPositions = function(): NavigationPosition[] 
         return {
             frameId: (frameIdMatch != null) ? parseInt(frameIdMatch[0]) : -100, // need to check the match isn't null for TS, but it should NOT be.
             isSlotNavigationPosition: isSlotNavigationPosition, 
-            ...positionObjIdentifier,            
-        };
+            ...positionObjIdentifier,
+            isInCollapsedFrameContainer: (showIsInCollapsedFrameContainer) ? (useStore().frameObjects[getFrameSectionIdFromFrameId(parseInt(frameIdMatch?.[0]??"-100"))].isCollapsed) : undefined,            
+        } as NavigationPosition;
     }).filter((navigationPosition) => useStore().frameObjects[navigationPosition.frameId] && !(navigationPosition.isSlotNavigationPosition && useStore().frameObjects[navigationPosition.frameId].isDisabled)) as NavigationPosition[]; 
 };
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,7 +2,7 @@ import Vue from "vue";
 import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot, StrypePEALayoutMode, SaveRequestReason, RootContainerFrameDefinition } from "@/types/types";
 import { getObjectPropertiesDifferences, getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
-import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
+import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getFrameSectionIdFromFrameId, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
 import { AppPlatform, AppVersion, vm } from "@/main";
 import initialStates from "@/store/initial-states";
 import { defineStore } from "pinia";
@@ -1236,6 +1236,12 @@ export const useStore = defineStore("app", {
                     newState[property]
                 );
             } );
+
+            // The frame cursor cannot be left inside a collapsed frame container (section),
+            // however, for compatibility with project saved under the old behaviour (which allowed the situation),
+            // we explicitly check the frame container (section) containing the current frame cursor is expanded
+            const currentPositionFrameContainerId = getFrameSectionIdFromFrameId(this.currentFrame.id);
+            this.frameObjects[currentPositionFrameContainerId].isCollapsed = false;
 
             this.clearNoneFrameRelatedState();
         },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1502,6 +1502,10 @@ export const useStore = defineStore("app", {
                     this.focusSlotCursorInfos = undefined;
                 }
 
+                // As we will show the frame cursor that is potentiallly inside a collapsed frame container, 
+                // we make sure we set that frame container expanded to ensure the changes visibility
+                this.frameObjects[getFrameSectionIdFromFrameId(this.currentFrame.id)].isCollapsed = false;
+
                 // Just like for saveStateChanges(), we need to simulate some dummy changes so that differences between
                 // the stateBeforeChanges and the current state regarding positioning and editing are all reflected properly
                 // (we do not know where we'll be when undo/redo is invoked, so we need to make as if changes of positionning occurred)

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot, StrypePEALayoutMode, SaveRequestReason } from "@/types/types";
+import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot, StrypePEALayoutMode, SaveRequestReason, RootContainerFrameDefinition } from "@/types/types";
 import { getObjectPropertiesDifferences, getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
 import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
@@ -242,6 +242,10 @@ export const useStore = defineStore("app", {
             // In this method, we check if frames can be added below the specified (disabled) frame.
             // Note: if we are in a joint structure, being below the (last) joint frame (i.e. "else" is seen as being below the root (i.e. "if") as there is no "below" a joint frame)
             return !state.frameObjects[state.frameObjects[frameId].parentId].isDisabled;
+        },
+
+        getRootFrameContainerId: (state) => {
+            return Object.values(state.frameObjects).filter((frame: FrameObject) => frame.frameType.type === RootContainerFrameDefinition.type)[0].id;
         },
         
         getMainCodeFrameContainerId: (state) => {
@@ -1221,14 +1225,6 @@ export const useStore = defineStore("app", {
                 topLevelCopiedFrames
             );
 
-        },
-
-        setCaretVisibility(payload: {frameId: number; caretVisibility: CaretPosition}) {
-            Vue.set(
-                this.frameObjects[payload.frameId],
-                "caretVisibility",
-                payload.caretVisibility
-            );
         },
 
         updateState(newState: Record<string, unknown>){

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -249,6 +249,7 @@ export interface NavigationPosition {
     labelSlotsIndex?: number;
     slotId?: string;
     slotType?: SlotType;
+    isInCollapsedFrameContainer?: boolean;
 }
 export interface AddFrameCommandDef {
     type: FramesDefinitions;


### PR DESCRIPTION
In answer to bug #269, we have decided to remove the expand/collapse toggle from "My code" section, and also show something in the interface when a non-empty frame container was collapsed. Both changes are illustrated here (imports are empty, definitions are not):
![image](https://github.com/user-attachments/assets/57e1ad5b-c5b6-4348-b01a-ad7143c56701)


With this change I have also reduced the space around the expand/collapse icons (and set a consistent size for all browsers). 

In this PR also:
- fix a bug: ensure that when a frame is collapsed and contains the frame cursor, the frame cursor gets pushed to the next available frame container
- fix a bug with clicking near a collapsed frame container: the frame cursor would get inside, but the frame container would not expand,
- fix a bug with same problem as above but for undo/redo
- fix a bug with same problem as above but for navigating an error located inside collapsed frame container,
- fix a bug with drop positions handling during drag and drop, when a frame container was collapsed,
- add a feature for hovering long enough a collapsed frame container during D&D would expand that frame container and allow showing drop positions
