### PR TITLE
Add a spinner inside the share project's dialog "OK" button

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -80,7 +80,7 @@
             <!-- category: export -->
             <!-- share project -->
             <a :id="shareProjectLinkId" v-show="showMenu" :class="{['strype-menu-link ' + scssVars.strypeMenuItemClassName]: true, disabled: !canShareProject}" :title="$t((isSyncingToGoogleDrive)?'':'appMenu.needSaveShareProj')" @click="onShareProjectClick">{{$t('appMenu.shareProject')}}<span class="strype-menu-kb-shortcut">{{shareProjectKBShortcut}}</span></a>
-            <ModalDlg :dlgId="shareProjectModalDlgId" :okCustomTitle="$t('buttonLabel.copyLink')" :okDisabled="isSharingLinkGenerationPending" 
+            <ModalDlg :dlgId="shareProjectModalDlgId" :okCustomTitle="$t('buttonLabel.copyLink')" :okDisabled="isSharingLinkGenerationPending" :useLoadingOK="isSharingLinkGenerationPending" 
                 :dlgTitle="$t('appMessage.createShareProjectLink')" :elementToFocusId="shareGDProjectPublicRadioBtnId">
                         <div>
                             <span class="share-mode-buttons-container-title">{{$i18n.t('appMessage.shareProjectModeLabel')}}</span>

--- a/src/components/ModalDlg.vue
+++ b/src/components/ModalDlg.vue
@@ -3,8 +3,14 @@
     <b-modal no-close-on-backdrop :hide-header-close="!showCloseBtn" :id="dlgId" :title="dlgTitle" :ok-only="okOnly" 
         :ok-title="okTitle" :ok-disabled="okDisabled" :cancel-title="cancelTitle" :size="size" :auto-focus-button="autoFocusButton">
         <slot/>
+        <!-- if we use a loading OK, we assume ONLY the OK button is customised and use the default cancel/hide buttons of the modal -->
+        <template v-if="useLoadingOK" #modal-ok>
+            <b-spinner label="Spinning" small></b-spinner>
+            <span class="modal-spin-ok-btn-span">{{ okTitle }}</span>
+        </template>
+        <!-- if we are not using a loading OK, we entirely customise the modal footer -->
         <!-- the footer part is entirely optional if other buttons than the default OK/Cancel or Yes/No are required -->
-        <template v-if="!hideDlgBtns" #modal-footer="{ok, cancel, hide}">
+        <template v-else-if="!hideDlgBtns" #modal-footer="{ok, cancel, hide}">
             <slot name="modal-footer-content" :ok="ok" :cancel="cancel" :hide="hide"/>
         </template>
         <template v-else #modal-footer>
@@ -29,6 +35,7 @@ export default Vue.extend({
         okOnly: Boolean,
         okCustomTitle: String,
         okDisabled: Boolean, // this is meant as a TEMPORARY disable, for example when async methods are called in between
+        useLoadingOK: Boolean, // when we want to include a progress inside a OK button. Assumed "Cancel" and "Hide" are used with OK.
         cancelCustomTitle: String,
         hideDlgBtns: Boolean,
         showCloseBtn: Boolean,     
@@ -98,4 +105,7 @@ export default Vue.extend({
 </script>
 
 <style lang="scss">
+.modal-spin-ok-btn-span {
+    margin-left: 5px;
+}
 </style>


### PR DESCRIPTION
Based on what we said during the meeting, this PR is for adding the spinner in the "OK" button of the share project dialog.
![image](https://github.com/user-attachments/assets/259496cb-6351-42a0-8941-6bdb3ab60f75)
