### PR TITLE
Added some bug fixing to the folding revamp branch

### DIFF
--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2252,6 +2252,11 @@ export const useStore = defineStore("app", {
        
                 // The new caret
                 this.currentFrame.caretPosition = nextPosition.caretPosition as CaretPosition;
+
+                // Only frame containers (sections) are collapsable, so we don't need to check if a destination frame itself is collapsed,
+                // but we do need to check if the target container is - and expand it if needed.
+                const containerId = getFrameSectionIdFromFrameId(nextPosition.frameId);
+                this.frameObjects[containerId].isCollapsed = false;
                 
                 // And since we just left a frame, we check errors
                 checkCodeErrors();             

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -824,21 +824,10 @@ export const useStore = defineStore("app", {
                 nextCaret.caretPosition
             );
 
-            const nextFrameObject = this.frameObjects[nextCaret.id];
-            if("isCollapsed" in nextFrameObject ) {
-                Vue.set(
-                    nextFrameObject,
-                    "isCollapsed",
-                    false
-                );
-            }
-            else if("isCollapsed" in this.frameObjects[nextFrameObject.parentId]){
-                Vue.set(
-                    this.frameObjects[nextFrameObject.parentId],
-                    "isCollapsed",
-                    false
-                );
-            }
+            // Only frame containers (sections) are collapsable, so we don't need to check if a destination frame itself is collapsed,
+            // but we do need to check if the target container is - and expand it if needed.
+            const containerId = getFrameSectionIdFromFrameId(nextCaret.id);
+            this.frameObjects[containerId].isCollapsed = false;
         },
 
         setCurrentFrame(newCurrentFrame: CurrentFrame) {


### PR DESCRIPTION
Following Neil's test it turned out that using up/down arrows to get inside a collapsed frame was not _always_ expanding the frame. That was due to a combination of old code that worked with the logic of having **all** frames collapsable (feature we had in a very early version of Strype), and having frame objects containing a value for "isCollapsable" (which was the case on this project - it was working fine with adding a new frame directly because isCollapsed was not set at all on the added frame...)

Also, the feature to open sections on left/right or tab was not implemented and therefore I've added it....
