### PR TITLE
Replace the enter textual symbol in blank line frame add command

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,6 +76,15 @@
 			<path stroke="currentColor" stroke-width="0.25" d="M6.875,5.625 h2.75 a.25,.25 0 0,1 0.25,.25 v.25 a.25,.5 0 0,1 -.25,.25 h-2.75 a.25,.25 0 0,1 -.25,-.25 v-.25 a.25,.25 0 0,1 .25,-.25 Z"/>
 			<path stroke="currentColor" stroke-width="0.25" d="M6.875,7.625 h2.75 a.25,.25 0 0,1 0.25,.25 v.25 a.25,.5 0 0,1 -.25,.25 h-2.75 a.25,.25 0 0,1 -.25,-.25 v-.25 a.25,.25 0 0,1 .25,-.25 Z"/>
 		</symbol>
+    <symbol id="strype-svgicon-enter" viewBox="0 0 64 64">
+      <path 
+      d="M56 16V40C56 41.1 55.1 42 54 42H20V32L8 44L20 56V46H54C57.3 46 60 43.3 60 40V16H56Z"
+      fill="currentColor" 
+      stroke="currentColor" 
+      stroke-linecap="round" 
+      stroke-linejoin="round" 
+      stroke-width="2"/>      
+    </symbol>
 	</svg>
   
   <b id="uncompatibleBrowserSpan" style="display: block; white-space: pre; margin:auto; width: 50%;"></b>

--- a/src/components/AddFrameCommand.vue
+++ b/src/components/AddFrameCommand.vue
@@ -1,6 +1,8 @@
 <template>
     <div :class="{'frame-cmd-container': true, disabled: isPythonExecuting || appStore.isDraggingFrame}" @click="onClick">
-        <button :class="{'frame-cmd-btn': true, 'frame-cmd-btn-large': isLargerShorcutSymbol}" :disabled="isPythonExecuting || appStore.isDraggingFrame">{{ symbol }}</button>
+        <button :class="{'frame-cmd-btn': true, 'frame-cmd-btn-large': isLargerShorcutSymbol}" :disabled="isPythonExecuting || appStore.isDraggingFrame">{{ (!isSVGIconSymbol) ? symbol : '' }}
+            <SVGIcon v-if="isSVGIconSymbol" :name="symbol" customClass="add-frame-command-symbol-svg-icon" />
+        </button>
         <span>{{ description }}</span>
     </div>
 </template>
@@ -14,6 +16,7 @@ import { useStore } from "@/store/store";
 import { mapStores } from "pinia";
 import { findAddCommandFrameType } from "@/helpers/editor";
 import { PythonExecRunningState } from "@/types/types";
+import SVGIcon from "@/components/SVGIcon.vue";
 
 //////////////////////
 //     Component    //
@@ -21,10 +24,15 @@ import { PythonExecRunningState } from "@/types/types";
 export default Vue.extend({
     name: "AddFrameCommand",
 
+    components: {
+        SVGIcon,
+    },
+
     props: {
         type: String, //Type of the Frame Command
         shortcut: String, //the keyboard shortcut to add the frame 
-        symbol: String, //the displayed shortcut in the UI, it can be a symbolic representation
+        symbol: String, //the displayed shortcut in the UI, it can be a symbolic representation or (if specified) a SVGIcon name
+        isSVGIconSymbol: Boolean, // if true, the symbol property is the name of a SVGIcon
         description: String, //the description of the frame
         index: Number, //when more than 1 frame is assigned to a shortcut, the index tells which frame definition should be used
     },
@@ -33,7 +41,7 @@ export default Vue.extend({
         ...mapStores(useStore),
 
         isLargerShorcutSymbol() {
-            return this.symbol.length > 1;
+            return this.symbol.length > 1 && !this.isSVGIconSymbol;
         },
 
         isPythonExecuting(): boolean {
@@ -84,5 +92,11 @@ export default Vue.extend({
 .frame-cmd-btn:disabled {
     cursor: default;
     color: rgb(180, 180, 180);
+}
+
+.add-frame-command-symbol-svg-icon {
+    color: black;
+    width: 10px;
+    height: 12px;
 }
 </style>

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -34,6 +34,7 @@
                                                             ? addFrameCommand[0].symbol
                                                             : addFrameCommand[0].shortcuts[0]
                                                     "
+                                                    :isSVGIconSymbol="addFrameCommand[0].isSVGIconSymbol"
                                                     :description="addFrameCommand[0].description"
                                                     :index="
                                                         addFrameCommand[0].index!==undefined

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -838,7 +838,8 @@ export function generateAllFrameCommandsDefs():void {
             type: getFrameDefType(AllFrameTypesIdentifier.blank),
             description: i18n.t("frame.blank_desc") as string,
             shortcuts: ["\x13"],
-            symbol: "↵",
+            symbol: "enter",
+            isSVGIconSymbol: true,
         }],
         "t": [{
             type: getFrameDefType(AllFrameTypesIdentifier.try),

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -255,7 +255,8 @@ export interface AddFrameCommandDef {
     type: FramesDefinitions;
     description: string; // The label that shown next to the key shortcut button
     shortcuts: [string, string?]; // The keyboard key shortcuts to be used to add a frame (eg "i" for an if frame), usually that's a single value array, but we can have 1 hidden shortcut as well
-    symbol?: string; // The symbol to show in the key shortcut button when the key it's not easily reprenstable (e.g. "⌴" for space)
+    symbol?: string; // The SVGIcon name for a symbol OR a string representation of the symbol to show in the key shortcut button when the key it's not easily representable
+    isSVGIconSymbol?: boolean; // To differenciate between the two situations mentioned above
     index?: number; // the index of frame type when a shortcut matches more than 1 context-distinct frames
 }
 


### PR DESCRIPTION
Using an SVGIcon instead of the text character for the command aforementioned (to avoid differences across browsers)