### PR TITLE
Fix selection-deletion under the new input events scheme

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -61,32 +61,5 @@ export default defineConfig({
             name: "webkit",
             use: { ...devices["Desktop Safari"] },
         },
-
-        /* Test against mobile viewports. */
-        // {
-        //   name: 'Mobile Chrome',
-        //   use: { ...devices['Pixel 5'] },
-        // },
-        // {
-        //   name: 'Mobile Safari',
-        //   use: { ...devices['iPhone 12'] },
-        // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
     ],
-
-    /* Run your local dev server before starting the tests */
-    // webServer: {
-    //   command: 'npm run start',
-    //   url: 'http://127.0.0.1:3000',
-    //   reuseExistingServer: !process.env.CI,
-    // },
 });

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -191,8 +191,8 @@ export default Vue.extend({
             let boldClass = "";               
             switch(this.slotType){
             case SlotType.operator:
-                // For commas, we do not show the operator style but the text style and we allow a right margin
-                codeTypeCSS = (this.code==",") ? scssVars.frameCodeSlotClassName + " slot-right-margin" : scssVars.frameOperatorSlotClassName;
+                // For commas, we add a right margin:
+                codeTypeCSS = scssVars.frameOperatorSlotClassName + ((this.code==",") ? " slot-right-margin" : "");
                 break;
             case SlotType.string:
             case SlotType.openingQuote:

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1068,9 +1068,15 @@ export default Vue.extend({
                                     }
                                 }
                                 // We set the text and let the refactoring turn it into the right bracketed structure:
+                                let sel = this.appStore.mostRecentSelectedText;
+                                // This does have a slight disadvantage that any smart quotes the user meant to insert
+                                // (e.g. inside a string literal) will get mangled, but I think we just live with that:
+                                sel = sel.replace(new RegExp(`[${UIDoubleQuotesCharacters[0]}${UIDoubleQuotesCharacters[1]}]`, "g"), STRING_DOUBLEQUOTE_PLACERHOLDER);
+                                sel = sel.replace(new RegExp(`[${UISingleQuotesCharacters[0]}${UISingleQuotesCharacters[1]}]`, "g"), STRING_SINGLEQUOTE_PLACERHOLDER);
+                                
                                 inputSpanField.textContent = (inputSpanField?.textContent?.substring(0, cursorPos) ?? "") +
                                     ((isStringQuote) ? ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER) : inputString) +
-                                    this.appStore.mostRecentSelectedText +
+                                    sel +
                                     ((isBracket) ? getMatchingBracket(inputString, true) : ((inputString == "\"") ? STRING_DOUBLEQUOTE_PLACERHOLDER : STRING_SINGLEQUOTE_PLACERHOLDER)) +
                                     (inputSpanField?.textContent?.substring(cursorPos + inputString.length) ?? "");
                                 const newSlotCursorInfos: SlotCursorInfos = {slotInfos: this.coreSlotInfo, cursorPos: cursorPos + 1};

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -542,8 +542,10 @@ export default Vue.extend({
         // Event callback equivalent to what would happen for a blur event callback 
         // (the spans don't get focus anymore because the containg editable div grab it)
         onLoseCaret(keepIgnoreKeyEventFlagOn?: boolean): void {
-            // Before anything, we make sure that the current frame still exists.
-            if(this.appStore.frameObjects[this.frameId] != undefined){
+            // Before anything, we make sure that the current frame still exists,
+            // and that our slot still exists.  If we shouldn't exist any more, we should
+            // just do nothing and exit quietly:
+            if(this.appStore.frameObjects[this.frameId] != undefined && retrieveSlotFromSlotInfos(this.coreSlotInfo)){
                 if(!this.debugAC) {
                     this.showAC = false;
                     this.acRequested = false;

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -375,7 +375,7 @@ export default Vue.extend({
             // text change, but also we need to handle the clipboard, as doing events here on keydown results the browser not being able to get the text
             // cut (since the slots have already disappear, and the action for cut seems to be done on the keyup event)
             if ((event.ctrlKey || event.metaKey) && (event.key.toLowerCase() ==  "x" || event.key.toLowerCase() ==  "c")){
-                // There is a selection already, we can directly can set the text in the browser's clipboard here
+                // There is a selection already, we can directly set the text in the browser's clipboard here
                 const selectionText = getEditableSelectionText();
                 if (selectionText) {
                     navigator.clipboard.writeText(selectionText);
@@ -384,10 +384,6 @@ export default Vue.extend({
                         document.getElementById(getLabelSlotUID(this.appStore.focusSlotCursorInfos.slotInfos))
                             ?.dispatchEvent(new KeyboardEvent(event.type, {
                                 key: "Backspace",
-                                altKey: false,
-                                shiftKey: false,
-                                ctrlKey: false,
-                                metaKey: false,
                             }));
                     }
                 }

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -180,7 +180,8 @@ export default Vue.extend({
                 }
 
                 const stateBeforeChanges = cloneDeep(this.appStore.$state);
-                // Must increment refactorCount in case the changed content doesn't trigger a noticeable refactor;
+                // Must increment refactorCount in case the changed content doesn't trigger a noticeable refactor
+                // (i.e. in case it doesn't change the number/type of slots);
                 // we definitely need to completely redo all the slots if Firefox has deleted a bunch of nodes
                 this.refactorCount += 1;
                 this.checkSlotRefactoring("", stateBeforeChanges);

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -160,7 +160,8 @@ export default Vue.extend({
                 // but we must manually restore the selection if the input should have wrapped it,
                 // because our usual mechanisms for detecting this will not work.
                 // We call this a "bad delete".
-                const topLevelDiv = document.getElementById(this.labelSlotsStructDivId);
+                const closestDivId = this.appStore.focusSlotCursorInfos ? ("div_" + getLabelSlotUID(this.appStore.focusSlotCursorInfos.slotInfos)) : this.labelSlotsStructDivId;
+                const closestDiv = document.getElementById(closestDivId);
                 if (event.data) {
                     const openBracket = openBracketCharacters.includes(event.data);
                     if (openBracket || stringQuoteCharacters.includes(event.data)) {
@@ -174,7 +175,7 @@ export default Vue.extend({
                         sel = sel.replace(new RegExp(`[${UIDoubleQuotesCharacters[0]}${UIDoubleQuotesCharacters[1]}]`, "g"), STRING_DOUBLEQUOTE_PLACERHOLDER);
                         sel = sel.replace(new RegExp(`[${UISingleQuotesCharacters[0]}${UISingleQuotesCharacters[1]}]`, "g"), STRING_SINGLEQUOTE_PLACERHOLDER);
                         appendSel.append(sel + closing);
-                        topLevelDiv?.append(appendSel);
+                        closestDiv?.append(appendSel);
                     }
                 }
 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -289,7 +289,8 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
     let foundFocusSpan = false;
     let ignoreSpan = !!delimiters;
     let hasStringSlots = false;
-    // The container and intermediate divs can have relevant text if Firefox has done a "bad delete":
+    // The container and intermediate divs can have relevant text if Firefox has done a "bad delete"
+    // (see comment in LabelSlotsStructure.onInput):
     frameLabelStruct.querySelectorAll("." + scssVars.labelSlotInputClassName + ", ." + scssVars.labelSlotContainerClassName).forEach((spanElement) => {
         // Sometimes div can end up with text content after a selection and overtype (a "bad delete") that seems to happen on Firefox.
         // We only care about these divs if there is text content

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -288,7 +288,28 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
     let foundFocusSpan = false;
     let ignoreSpan = !!delimiters;
     let hasStringSlots = false;
-    frameLabelStruct.querySelectorAll("." + scssVars.labelSlotInputClassName).forEach((spanElement) => {
+    // The container can have relevant text if Firefox has done a "bad delete":
+    frameLabelStruct.querySelectorAll("." + scssVars.labelSlotInputClassName + ", ." + scssVars.labelSlotContainerClassName).forEach((spanElement) => {
+        // Sometimes div can end up with text content after a selection and overtype (a "bad delete") that seems to happen on Firefox.
+        // We only care about these divs if there is text content
+        // directly inside the div (which shouldn't happen except in this situation)
+        if (spanElement.classList.contains(scssVars.labelSlotContainerClassName)) {
+            // Find all the text node direct children:
+            const directTextNodes = Array.from(spanElement.childNodes).filter(
+                (child) => child.nodeType === Node.TEXT_NODE
+            );
+            // Combine the text content from all direct text nodes (should only be one, but no harm doing all):
+            const content = directTextNodes.map((textNode) => textNode.textContent).join("");
+            if (content.length > 0) {
+                // Found this bad input:
+                uiLiteralCode += content;
+                // Also, we know the cursor should be directly after this bad input:
+                foundFocusSpan = true;
+                focusSpanPos += content.length;
+            }
+            return;
+        }
+        
         if(delimiters && (delimiters.startSlotUID == spanElement.id || delimiters.stopSlotUID == spanElement.id)){
             ignoreSpan = !ignoreSpan ;
         } 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -289,7 +289,7 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
     let foundFocusSpan = false;
     let ignoreSpan = !!delimiters;
     let hasStringSlots = false;
-    // The container can have relevant text if Firefox has done a "bad delete":
+    // The container and intermediate divs can have relevant text if Firefox has done a "bad delete":
     frameLabelStruct.querySelectorAll("." + scssVars.labelSlotInputClassName + ", ." + scssVars.labelSlotContainerClassName).forEach((spanElement) => {
         // Sometimes div can end up with text content after a selection and overtype (a "bad delete") that seems to happen on Firefox.
         // We only care about these divs if there is text content
@@ -339,7 +339,7 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
                 uiLiteralCode += (spanElement.textContent??"").replace(/\u200B/g, "");
             }
         
-            if(spanElement.id === currentSlotUID){
+            if(spanElement.id === currentSlotUID && !foundFocusSpan){
                 focusSpanPos += (useStore().focusSlotCursorInfos?.cursorPos??0);     
                 foundFocusSpan = true;
             }

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -211,7 +211,8 @@ export function getTextStartCursorPositionOfHTMLElement(htmlElement: HTMLSpanEle
     const sel = document.getSelection();
     if (sel && sel.rangeCount) {
         const range = sel.getRangeAt(0);
-        if (range.commonAncestorContainer.parentNode == htmlElement) {
+        if (range.commonAncestorContainer.parentNode == htmlElement
+            || range.commonAncestorContainer.parentNode?.parentNode == htmlElement) {
             caretPos = range.startOffset;
         }
     }

--- a/tests/playwright/e2e/structured-expressions-selection.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-selection.spec.ts
@@ -343,6 +343,7 @@ test.describe("Selecting then typing in one slot", () => {
     testSelectionBoth("123456", 2, 4, "-", "{12}-{$56}");
     testSelectionBoth("123456", 2, 4, "e", "{12e$56}");
     testSelectionBoth("123456", 2, 4, ".", "{12.$56}");
+    testSelectionBoth("123456", 0, 6, "(", "{}_({$123456})_{}");
 
     // Turn into a number slot by replacement:
     testSelectionBoth("abc123", 0, 3, "+", "{+$123}");
@@ -367,6 +368,20 @@ test.describe("Selecting then typing in multiple slots", () => {
     testSelectionBoth("123+456", 2,5, "(", "{12}_({$3}+{4})_{56}");
 
     testSelectionBoth("123+456", 2, 5, "\"", "{12}_“$3+4”_{56}");
+    
+    // Select just an operator and overtype:
+    testSelectionBoth("+", 0, 1, "a", "{a$}");
+    testSelectionBoth("+", 0, 1, "(", "{}_({$}+{})_{}");
+
+    // Select string or bracket and overtype:
+    testSelectionBoth("\"abc\"", 0, 5, "z", "{z$}");
+    testSelectionBoth("(abc)", 0, 5, "z", "{z$}");
+    
+    // Select a string and attempt to wrap in a bracket:
+    testSelectionBoth("\"abc\"", 0, 5, "(", "{}_({$}_“abc”_{})_{}");
+    // Select a bracket and attempt to wrap in another bracket:
+    testSelectionBoth("(123)", 0, 5, "(", "{}_({$}_({123})_{})_{}");
+
 });
 
 test.describe("Selecting then deleting in multiple slots", () => {

--- a/tests/playwright/e2e/structured-expressions-selection.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-selection.spec.ts
@@ -348,6 +348,9 @@ test.describe("Selecting then typing in one slot", () => {
     testSelectionBoth("abc123", 0, 3, "+", "{+$123}");
     testSelectionBoth("abc123", 0, 3, "-", "{-$123}");
     testSelectionBoth("abc123", 0, 3, "*", "{}*{$123}");
+
+    testSelectionBoth("abc123", 2, 4, "\"", "{ab}_“$c1”_{23}");
+    testSelectionBoth("abc123", 2, 4, "'", "{ab}_‘$c1’_{23}");
 });
 
 test.describe("Selecting then typing in multiple slots", () => {
@@ -362,11 +365,17 @@ test.describe("Selecting then typing in multiple slots", () => {
     testSelectionBoth("123+456", 2,5, "*", "{12}*{$56}");
     
     testSelectionBoth("123+456", 2,5, "(", "{12}_({$3}+{4})_{56}");
+
+    testSelectionBoth("123+456", 2, 5, "\"", "{12}_“$3+4”_{56}");
 });
 
 test.describe("Selecting then deleting in multiple slots", () => {
     testSelectionBoth("123+456", 2,5, (page) => page.keyboard.press("Delete"), "{12$56}");
     testSelectionBoth("123+456", 2,5, (page) => page.keyboard.press("Backspace"), "{12$56}");
+    
+    // Prevent invalid selections (trying to select from outside brackets to within):
+    testSelection("123+(456)*789", 6, 12, (page) => page.keyboard.press("Backspace"), "{123}+{}_({4$})_{}*{789}");
+    testSelection("123+(456)*789", 6, 2, (page) => page.keyboard.press("Backspace"), "{123}+{}_({$56})_{}*{789}");
 });
 
 test.describe("Selecting then cutting/copying", () => {

--- a/tests/playwright/e2e/structured-expressions-selection.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-selection.spec.ts
@@ -355,12 +355,6 @@ test.describe("Selecting then typing in one slot", () => {
 });
 
 test.describe("Selecting then typing in multiple slots", () => {
-    // Note that because of Cypress not being able to send shift-left/right in a way
-    // that the browser handles to move selection, we are moving our own selection.
-    // Thus some selections are possible (e.g. across brackets) for us to set
-    // that would not be allowed in Strype (e.g. selecting across multiple bracketing levels)
-    // So we just don't make those selections; we can't test that those are banned
-    // programmatically.
     testSelectionBoth("123+456", 2,5, "0", "{120$56}");
     testSelectionBoth("123+456", 2,5, ".", "{12.$56}");
     testSelectionBoth("123+456", 2,5, "*", "{12}*{$56}");

--- a/tests/playwright/e2e/structured-expressions-selection.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-selection.spec.ts
@@ -382,6 +382,12 @@ test.describe("Selecting then typing in multiple slots", () => {
     // Select a bracket and attempt to wrap in another bracket:
     testSelectionBoth("(123)", 0, 5, "(", "{}_({$}_({123})_{})_{}");
 
+    // Select multiple strings:
+    testSelectionBoth("print(\"Hello\"+\"Goodbye\")", 6, 23, "(", "{print}_({}_({$}_“Hello”_{}+{}_“Goodbye”_{})_{})_{}");
+    // Select inside brackets:
+    testSelectionBoth("sum([(1+2),3-4])", 11, 14, "(", "{sum}_({}_[{}_({1}+{2})_{},{}_({$3}-{4})_{}]_{})_{}");
+    // String quote brackets:
+    testSelectionBoth("print((1+2))", 6, 11, "\"", "{print}({}_“$(1+2)”_{})_{}");
 });
 
 test.describe("Selecting then deleting in multiple slots", () => {


### PR DESCRIPTION
This adds some more tests for selection in slots using the new arrangement, and fixes those tests.

It's mainly about Firefox, which can do what I've called a "bad delete" which puts content into the parent div.  So we have to make sure we scan that and deal with it accordingly.  Let me know if the comments are clear enough; happy to write more if needed.

The tests all now pass and I think once this is merged (still into the input-events branch for now) I can bring the input-events branch up to date with main, and we can do a wider test on our test server.