### PR TITLE
Saving the divider's per PEA layout 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,6 +76,15 @@
 			<path stroke="currentColor" stroke-width="0.25" d="M6.875,5.625 h2.75 a.25,.25 0 0,1 0.25,.25 v.25 a.25,.5 0 0,1 -.25,.25 h-2.75 a.25,.25 0 0,1 -.25,-.25 v-.25 a.25,.25 0 0,1 .25,-.25 Z"/>
 			<path stroke="currentColor" stroke-width="0.25" d="M6.875,7.625 h2.75 a.25,.25 0 0,1 0.25,.25 v.25 a.25,.5 0 0,1 -.25,.25 h-2.75 a.25,.25 0 0,1 -.25,-.25 v-.25 a.25,.25 0 0,1 .25,-.25 Z"/>
 		</symbol>
+    <symbol id="strype-svgicon-enter" viewBox="0 0 64 64">
+      <path 
+      d="M56 16V40C56 41.1 55.1 42 54 42H20V32L8 44L20 56V46H54C57.3 46 60 43.3 60 40V16H56Z"
+      fill="currentColor" 
+      stroke="currentColor" 
+      stroke-linecap="round" 
+      stroke-linejoin="round" 
+      stroke-width="2"/>      
+    </symbol>
 	</svg>
   
   <b id="uncompatibleBrowserSpan" style="display: block; white-space: pre; margin:auto; width: 50%;"></b>

--- a/src/components/AddFrameCommand.vue
+++ b/src/components/AddFrameCommand.vue
@@ -1,6 +1,8 @@
 <template>
     <div :class="{'frame-cmd-container': true, disabled: isPythonExecuting || appStore.isDraggingFrame}" @click="onClick">
-        <button :class="{'frame-cmd-btn': true, 'frame-cmd-btn-large': isLargerShorcutSymbol}" :disabled="isPythonExecuting || appStore.isDraggingFrame">{{ symbol }}</button>
+        <button :class="{'frame-cmd-btn': true, 'frame-cmd-btn-large': isLargerShorcutSymbol}" :disabled="isPythonExecuting || appStore.isDraggingFrame">{{ (!isSVGIconSymbol) ? symbol : '' }}
+            <SVGIcon v-if="isSVGIconSymbol" :name="symbol" customClass="add-frame-command-symbol-svg-icon" />
+        </button>
         <span>{{ description }}</span>
     </div>
 </template>
@@ -14,6 +16,7 @@ import { useStore } from "@/store/store";
 import { mapStores } from "pinia";
 import { findAddCommandFrameType } from "@/helpers/editor";
 import { PythonExecRunningState } from "@/types/types";
+import SVGIcon from "@/components/SVGIcon.vue";
 
 //////////////////////
 //     Component    //
@@ -21,10 +24,15 @@ import { PythonExecRunningState } from "@/types/types";
 export default Vue.extend({
     name: "AddFrameCommand",
 
+    components: {
+        SVGIcon,
+    },
+
     props: {
         type: String, //Type of the Frame Command
         shortcut: String, //the keyboard shortcut to add the frame 
-        symbol: String, //the displayed shortcut in the UI, it can be a symbolic representation
+        symbol: String, //the displayed shortcut in the UI, it can be a symbolic representation or (if specified) a SVGIcon name
+        isSVGIconSymbol: Boolean, // if true, the symbol property is the name of a SVGIcon
         description: String, //the description of the frame
         index: Number, //when more than 1 frame is assigned to a shortcut, the index tells which frame definition should be used
     },
@@ -33,7 +41,7 @@ export default Vue.extend({
         ...mapStores(useStore),
 
         isLargerShorcutSymbol() {
-            return this.symbol.length > 1;
+            return this.symbol.length > 1 && !this.isSVGIconSymbol;
         },
 
         isPythonExecuting(): boolean {
@@ -84,5 +92,11 @@ export default Vue.extend({
 .frame-cmd-btn:disabled {
     cursor: default;
     color: rgb(180, 180, 180);
+}
+
+.add-frame-command-symbol-svg-icon {
+    color: black;
+    width: 10px;
+    height: 12px;
 }
 </style>

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -747,6 +747,8 @@ export default Vue.extend({
                             this.commandsSplitterPane2Size = (100 - this.commandSplitterPane1MinSize);      
                             (this.$refs.peaCommandsSplitterPane1Ref as InstanceType<typeof Pane>).$data.style.height = this.commandSplitterPane1MinSize + "%";
                             (this.$refs.peaCommandsSplitterPane2Ref as InstanceType<typeof Pane>).$data.style.height = this.commandsSplitterPane2Size + "%";
+                            // And trigger the Graphics to resize properly
+                            document.getElementById(getPEATabContentContainerDivId())?.dispatchEvent(new CustomEvent(CustomEventTypes.pythonExecAreaSizeChanged));
                         }, 200);                        
                     }     
                 }    

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -89,7 +89,7 @@
 import AddFrameCommand from "@/components/AddFrameCommand.vue";
 import { computeAddFrameCommandContainerSize, CustomEventTypes, getActiveContextMenu, getAddFrameCmdElementUID, getCommandsContainerUID, getCommandsRightPaneContainerId, getCurrentFrameSelectionScope, getEditorMiddleUID, getMenuLeftPaneUID, handleContextMenuKBInteraction, hiddenShorthandFrames, notifyDragEnded } from "@/helpers/editor";
 import { useStore } from "@/store/store";
-import { AddFrameCommandDef, AllFrameTypesIdentifier, CaretPosition, FrameObject, PythonExecRunningState, SelectAllFramesFuncDefScope, StrypePEALayoutMode, StrypeSyncTarget } from "@/types/types";
+import { AddFrameCommandDef, AllFrameTypesIdentifier, CaretPosition, defaultEmptyStrypeLayoutDividerSettings, FrameObject, PythonExecRunningState, SelectAllFramesFuncDefScope, StrypePEALayoutMode, StrypeSyncTarget } from "@/types/types";
 import $ from "jquery";
 import Vue from "vue";
 import browserDetect from "vue-browser-detect-plugin";
@@ -714,8 +714,14 @@ export default Vue.extend({
             // We also save the value in the store. We do not want to set commandsSplitterPane2Size as get/set computed property
             // (and call the appStore change in set()) because we set the value based on other settings (the 4:3 ratio) when PEA is mounted,
             // that value then shouldn't be saved in the store.
-            this.appStore.peaCommandsSplitterPane2Size = this.commandsSplitterPane2Size;
-        },
+            if(this.appStore.peaCommandsSplitterPane2Size != undefined){
+                this.appStore.peaCommandsSplitterPane2Size[this.appStore.peaLayoutMode??StrypePEALayoutMode.tabsCollapsed] = this.commandsSplitterPane2Size;
+            }
+            else {
+                // The tricky case of when the state property has never been set
+                this.appStore.peaCommandsSplitterPane2Size = {...defaultEmptyStrypeLayoutDividerSettings, [this.appStore.peaLayoutMode??StrypePEALayoutMode.tabsCollapsed]: event[1].size};
+            }
+        }, 
 
         setPEACommandsSplitterPanesMinSize() {
             // Called to get the right min sizes of the pea/Commands splitter.

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -34,6 +34,7 @@
                                                             ? addFrameCommand[0].symbol
                                                             : addFrameCommand[0].shortcuts[0]
                                                     "
+                                                    :isSVGIconSymbol="addFrameCommand[0].isSVGIconSymbol"
                                                     :description="addFrameCommand[0].description"
                                                     :index="
                                                         addFrameCommand[0].index!==undefined

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -58,10 +58,11 @@ import { useStore } from "@/store/store";
 import Parser from "@/parser/parser";
 import { execPythonCode } from "@/helpers/execPythonCode";
 import { mapStores } from "pinia";
-import { checkEditorCodeErrors, countEditorCodeErrors, CustomEventTypes, debounceComputeAddFrameCommandContainerSize, getEditorCodeErrorsHTMLElements, getFrameUID, getMenuLeftPaneUID, getPEAComponentRefId, getPEAConsoleId, getPEAControlsDivId, getPEAGraphicsContainerDivId, getPEAGraphicsDivId,  getPEATabContentContainerDivId, hasPrecompiledCodeError, setPythonExecAreaLayoutButtonPos, setPythonExecutionAreaTabsContentMaxHeight } from "@/helpers/editor";
+import { checkEditorCodeErrors, countEditorCodeErrors, CustomEventTypes, debounceComputeAddFrameCommandContainerSize, getEditorCodeErrorsHTMLElements, getFrameUID, getMenuLeftPaneUID, getPEAComponentRefId, getPEAConsoleId, getPEAControlsDivId, getPEAGraphicsContainerDivId, getPEAGraphicsDivId,  getPEATabContentContainerDivId, getStrypeCommandComponentRefId, hasPrecompiledCodeError, setPythonExecAreaLayoutButtonPos, setPythonExecutionAreaTabsContentMaxHeight } from "@/helpers/editor";
 import i18n from "@/i18n";
-import { PythonExecRunningState, StrypePEALayoutData, StrypePEALayoutMode } from "@/types/types";
+import { defaultEmptyStrypeLayoutDividerSettings, PythonExecRunningState, StrypePEALayoutData, StrypePEALayoutMode } from "@/types/types";
 import Menu from "@/components/Menu.vue";
+import CommandsComponent from "@/components/Commands.vue";
 import SVGIcon from "@/components/SVGIcon.vue";
 import {Splitpanes, Pane} from "splitpanes";
 import { debounce } from "lodash";
@@ -271,7 +272,9 @@ export default Vue.extend({
             // The current size (in %) of the splitter's pane 1, we keep this as a variable not directly affected to the splitter's 
             // pane size to maintain visual aspects when layout switches (the actual size may be explicitly changed to 0 or 100
             // depending on the layout mode).
-            return this.appStore.peaSplitViewSplitterPane1Size ?? parseFloat(scssVars.peaSplitViewSplitterPane1SizePercentValue);
+            return (this.appStore.peaSplitViewSplitterPane1Size != undefined && this.appStore.peaLayoutMode != undefined && this.appStore.peaSplitViewSplitterPane1Size[this.appStore.peaLayoutMode] != undefined)
+                ? this.appStore.peaSplitViewSplitterPane1Size[this.appStore.peaLayoutMode] as number
+                : parseFloat(scssVars.peaSplitViewSplitterPane1SizePercentValue);
         },
 
         runCodeButtonIconText(): string {
@@ -318,7 +321,13 @@ export default Vue.extend({
             // Only update the panel size when we are in stacked layout
             if(!this.isTabsLayout){
                 // Save the PEA splitter's pane 1 size with the project (it will update currentSplitterPane1Size by reactivity)
-                this.appStore.peaSplitViewSplitterPane1Size = event[0].size;
+                if(this.appStore.peaSplitViewSplitterPane1Size != undefined){
+                    this.appStore.peaSplitViewSplitterPane1Size[this.appStore.peaLayoutMode??StrypePEALayoutMode.tabsCollapsed] = event[0].size;
+                }
+                else {
+                    // The tricky case of when the state property has never been set
+                    this.appStore.peaSplitViewSplitterPane1Size = {...defaultEmptyStrypeLayoutDividerSettings, [this.appStore.peaLayoutMode??StrypePEALayoutMode.tabsCollapsed]: event[0].size};
+                }
             }
 
             // Notify a resize of the PEA happened
@@ -506,6 +515,14 @@ export default Vue.extend({
                 else{
                     // When the PEA is maximized, we set the max height via styling: this rules over CSS.
                     setPythonExecutionAreaTabsContentMaxHeight();
+                }
+
+                // As now the dividers positions are saved by PEA layout modes, we need to set 
+                // the right position of the divider between the commands and the PEA (in collapsed layouts)
+                if((layoutMode == StrypePEALayoutMode.tabsCollapsed || layoutMode == StrypePEALayoutMode.splitCollapsed)
+                    && this.appStore.peaCommandsSplitterPane2Size && this.appStore.peaCommandsSplitterPane2Size[layoutMode] != undefined){
+                    (this.$root.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).commandsSplitterPane2Size
+                         = this.appStore.peaCommandsSplitterPane2Size[layoutMode] as number;
                 }
 
                 // If we are switching to the split view (or between split views) and graphics exists, it can add scrolling bars which then mess up the rendering.

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -838,7 +838,8 @@ export function generateAllFrameCommandsDefs():void {
             type: getFrameDefType(AllFrameTypesIdentifier.blank),
             description: i18n.t("frame.blank_desc") as string,
             shortcuts: ["\x13"],
-            symbol: "↵",
+            symbol: "enter",
+            isSVGIconSymbol: true,
         }],
         "t": [{
             type: getFrameDefType(AllFrameTypesIdentifier.try),

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot, StrypePEALayoutMode, SaveRequestReason, RootContainerFrameDefinition } from "@/types/types";
+import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, EditableSlotReachInfos, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot, StrypePEALayoutMode, SaveRequestReason, RootContainerFrameDefinition, StrypeLayoutDividerSettings } from "@/types/types";
 import { getObjectPropertiesDifferences, getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
 import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getFrameSectionIdFromFrameId, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
@@ -81,21 +81,22 @@ export const useStore = defineStore("app", {
             isEditing: false,
 
             /* These state properties are for saving the layout of the UI.
-             * They are initally set to UNDEFINED so we can work out which layout changes the users have done.
+             * They are initally set to UNDEFINED so we can work out which layout changes the users have done ("delete" needs optional properties).
              * We always apply the changes after getting back to the default layout (when a file is loaded after first time).
+             * All the splitters' size properties are expressed PER layout so users can have different configurations for each layout.
              ***/ 
-            editorCommandsSplitterPane2Size: undefined as number | undefined, // same as above for the divider between the editor and the commands (pane 2), default is 34%
+            editorCommandsSplitterPane2Size: undefined as StrypeLayoutDividerSettings | undefined, // same as above for the divider between the editor and the commands (pane 2), default is 34%
             
             /* IFTRUE_isPython */
             peaLayoutMode:  undefined as StrypePEALayoutMode | undefined, // the project layout view is saved with the store
             
             // The size of the commands/PEA splitter pane 2 size is saved with the store.
             // We can't have a default value as the default size will depend on the viewport (to have the PEA in 4:3 ratio)
-            peaCommandsSplitterPane2Size: undefined as number | undefined, 
+            peaCommandsSplitterPane2Size: undefined as StrypeLayoutDividerSettings | undefined, 
 
-            peaSplitViewSplitterPane1Size: undefined as number | undefined, // same as above for the split view PEA divider (pane 1), this time a default value is 50%
+            peaSplitViewSplitterPane1Size: undefined as StrypeLayoutDividerSettings | undefined, // same as above for the split view PEA divider (pane 1), this time a default value is 50%
             
-            peaExpandedSplitterPane2Size: undefined as number | undefined, // same as above for the expanded view divider (pane 2), this time a default value is 50%
+            peaExpandedSplitterPane2Size: undefined as StrypeLayoutDividerSettings | undefined, // same as above for the expanded view divider (pane 2), this time a default value is 50%
             /* FITRUE_isPython */
             /* end properties for saving layout */
 
@@ -2443,11 +2444,11 @@ export const useStore = defineStore("app", {
                         let chainedTimeOuts = 400;
                         // Now we can restore the backuped properties of the new state related to the layout.
                         // If any of the properties for layout changes was updated, the PEA 4:3 ratio isn't any longer meaningful.
-                        if(newEditorCommandsSplitterPane2Size){
+                        if(newEditorCommandsSplitterPane2Size != undefined && newEditorCommandsSplitterPane2Size[newPEALayout??StrypePEALayoutMode.tabsCollapsed] != undefined){
                             this.editorCommandsSplitterPane2Size = newEditorCommandsSplitterPane2Size;
                             // If this splitter was changed, the PEA needs to be resized once the splitter has updated
                             setTimeout(() => {
-                                (vm.$children[0] as InstanceType<typeof AppComponent>).onStrypeCommandsSplitPaneResize({1: {size: newEditorCommandsSplitterPane2Size}});
+                                (vm.$children[0] as InstanceType<typeof AppComponent>).onStrypeCommandsSplitPaneResize({1: {size: newEditorCommandsSplitterPane2Size[newPEALayout??StrypePEALayoutMode.tabsCollapsed]}}, newPEALayout);
                             }, chainedTimeOuts);
                         }
                         if(newPEALayout){
@@ -2460,21 +2461,26 @@ export const useStore = defineStore("app", {
                         if(newPEACommandsSplitterPane2Size){
                             this.peaCommandsSplitterPane2Size = newPEACommandsSplitterPane2Size;
                             // If this splitter was changed, the PEA needs to be resized once the splitter has updated
-                            setTimeout(() => {
-                                (vm.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).onCommandsSplitterResize({1: {size: newPEACommandsSplitterPane2Size}});
-                            }, (chainedTimeOuts += 200));
+                            if(newPEALayout != undefined && newPEACommandsSplitterPane2Size[newPEALayout] != undefined) {
+                                setTimeout(() => {
+                                    (vm.$children[0].$refs[getStrypeCommandComponentRefId()] as InstanceType<typeof CommandsComponent>).onCommandsSplitterResize({1: {size: newPEACommandsSplitterPane2Size[newPEALayout]}});
+                                }, (chainedTimeOuts += 200));
+                            }
                         }
         
-                        if(newPEASplitViewSplitterPane1Size){
+                        if(newPEASplitViewSplitterPane1Size != undefined && newPEALayout != undefined && newPEASplitViewSplitterPane1Size[newPEALayout] != undefined){
                             this.peaSplitViewSplitterPane1Size = newPEASplitViewSplitterPane1Size;
                         }
         
-                        if(newPEAExpandedSplitterPane2Size) {
+                        if(newPEAExpandedSplitterPane2Size != undefined) {
                             this.peaExpandedSplitterPane2Size = newPEAExpandedSplitterPane2Size;
                             // If this splitter was changed, the PEA needs to be resized once the splitter has updated
-                            setTimeout(() => {
-                                (vm.$children[0] as InstanceType<typeof AppComponent>).onExpandedPythonExecAreaSplitPaneResize({1: {size: newPEAExpandedSplitterPane2Size}});
-                            }, (chainedTimeOuts += 200));
+                            
+                            if(newPEALayout != undefined && newPEAExpandedSplitterPane2Size[newPEALayout] != undefined) { 
+                                setTimeout(() => {
+                                    (vm.$children[0] as InstanceType<typeof AppComponent>).onExpandedPythonExecAreaSplitPaneResize({1: {size: newPEAExpandedSplitterPane2Size[newPEALayout]}});
+                                }, (chainedTimeOuts += 200));
+                            }
                         }
                         
                         // We can resolve the promise when all the changes for the UI have been done

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -255,7 +255,8 @@ export interface AddFrameCommandDef {
     type: FramesDefinitions;
     description: string; // The label that shown next to the key shortcut button
     shortcuts: [string, string?]; // The keyboard key shortcuts to be used to add a frame (eg "i" for an if frame), usually that's a single value array, but we can have 1 hidden shortcut as well
-    symbol?: string; // The symbol to show in the key shortcut button when the key it's not easily reprenstable (e.g. "⌴" for space)
+    symbol?: string; // The SVGIcon name for a symbol OR a string representation of the symbol to show in the key shortcut button when the key it's not easily representable
+    isSVGIconSymbol?: boolean; // To differenciate between the two situations mentioned above
     index?: number; // the index of frame type when a shortcut matches more than 1 context-distinct frames
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1117,7 +1117,7 @@ export interface Locale {
 }
 
 export enum StrypePEALayoutMode {
-    tabsCollapsed, // the default layout mode where PEA is collapsed and using tabs for console/graphics
+    tabsCollapsed, // the default layout mode where PEA is collapsed and using tabs for console/graphics (and selected mode for the micro:bit version)
     tabsExpanded, // the layout mode where PEA is expanded and using tabs for console/graphics
     splitCollapsed, // the layout mode where PEA is collapsed and console/graphics windows are (horizontally) split
     splitExpanded, // the layout mode where PEA is expanded and console/graphics windows are (vertically) split
@@ -1126,3 +1126,17 @@ export interface StrypePEALayoutData {
     mode: StrypePEALayoutMode, // The layout view for the PEA in Strype, see related enum
     iconName: string, // the name of the icon to be retrieved from our SVG icons + localisation key name (makes it simpler to have one property!)
 }
+
+// Typescript doesn't allow to declare types with an index signature parameter being something else than number or string or symbol.
+// So to be able to still use types, we can use this trick that will use the values of the enum we want to use for the index signature type.
+// This type however requires all values of the enum to be used as indexes - so we need to also allow undefined values for the indexes.
+export type StrypeLayoutDividerSettings = {
+    [layout in StrypePEALayoutMode]: number | undefined;
+};
+
+export const defaultEmptyStrypeLayoutDividerSettings: StrypeLayoutDividerSettings = {
+    "0": undefined,
+    "1": undefined,
+    "2": undefined,
+    "3": undefined,
+};


### PR DESCRIPTION
This PR adds functionality to save the dividers' positions _per layout_ rather than for the whole UI as it was previously implemented.