### PR TITLE
State handling at start

### DIFF
--- a/src/store/initial-states.ts
+++ b/src/store/initial-states.ts
@@ -35,6 +35,13 @@ const initialStates: StateAppObjects = {
         showKeystroke: false,
         nextAvailableId: 18,
     },
+    
+    "initialEmptyState": {
+        debugging: false,
+        initialState: emptyState,
+        showKeystroke: false,
+        nextAvailableId: 1,
+    },
 
     "initialPythonState": {
         debugging: false,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1316,7 +1316,6 @@ export const useStore = defineStore("app", {
         },
 
         saveStateChanges(previousState: (typeof this.$state)) {
-            console.log("in savestatchanged");
             this.isEditorContentModified = true;
             // Saves the state changes in diffPreviousState.
             // We do not simply save the differences between the state and the previous state, because when undo/redo will be invoked, we cannot know what will be 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,7 +6,7 @@ import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evalua
 import { AppPlatform, AppVersion, vm } from "@/main";
 import initialStates from "@/store/initial-states";
 import { defineStore } from "pinia";
-import { CustomEventTypes, generateAllFrameCommandsDefs, getAddCommandsDefs, getFocusedEditableSlotTextSelectionStartEnd, getLabelSlotUID, isLabelSlotEditable, setDocumentSelection, parseCodeLiteral, undoMaxSteps, getSelectionCursorsComparisonValue, getEditorMiddleUID, getFrameHeaderUID, getImportDiffVersionModalDlgId, checkEditorCodeErrors, countEditorCodeErrors, getCaretUID, getStrypeCommandComponentRefId, getCaretContainerUID, isCaretContainerElement } from "@/helpers/editor";
+import { CustomEventTypes, generateAllFrameCommandsDefs, getAddCommandsDefs, getFocusedEditableSlotTextSelectionStartEnd, getLabelSlotUID, isLabelSlotEditable, setDocumentSelection, parseCodeLiteral, undoMaxSteps, getSelectionCursorsComparisonValue, getEditorMiddleUID, getFrameHeaderUID, getImportDiffVersionModalDlgId, checkEditorCodeErrors, countEditorCodeErrors, getCaretUID, getStrypeCommandComponentRefId, getCaretContainerUID, isCaretContainerElement, AutoSaveKeyNames } from "@/helpers/editor";
 import { DAPWrapper } from "@/helpers/partial-flashing";
 import LZString from "lz-string";
 import { getAPIItemTextualDescriptions } from "@/helpers/microbitAPIDiscovery";
@@ -22,17 +22,42 @@ import CommandsComponent from "@/components/Commands.vue";
 import { actOnTurtleImport, getPEAComponentRefId } from "@/helpers/editor";
 /* FITRUE_isPython */
 
-let initialState: StateAppObject = initialStates["initialPythonState"];
-/* IFTRUE_isMicrobit */
-initialState = initialStates["initialMicrobitState"];
-/* FITRUE_isMicrobit */
+function getState(): StateAppObject {
+    // If we have a state available in the local (browser's) storage, we strip off the frame contents
+    // from the default state, for a smoother visual rendering. Note that App.vue is responsible for
+    // loading the local state later. Here, we only check something exists in the local storage.
+    let isExistingStateLocated = false;
+    let returnedState;
+    if(typeof(Storage) !== "undefined") {
+        let storageString = AutoSaveKeyNames.pythonEditorState;
+        /* IFTRUE_isMicrobit */
+        storageString = AutoSaveKeyNames.mbEditor;
+        /* FITRUE_isMicrobit */
+        const savedState = localStorage.getItem(storageString);
+        if(savedState) {
+            isExistingStateLocated = true;
+            returnedState = initialStates["initialEmptyState"];        
+        }
+    }
+    
+    if(!isExistingStateLocated) {
+        /* IFTRUE_isPython */
+        returnedState = initialStates["initialPythonState"];
+        /* FITRUE_isPython */
+        /* IFTRUE_isMicrobit */
+        returnedState = initialStates["initialMicrobitState"];
+        /* FITRUE_isMicrobit */
+    }
+    return (returnedState as StateAppObject);
+}
+
+const initialState = getState();
 
 // These are deliberately held outside the store because:
 // (a) we used to blank them on page load anyway
 // (b) there was a bug where sometimes we could end up diffing-the-diffs which led to quadratic memory and CPU consumption.
 const diffToPreviousState : ObjectPropertyDiff[][] = [];
 const diffToNextState: ObjectPropertyDiff[][] = [];
-
 
 export const useStore = defineStore("app", {
     state: () => {
@@ -1291,6 +1316,7 @@ export const useStore = defineStore("app", {
         },
 
         saveStateChanges(previousState: (typeof this.$state)) {
+            console.log("in savestatchanged");
             this.isEditorContentModified = true;
             // Saves the state changes in diffPreviousState.
             // We do not simply save the differences between the state and the previous state, because when undo/redo will be invoked, we cannot know what will be 


### PR DESCRIPTION
In order to make the appearance of a saved state loading (from the browser storage) better when opening Strype, the default state with pre-existing frames is _only_ loaded if there is no existing saved state in the browser's storage.
(Note that there is _still_ a initial state being loaded, but it doesn't contain any other frames but the root and sections.)