### PR TITLE
Auto-close error popups

### DIFF
--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -48,7 +48,7 @@
                 :content="errorPopupContent"
                 :custom-class="(hasRuntimeError || hasParsingError) ? 'error-popover modified-title-popover': 'error-popover'"
                 placement="left"
-                @shown="setAutoCloseErroPopup"
+                @shown="setAutoCloseErrorPopup"
                 @hide="clearAutoCloseErrorPopupHandle"
             >
             </b-popover>
@@ -1127,16 +1127,16 @@ export default Vue.extend({
         },
 
         clearAutoCloseErrorPopupHandle(event: BvEvent) {
-            const closeErrorPupHandleId = document.getElementById(event.componentId??"undef" )?.getAttribute("popup-close-tiemouthandle");
+            const closeErrorPupHandleId = document.getElementById(event.componentId??"undef" )?.getAttribute("popup-close-timeouthandle");
             if(closeErrorPupHandleId){
                 clearTimeout(this.currentErrorPopupCloseTimeoutHandles[closeErrorPupHandleId]);
                 delete this.currentErrorPopupCloseTimeoutHandles[closeErrorPupHandleId];
             }
         },
 
-        setAutoCloseErroPopup(event: BvEvent){
+        setAutoCloseErrorPopup(event: BvEvent){
             this.currentErrorPopupInstanceCounter++;
-            document.getElementById(event.componentId??"undef")?.setAttribute("popup-close-tiemouthandle", this.currentErrorPopupInstanceCounter.toString());
+            document.getElementById(event.componentId??"undef")?.setAttribute("popup-close-timeouthandle", this.currentErrorPopupInstanceCounter.toString());
             this.currentErrorPopupCloseTimeoutHandles[this.currentErrorPopupInstanceCounter] = setTimeout(() => {
                 // We close the popup programmatically when no explicit closing action occurred from the user.
                 // The closing timeout will be called on a hanging popup and not on an explicitly closed popup

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -48,6 +48,8 @@
                 :content="errorPopupContent"
                 :custom-class="(hasRuntimeError || hasParsingError) ? 'error-popover modified-title-popover': 'error-popover'"
                 placement="left"
+                @shown="setAutoCloseErroPopup"
+                @hide="clearAutoCloseErrorPopupHandle"
             >
             </b-popover>
             <FrameBody
@@ -94,7 +96,7 @@ import VueContext, {VueContextConstructor}  from "vue-context";
 import { getAboveFrameCaretPosition, getAllChildrenAndJointFramesIds, getLastSibling, getNextSibling, getOutmostDisabledAncestorFrameId, getParent, getParentOrJointParent, isFramePartOfJointStructure, isLastInParent } from "@/helpers/storeMethods";
 import { CustomEventTypes, getFrameBodyUID, getFrameContextMenuUID, getFrameHeaderUID, getFrameUID, isIdAFrameId, getFrameBodyRef, getJointFramesRef, getCaretContainerRef, setContextMenuEventClientXY, adjustContextMenuPosition, getActiveContextMenu, notifyDragStarted, getCaretUID, getHTML2CanvasFramesSelectionCropOptions, parseFrameUID } from "@/helpers/editor";
 import { mapStores } from "pinia";
-import { BPopover } from "bootstrap-vue";
+import { BPopover, BvEvent } from "bootstrap-vue";
 import html2canvas from "html2canvas";
 import { saveAs } from "file-saver";
 import scssVars from "@/assets/style/_export.module.scss";
@@ -152,6 +154,9 @@ export default Vue.extend({
             // We keep a data property for frame run time error, even if that's a duplication, we need to keep it because
             // when the error in the frame is lifted, the error message disappear, and we need to use it in the popup
             runtimeErrorAtLastRunMsg: "",
+            //flags for the auto-close timers dictionnary to be used for auto-closing
+            currentErrorPopupInstanceCounter: 0,
+            currentErrorPopupCloseTimeoutHandles: {} as {[id: string]: NodeJS.Timeout},
         };
     },
 
@@ -1119,6 +1124,26 @@ export default Vue.extend({
             if(this.appStore.frameObjects[this.frameId] && this.hasParsingError){
                 (this.$refs.errorPopover as InstanceType<typeof BPopover>).$emit((isFocusing) ? "open" : "close");
             }
+        },
+
+        clearAutoCloseErrorPopupHandle(event: BvEvent) {
+            const closeErrorPupHandleId = document.getElementById(event.componentId??"undef" )?.getAttribute("popup-close-tiemouthandle");
+            if(closeErrorPupHandleId){
+                clearTimeout(this.currentErrorPopupCloseTimeoutHandles[closeErrorPupHandleId]);
+                delete this.currentErrorPopupCloseTimeoutHandles[closeErrorPupHandleId];
+            }
+        },
+
+        setAutoCloseErroPopup(event: BvEvent){
+            this.currentErrorPopupInstanceCounter++;
+            document.getElementById(event.componentId??"undef")?.setAttribute("popup-close-tiemouthandle", this.currentErrorPopupInstanceCounter.toString());
+            this.currentErrorPopupCloseTimeoutHandles[this.currentErrorPopupInstanceCounter] = setTimeout(() => {
+                // We close the popup programmatically when no explicit closing action occurred from the user.
+                // The closing timeout will be called on a hanging popup and not on an explicitly closed popup
+                // because we clear the timeout in the latter case (see clearAutoCloseErrorPopupHandle()).
+                (this.$refs.errorPopover as InstanceType<typeof BPopover>)?.$emit("close");
+            }, 3000);
+
         },
     },
 });

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -1143,7 +1143,6 @@ export default Vue.extend({
                 // because we clear the timeout in the latter case (see clearAutoCloseErrorPopupHandle()).
                 (this.$refs.errorPopover as InstanceType<typeof BPopover>)?.$emit("close");
             }, 3000);
-
         },
     },
 });

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -357,7 +357,6 @@ export default Vue.extend({
                 // because we clear the timeout in the latter case (see clearAutoCloseErrorPopupHandle()).
                 (this.$refs.errorPopover as InstanceType<typeof BPopover>)?.$emit("close");
             }, 3000);
-
         },
 
         // Event callback equivalent to what would happen for a focus event callback 

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -43,7 +43,7 @@
             :content="errorMessage"
             custom-class="error-popover modified-title-popover"
             placement="bottom"
-            @shown="setAutoCloseErroPopup"
+            @shown="setAutoCloseErrorPopup"
             @hide="clearAutoCloseErrorPopupHandle"
         >
         </b-popover>
@@ -341,16 +341,16 @@ export default Vue.extend({
         },
 
         clearAutoCloseErrorPopupHandle(event: BvEvent) {
-            const closeErrorPupHandleId = document.getElementById(event.componentId??"undef" )?.getAttribute("popup-close-tiemouthandle");
+            const closeErrorPupHandleId = document.getElementById(event.componentId??"undef" )?.getAttribute("popup-close-timeouthandle");
             if(closeErrorPupHandleId){
                 clearTimeout(this.currentErrorPopupCloseTimeoutHandles[closeErrorPupHandleId]);
                 delete this.currentErrorPopupCloseTimeoutHandles[closeErrorPupHandleId];
             }
         },
 
-        setAutoCloseErroPopup(event: BvEvent){
+        setAutoCloseErrorPopup(event: BvEvent){
             this.currentErrorPopupInstanceCounter++;
-            document.getElementById(event.componentId??"undef")?.setAttribute("popup-close-tiemouthandle", this.currentErrorPopupInstanceCounter.toString());
+            document.getElementById(event.componentId??"undef")?.setAttribute("popup-close-timeouthandle", this.currentErrorPopupInstanceCounter.toString());
             this.currentErrorPopupCloseTimeoutHandles[this.currentErrorPopupInstanceCounter] = setTimeout(() => {
                 // We close the popup programmatically when no explicit closing action occurred from the user.
                 // The closing timeout will be called on a hanging popup and not on an explicitly closed popup


### PR DESCRIPTION
This PR is an answer to fix #389 , which requested a mechanism for closing popups that were "in the way" sometimes depending on the website content and viewport.

Having a close button was a bit complex to realise for frame error popups because it messed up the styling (for frames, we have one popup object which style is dynamically modified according to the type of error).

So an alternative, a timeout to auto-close the popup after 3 seconds has been implemented.
(It concerns the popups for frames and label slots errors).