### PR TITLE
Replaced timeouts by listening "escape" key hit to close error popups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "strype-editor",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "private": true,
     "scripts": {
         "serve": "vue-cli-service serve --port 8081",

--- a/src/App.vue
+++ b/src/App.vue
@@ -451,6 +451,11 @@ export default Vue.extend({
                 event.stopPropagation();
                 return;
             }
+
+            // Handle "escape" on error popover: if an error popover is showing, escape should discard the popup.
+            if(event.key == "Escape" && !this.appStore.isAppMenuOpened && !this.isPythonExecuting && !this.appStore.isDraggingFrame){
+                [...document.getElementsByClassName("popover b-popover error-popover")].forEach((popup) => (popup as HTMLDivElement).style.display = "none");
+            }
         });
 
         /* IFTRUE_isPython */

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -649,7 +649,7 @@ export default Vue.extend({
         
         onEscKeyUp(event: KeyboardEvent) {
             // When an error popup is showing, the popup takes precedence
-            if([...document.getElementsByClassName("popover b-popover error-popover")].map((popup) => (popup as HTMLDivElement).style.display != "none").some((popupShowing) => popupShowing)) {
+            if([...document.getElementsByClassName("popover b-popover error-popover")].some((popup) => (popup as HTMLDivElement).style.display != "none")) {
                 return;
             }
 

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -648,6 +648,11 @@ export default Vue.extend({
         },
         
         onEscKeyUp(event: KeyboardEvent) {
+            // When an error popup is showing, the popup takes precedence
+            if([...document.getElementsByClassName("popover b-popover error-popover")].map((popup) => (popup as HTMLDivElement).style.display != "none").some((popupShowing) => popupShowing)) {
+                return;
+            }
+
             // If the AC is loaded we want to close it with an ESC and stay focused on the editableSlot
             if(this.showAC && this.acRequested) {
                 event.preventDefault();

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -45,8 +45,6 @@
             :content="errorMessage"
             custom-class="error-popover modified-title-popover"
             placement="bottom"
-            @shown="setAutoCloseErrorPopup"
-            @hide="clearAutoCloseErrorPopupHandle"
         >
         </b-popover>
 
@@ -75,7 +73,7 @@ import { checkCodeErrors, evaluateSlotType, getFlatNeighbourFieldSlotInfos, getO
 import Parser from "@/parser/parser";
 import { cloneDeep, debounce } from "lodash";
 import LabelSlotsStructure from "./LabelSlotsStructure.vue";
-import { BPopover, BvEvent } from "bootstrap-vue";
+import { BPopover } from "bootstrap-vue";
 import Frame from "@/components/Frame.vue";
 import scssVars from "@/assets/style/_export.module.scss";
 
@@ -136,9 +134,6 @@ export default Vue.extend({
             //or that the slot is initially empty
             canBackspaceDeleteFrame: true,
             requestDelayBackspaceFrameRemoval: false,
-            //flags for the auto-close timers dictionnary to be used for auto-closing
-            currentErrorPopupInstanceCounter: 0,
-            currentErrorPopupCloseTimeoutHandles: {} as {[id: string]: NodeJS.Timeout},
         };
     },
     
@@ -358,25 +353,6 @@ export default Vue.extend({
         erroneous(): boolean {
             // Only show the popup when there is an error and the code hasn't changed
             return this.isFirstChange && this.appStore.isErroneousSlot(this.coreSlotInfo);
-        },
-
-        clearAutoCloseErrorPopupHandle(event: BvEvent) {
-            const closeErrorPupHandleId = document.getElementById(event.componentId??"undef" )?.getAttribute("popup-close-timeouthandle");
-            if(closeErrorPupHandleId){
-                clearTimeout(this.currentErrorPopupCloseTimeoutHandles[closeErrorPupHandleId]);
-                delete this.currentErrorPopupCloseTimeoutHandles[closeErrorPupHandleId];
-            }
-        },
-
-        setAutoCloseErrorPopup(event: BvEvent){
-            this.currentErrorPopupInstanceCounter++;
-            document.getElementById(event.componentId??"undef")?.setAttribute("popup-close-timeouthandle", this.currentErrorPopupInstanceCounter.toString());
-            this.currentErrorPopupCloseTimeoutHandles[this.currentErrorPopupInstanceCounter] = setTimeout(() => {
-                // We close the popup programmatically when no explicit closing action occurred from the user.
-                // The closing timeout will be called on a hanging popup and not on an explicitly closed popup
-                // because we clear the timeout in the latter case (see clearAutoCloseErrorPopupHandle()).
-                (this.$refs.errorPopover as InstanceType<typeof BPopover>)?.$emit("close");
-            }, 3000);
         },
 
         // Event callback equivalent to what would happen for a focus event callback 


### PR DESCRIPTION
After discussing in meeting the timeout to close the error popups, a better approach has been suggested: to listen to "escape" key instead. (see #435)

This PR also bumps the version for a following new release.