### PR TITLE
Fixed a bug with quotes not overtyping closing quotes in an empty string

### DIFF
--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -901,7 +901,7 @@ export default Vue.extend({
             // Our position will no longer have a selection, it's just us at the given cursor pos:
             this.appStore.setSlotTextCursors({slotInfos: this.coreSlotInfo, cursorPos: cursorPos + inputString.length}, {slotInfos: this.coreSlotInfo, cursorPos: cursorPos + inputString.length});
 
-            const isAtEndOfSlot = !hasTextSelection && cursorPos + inputString.length >= inputSpanFieldContent.length;
+            const isAtEndOfSlot = !hasTextSelection && cursorPos + inputString.length >= inputSpanFieldContent.replace(/\u200B/g, "").length;
             const isAtEndOfLastSlot = nextSlotInfos == null && isAtEndOfSlot;
 
 

--- a/tests/cypress/e2e/structured-expressions-terms.cy.ts
+++ b/tests/cypress/e2e/structured-expressions-terms.cy.ts
@@ -28,6 +28,10 @@ beforeEach(() => {
 
 
 describe("Stride TestExpressionSlot.testStrings()", () => {
+    // Empty strings:
+    testInsert("\"\"", "{}_“”_{$}");
+    testInsert("''", "{}_‘’_{$}");
+    
     // With trailing quote
     testInsert("\"hello\"", "{}_“hello”_{$}");
     // Without trailing quote (caret stays in string):


### PR DESCRIPTION
This was due to not taking account of the zero-width space which was present at this point.

Fixes #447