### PR TITLE
Fixed a bug where copying strings would copy as Unicode quotes rather than ASCII quotes

### DIFF
--- a/src/assets/style/_export.module.scss
+++ b/src/assets/style/_export.module.scss
@@ -29,6 +29,7 @@
   labelSlotMediaClassName: $strype-classname-label-slot-media;
   errorSlotClassName: $strype-classname-error-slot;
   frameStringSlotClassName: $strype-classname-frame-string-slot;
+  frameStringSlotQuoteClassName: $strype-classname-frame-string-slot-quote;
   frameOperatorSlotClassName: $strype-classname-frame-operator-slot;
   frameCommentSlotClassName: $strype-classname-frame-comment-slot;
   frameCodeSlotClassName: $strype-classname-frame-code-slot;

--- a/src/assets/style/variables.scss
+++ b/src/assets/style/variables.scss
@@ -32,6 +32,7 @@ $strype-classname-label-slot-input: label-slot-input;
 $strype-classname-label-slot-media: label-slot-media;
 $strype-classname-error-slot: error-slot;
 $strype-classname-frame-string-slot: string-slot;
+$strype-classname-frame-string-slot-quote: string-slot-quote;
 $strype-classname-frame-operator-slot: operator-slot;
 $strype-classname-frame-comment-slot: comment-slot;
 $strype-classname-frame-code-slot: code-slot;

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -224,9 +224,11 @@ export default Vue.extend({
                 codeTypeCSS = scssVars.frameOperatorSlotClassName + ((this.code==",") ? " slot-right-margin" : "");
                 break;
             case SlotType.string:
+                codeTypeCSS = scssVars.frameStringSlotClassName;
+                break;
             case SlotType.openingQuote:
             case SlotType.closingQuote:
-                codeTypeCSS = scssVars.frameStringSlotClassName;
+                codeTypeCSS = scssVars.frameStringSlotClassName + " " + scssVars.frameStringSlotQuoteClassName;
                 break;
             default:
                 // Check comments here
@@ -979,6 +981,7 @@ export default Vue.extend({
                 const isEscapingString = isFieldStringSlot(currentSlot) && cursorPos > 0 && (getNumPrecedingBackslashes(inputSpanFieldContent, cursorPos) % 2) == 1
                     && ((cursorPos + inputString.length < inputSpanFieldContent.length && inputSpanFieldContent[cursorPos + inputString.length]!= inputString) || isAtEndOfSlot);
                 if(isEscapingString){
+                    console.log("Escaping string");
                     // Just let the input occur:
                     return;
                 }
@@ -1466,10 +1469,13 @@ export default Vue.extend({
             }
             
             // When the backspace key is hit we delete the container frame when:
-            //  1) there is no text in the slots
-            //  2) we are in the first slot of a frame (*first that appears in the UI*) 
+            //  1) there is no text in the slots (or only empty parts)
+            //  2) we are in the first slot of a frame (*first that appears in the UI*)
+            //  3) there is no text selection
             // To avoid unwanted deletion, we "force" a delay before removing the frame.
-            if(this.isFrameEmptyAndAtLabelSlotStart){
+            const anchor = this.appStore.anchorSlotCursorInfos;
+            const focus = this.appStore.focusSlotCursorInfos;
+            if(this.isFrameEmptyAndAtLabelSlotStart && (!anchor || !focus || areSlotCoreInfosEqual(anchor.slotInfos, focus.slotInfos))){
                 event.stopPropagation();
                 event.stopImmediatePropagation();
                 event.preventDefault();

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -981,7 +981,6 @@ export default Vue.extend({
                 const isEscapingString = isFieldStringSlot(currentSlot) && cursorPos > 0 && (getNumPrecedingBackslashes(inputSpanFieldContent, cursorPos) % 2) == 1
                     && ((cursorPos + inputString.length < inputSpanFieldContent.length && inputSpanFieldContent[cursorPos + inputString.length]!= inputString) || isAtEndOfSlot);
                 if(isEscapingString){
-                    console.log("Escaping string");
                     // Just let the input occur:
                     return;
                 }

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -2064,8 +2064,13 @@ export function getEditableSelectionText() : string {
                 continue;
             }
         }
-        if (isNodeSelectableText(node)) {
-            allNodes.push(node.nodeValue ?? "");
+        const selectableText = isNodeSelectableText(node);
+        if (selectableText == "yes" || selectableText == "yes_quote") {
+            let nodeContent = node.nodeValue ?? "";
+            if (selectableText == "yes_quote") {
+                nodeContent = nodeContent.replaceAll(/[“”]/g, "\"").replaceAll(/[‘’]/g, "'");
+            }
+            allNodes.push(nodeContent);
         }
     }
 
@@ -2073,21 +2078,36 @@ export function getEditableSelectionText() : string {
 }
 
 // Helper function to check if a node is inside a contenteditable element
-function isNodeSelectableText(node: Node | null): boolean {
+function isNodeSelectableText(node: Node | null) : ("no" | "yes_quote" | "yes") {
     if (!node || node.nodeType !== Node.TEXT_NODE) {
-        return false;
+        return "no";
     }
 
     // Check if the nearest element ancestors is contenteditable
     let current: Node | null = node;
+    let editable = false;
+    let quote = false;
     while (current) {
         if (current.nodeType === Node.ELEMENT_NODE) {
             const el = current as HTMLElement;
-            return el.classList.contains(scssVars.labelSlotInputClassName);
+            if (el.classList.contains(scssVars.labelSlotInputClassName)){
+                editable = true;
+            }
+            if (el.classList.contains(scssVars.frameStringSlotQuoteClassName)) {
+                quote = true;
+            }
         }
         current = current.parentNode;
     }
-    return false;
+    if (editable && quote) {
+        return "yes_quote";
+    }
+    else if (editable) {
+        return "yes";
+    }
+    else {
+        return "no";
+    }
 }
 
 // Gets all the HTML elements which are part of the window text selection.

--- a/tests/playwright/e2e/structured-expressions-selection.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-selection.spec.ts
@@ -392,6 +392,11 @@ test.describe("Selecting then deleting in multiple slots", () => {
     // Prevent invalid selections (trying to select from outside brackets to within):
     testSelection("123+(456)*789", 6, 12, (page) => page.keyboard.press("Backspace"), "{123}+{}_({4$})_{}*{789}");
     testSelection("123+(456)*789", 6, 2, (page) => page.keyboard.press("Backspace"), "{123}+{}_({$56})_{}*{789}");
+
+    testSelectionBoth("''", 0,2, (page) => page.keyboard.press("Backspace"), "{$}");
+    testSelectionBoth("''", 0,2, (page) => page.keyboard.press("Delete"), "{$}");
+    testSelectionBoth("\"\"", 2,0, (page) => page.keyboard.press("Backspace"), "{$}");
+    testSelectionBoth("\"\"", 2,0, (page) => page.keyboard.press("Delete"), "{$}");
 });
 
 test.describe("Selecting then cutting/copying", () => {
@@ -404,6 +409,10 @@ test.describe("Selecting then cutting/copying", () => {
     
     // Check we don't see zero-width spaces:
     testCutCopyBothWays("fax()", 2, 5, 2, "x()", "{fa$}", "{fa|x}_({})_{$}");
+    
+    // Check that strings are copied correctly:
+    testCutCopyBothWays("\"\"", 0, 2, 1, "\"\"", "{$}", "{|}_“”_{$}");
+    testCutCopyBothWays("''", 0, 2, 1, "''", "{$}", "{|}_‘’_{$}");
 });
 
 test.describe("Paste over selection", () => {


### PR DESCRIPTION
This also revealed an issue where pressing backspace while you have backwards-selected an empty string in a slot would delete the frame.

Tests are now present for both cases.

Fixes #451