### PR TITLE
Parallelise cypress tests

### DIFF
--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -2,7 +2,14 @@ name: Build and run tests
 on: [push,pull_request]
 jobs:
   Build-And-Run-Tests:
-    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+          # Test Python and Microbit, on Ubuntu and Mac, should be all in parallel:
+          testtask: ["test:cypress:python-only", "test:cypress:microbit-only"] 
+          os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -15,7 +22,7 @@ jobs:
       - name: NPM Linter
         run: npm run lint:check
       - name: NPM Test (Cypress)
-        run: npm run test:cypress
+        run: npm run ${{ matrix.testtask }}
       - name: Upload test videos (if any)
         uses: actions/upload-artifact@v4
         # Store screenshots and videos only on failure:

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
           # Test Python and Microbit, on Ubuntu and Mac, should be all in parallel:
-          testtask: ["test:cypress:python-only", "test:cypress:microbit-only"] 
+          testtype: ["python", "microbit"] 
           os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,13 +22,13 @@ jobs:
       - name: NPM Linter
         run: npm run lint:check
       - name: NPM Test (Cypress)
-        run: npm run ${{ matrix.testtask }}
+        run: npm run test:cypress:${{ matrix.testtype }}-only
       - name: Upload test videos (if any)
         uses: actions/upload-artifact@v4
         # Store screenshots and videos only on failure:
         if: ${{ failure() }}
         with:
-            name: cypress-screenshots-and-video
+            name: cypress-screenshots-and-video-${{matrix.os}}-${{matrix.testtype}}
             path: | 
               tests/cypress/screenshots
               tests/cypress/videos

--- a/.github/workflows/build-and-run-tests.yml
+++ b/.github/workflows/build-and-run-tests.yml
@@ -6,9 +6,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          # Test Python and Microbit, on Ubuntu and Mac, should be all in parallel:
-          testtype: ["python", "microbit"] 
-          os: [ ubuntu-latest, macos-latest ]
+          # Test Python and Microbit, on Ubuntu, should be all in parallel:
+          testtype: ["python", "microbit"]
+          # Did have Mac here, but it seems to run out of memory so taken it out:
+          os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
         "serve:https": "HTTPS=true vue-cli-service serve",
         "cy:run:microbit": "cypress run --env mode=microbit",
         "cy:run:python": "cypress run --env mode=python",
+        "test:cypress:microbit-only": "cross-env WAIT_ON_TIMEOUT=90000 start-server-and-test serve:microbit http-get://127.0.0.1:8081/microbit/ cy:run:microbit",
+        "test:cypress:python-only": "cross-env WAIT_ON_TIMEOUT=90000 start-server-and-test serve:python http-get://127.0.0.1:8081/editor/ cy:run:python",
         "test:cypress": "cross-env WAIT_ON_TIMEOUT=90000 start-server-and-test serve:python http-get://127.0.0.1:8081/editor/ cy:run:python && cross-env WAIT_ON_TIMEOUT=90000 start-server-and-test serve:microbit http-get://127.0.0.1:8081/microbit/ cy:run:microbit",
         "playwright:run": "npx playwright test",
         "test:playwright": "cross-env BASE_URL=http://127.0.0.1:8081/editor/ start-server-and-test serve:python http-get://127.0.0.1:8081/editor/ playwright:run"


### PR DESCRIPTION
As mentioned, run the Python and Microbit Cypress tests in parallel.  This halves the time required, from 1h20m to 40m.