### PR TITLE
Fix bugs with media literals

### DIFF
--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -515,14 +515,18 @@ export default Vue.extend({
                 /* IFTRUE_isPython */
                 for (let item of items) {
                     let file = item.getAsFile();
-                    let isImage = item.type.startsWith("image");
-                    let isAudio = item.type.startsWith("audio");
+                    // Note: it is incredibly important that we store item.type in a variable here.  Due to browser clipboard
+                    // permissions, if we access item.type inside the .then() below, it will appear blank.  So we must
+                    // fetch it now and store it:
+                    const itemType = item.type;
+                    let isImage = itemType.startsWith("image");
+                    let isAudio = itemType.startsWith("audio");
                     if (file && (isImage || isAudio)) {
                         readFileAsyncAsData(file).then(isImage ? readImageSizeFromDataURI : (s) => Promise.resolve({dataURI: s, width: -1, height: -1})).then((dataAndDim) => {
                             // The code is the code to load the literal from its base64 string representation:
                             const code = (isImage ? "load_image" : "load_sound") + "(\"" + dataAndDim.dataURI + "\")";
                             document.getElementById(getLabelSlotUID(focusSlotCursorInfos.slotInfos))
-                                ?.dispatchEvent(new CustomEvent(CustomEventTypes.editorContentPastedInSlot, {detail: {type: item.type, content: code, width: dataAndDim.width, height: dataAndDim.height}}));
+                                ?.dispatchEvent(new CustomEvent(CustomEventTypes.editorContentPastedInSlot, {detail: {type: itemType, content: code, width: dataAndDim.width, height: dataAndDim.height}}));
                         });
                         return;
                     }

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -2049,28 +2049,30 @@ export function getEditableSelectionText() : string {
     const allNodes = [] as string[];
     const treeWalker = document.createTreeWalker(
         range.cloneContents(),
-        NodeFilter.SHOW_TEXT,
+        // Need to show elements to find the media literal images:
+        NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
         null
     );
 
     for (let node = treeWalker.nextNode(); node; node = treeWalker.nextNode()) {
         if (node.nodeType === Node.ELEMENT_NODE) {
             const el = node as HTMLElement;
-            if (el.classList.contains(".labelSlot-Media")) {
+            if (el.classList.contains(scssVars.labelSlotMediaClassName)) {
                 const code = el.getAttribute("data-code");
                 if (code) {
                     allNodes.push(code);
                 }
-                continue;
             }
         }
-        const selectableText = isNodeSelectableText(node);
-        if (selectableText == "yes" || selectableText == "yes_quote") {
-            let nodeContent = node.nodeValue ?? "";
-            if (selectableText == "yes_quote") {
-                nodeContent = nodeContent.replaceAll(/[“”]/g, "\"").replaceAll(/[‘’]/g, "'");
+        else {
+            const selectableText = isNodeSelectableText(node);
+            if (selectableText == "yes" || selectableText == "yes_quote") {
+                let nodeContent = node.nodeValue ?? "";
+                if (selectableText == "yes_quote") {
+                    nodeContent = nodeContent.replaceAll(/[“”]/g, "\"").replaceAll(/[‘’]/g, "'");
+                }
+                allNodes.push(nodeContent);
             }
-            allNodes.push(nodeContent);
         }
     }
 

--- a/tests/playwright/e2e/structured-expressions-selection.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-selection.spec.ts
@@ -1,17 +1,49 @@
-import {Page, test, expect} from "@playwright/test";
+import {expect, Page, test} from "@playwright/test";
+import fs from "fs";
 
 let scssVars: {[varName: string]: string};
 //let strypeElIds: {[varName: string]: (...args: any[]) => string};
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    if (process.platform === "win32" && browserName === "webkit") {
+        testInfo.skip(true, "Skipping on WebKit + Windows due to clipboard permission issues.");
+    }
+    
     // We must use a fake clipboard object to avoid issues with browser clipboard permissions:
     await page.addInitScript(() => {
-        let mockContent = "<empty>";
+        let mockTextContent = "<empty>";
+        let mockImageContentType = "";
+        let mockImageContent : Blob | null = null;
         const mockClipboard = {
-            content: "<empty>",
-            writeText: async (text: string) => {
-                mockContent = text;
+            write: async (items: ClipboardItem[]) => {
+                for (const item of items) {
+                    for (const type of item.types) {
+                        if (type.startsWith("image/")) {
+                            mockImageContent = await item.getType(type);
+                            mockImageContentType = type;
+                        }
+                    }
+                }
             },
-            readText: async () => mockContent,
+            read: async () => {
+                if (!mockImageContent || !mockImageContentType) {
+                    return [];
+                }
+                return [
+                    {
+                        types: [mockImageContentType],
+                        getType: async (type : string) => {
+                            if (type === mockImageContentType){
+                                return mockImageContent;
+                            }
+                            throw new Error("Unsupported type");
+                        },
+                    },
+                ];
+            },
+            writeText: async (text: string) => {
+                mockTextContent = text;
+            },
+            readText: async () => mockTextContent,
         };
 
         // override the native clipboard API
@@ -146,8 +178,8 @@ function testPasteOverBoth(code: string, startIndex: number, endIndex: number, t
 
 enum CUT_COPY_TEST { CUT_ONLY, COPY_ONLY, CUT_REPASTE }
 
-function doPagePaste(page: Page, clipboardContent: string) {
-    return page.evaluate((pasteContent: string) => {
+function doPagePaste(page: Page, clipboardContent: string, clipboardContentType = "text") {
+    return page.evaluate(({clipboardContent, clipboardContentType}) => {
         const pasteEvent = new ClipboardEvent("paste", {
             bubbles: true,
             cancelable: true,
@@ -155,11 +187,22 @@ function doPagePaste(page: Page, clipboardContent: string) {
         });
 
         // Set custom clipboard data for the paste event
-        pasteEvent.clipboardData?.setData("text", pasteContent);
+        if (clipboardContentType.startsWith("text")) {
+            pasteEvent.clipboardData?.setData(clipboardContentType, clipboardContent);
+        }
+        else {
+            const byteCharacters = atob(clipboardContent);
+            const byteNumbers = new Array(byteCharacters.length);
+            for (let i = 0; i < byteCharacters.length; i++) {
+                byteNumbers[i] = byteCharacters.charCodeAt(i);
+            }
+            const file = new File([new Blob([new Uint8Array(byteNumbers)], {type: clipboardContentType})], "anon", { type: clipboardContentType});
+            pasteEvent.clipboardData?.items.add(file);
+        }
 
         // Dispatch the paste event to the whole document
         document.activeElement?.dispatchEvent(pasteEvent);
-    }, clipboardContent);
+    }, {clipboardContent, clipboardContentType});
 }
 
 function testCutCopy(code : string, stepsToBegin: number, stepsWhileSelecting: number, expectedClipboard : string, expectedAfter : string, kind: CUT_COPY_TEST) : void {
@@ -436,4 +479,35 @@ test.describe("Paste over selection", () => {
     testPasteOverBoth("11+(22*33)/44", 4, 9, "55", "{11}+{}_({55$})_{}/{44}");
     testPasteOverBoth("11+(22*33)/44", 5, 8, "55", "{11}+{}_({255$3})_{}/{44}");
     testPasteOverBoth("11+(22*33)/44", 4, 9, "55*(66-77)", "{11}+{}_({55}*{}_({66}-{77})_{$})_{}/{44}");
+});
+
+test.describe("Media literal copying", () => {
+    test("Test copying text with a media literal", async ({page}) => {
+        await page.keyboard.press("Backspace");
+        await page.keyboard.press("Backspace");
+        await page.keyboard.type("i");
+        await page.waitForTimeout(100);
+        await assertState(page, "{$}");
+        await typeIndividually(page, "set_background(");
+        const image = fs.readFileSync("public/graphics_images/cat-test.jpg").toString("base64");
+        await doPagePaste(page, image, "image/jpeg");
+        await typeIndividually(page, ")");
+        let startIndex = 0;
+        const endIndex = "set_background(X)".length;
+        await page.keyboard.press("Home");
+        for (let i = 0; i < startIndex; i++) {
+            await page.keyboard.press("ArrowRight");
+            await page.waitForTimeout(75);
+        }
+        while (startIndex < endIndex) {
+            await page.keyboard.press("Shift+ArrowRight");
+            await page.waitForTimeout(75);
+            startIndex += 1;
+        }
+        await page.waitForTimeout(100);
+        await page.keyboard.press("ControlOrMeta+c");
+        await page.waitForTimeout(100);
+        const clipboardContent : string = await page.evaluate("navigator.clipboard.readText()");
+        expect(clipboardContent).toEqual("set_background(load_image(\"data:image/jpeg;base64," + image + "\"))");
+    });
 });


### PR DESCRIPTION
Fixes the issue with not copying media literals, and separately with not being able to paste them on Chrome.  Well spotted!  Also adds a test for the former, but I couldn't reproduce the permissions issue in the Playwright tests, only on desktop which is a bit annoying.