### PR TITLE
Add media readouts in edit dialogs

### DIFF
--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -201,6 +201,14 @@
     "soundPlay": "Play",
     "soundSeconds": "seconds",
     "soundStop": "Stop",
-    "volumeScale": "Volume Scaling"
+    "volumeScale": "Volume Scaling",
+    "cursorPosWin": "Position (Ctrl-C to copy):",
+    "cursorPosMac": "Position (⌘ C to copy):",
+    "cursorColorWin": "Color (Ctrl-Shift-C to copy):",
+    "cursorColorMac": "Color (⇧ ⌘ C to copy):",
+    "cursorTimeWin": "Time (Ctrl-C to copy):",
+    "cursorTimeMac": "Time (⌘ C to copy):",
+    "cursorHeightWin": "Height (Ctrl-Shift-C to copy):",
+    "cursorHeightMac": "Height (⇧ ⌘ C to copy):"
   }
 }


### PR DESCRIPTION
This was a feature request from Mark, and seemed like it might be useful for any kind of image manipulation.  It adds features to the media literal edit dialogs to pick X,Y positions or values.  Image dialog has this just below the picture (on Mac -- affects how keyboard shortcuts are written):

![image](https://github.com/user-attachments/assets/222e71cd-9ff3-4f7f-82d1-3da229671b9f)

Sound dialog has this just below preview picture:

![image](https://github.com/user-attachments/assets/ecc071fd-b295-435b-aced-6869ea37077c)
