### PR TITLE
Handle comments indentation from Python files + fix bug with wrapping with joint frames

### DIFF
--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -196,7 +196,7 @@ function transformCommentsAndBlanks(codeLines: string[]) : {disabledLines : numb
         // following the Python indentation rule would be seen as an error by Skulpt.
         // The logic is: 
         // - if there is no line before the comments (they are at the start of the code) the indent is 0.
-        // - if there is no line after the comments (they are at then end of the code), we indent the block as before.
+        // - if there is no line after the comments (they are at then end of the code), we indent the block as before or leave it to 0 if it was.
         // - if lines before and after the comments are with the same indentation: we change the comments' indentation for the same
         // - if the line before the comments has a different indent than the line after, we indent the block as after.
         if(aCommentBlockLines.length == 0){
@@ -212,7 +212,7 @@ function transformCommentsAndBlanks(codeLines: string[]) : {disabledLines : numb
             else{
                 const indentBefore = /^(\s*).*$/.exec(transformedLines[commentBlockStartLineIndex - 1])?.[1]??"";
                 if(commentBlockEndLineIndex == transformedLines.length - 1){    
-                    return indentBefore + line.trimStart();
+                    return ((/^\s.*$/.exec(line)==null) ? "" : indentBefore) + line.trimStart();
                 }
                 else{
                     const indentAfter = /^(\s*).*$/.exec(transformedLines[commentBlockEndLineIndex + 1])?.[1]??"";

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -196,7 +196,7 @@ function transformCommentsAndBlanks(codeLines: string[]) : {disabledLines : numb
         // following the Python indentation rule would be seen as an error by Skulpt.
         // The logic is: 
         // - if there is no line before the comments (they are at the start of the code) the indent is 0.
-        // - if there is no line after the comments (they are at then end of the code), we indent the block as before or leave it to 0 if it was.
+        // - if there is no line after the comments (they are at then end of the code), we indent the block as before or leave it to 0 if it was (and all others).
         // - if lines before and after the comments are with the same indentation: we change the comments' indentation for the same
         // - if the line before the comments has a different indent than the line after, we indent the block as after.
         if(aCommentBlockLines.length == 0){
@@ -204,15 +204,17 @@ function transformCommentsAndBlanks(codeLines: string[]) : {disabledLines : numb
             return;
         }
 
-        const commentBlockStartLineIndex = aCommentBlockLines[0], commentBlockEndLineIndex = aCommentBlockLines[aCommentBlockLines.length - 1];       
+        const commentBlockStartLineIndex = aCommentBlockLines[0], commentBlockEndLineIndex = aCommentBlockLines[aCommentBlockLines.length - 1];
+        let hasZeroIndent = false;     
         const subrange = transformedLines.slice(commentBlockStartLineIndex, commentBlockEndLineIndex + 1).map((line) => {
             if(commentBlockStartLineIndex == 0){
                 return line.trimStart();
             }
             else{
                 const indentBefore = /^(\s*).*$/.exec(transformedLines[commentBlockStartLineIndex - 1])?.[1]??"";
-                if(commentBlockEndLineIndex == transformedLines.length - 1){    
-                    return ((/^\s.*$/.exec(line)==null) ? "" : indentBefore) + line.trimStart();
+                if(commentBlockEndLineIndex == transformedLines.length - 1){
+                    hasZeroIndent ||= (/^\s.*$/.exec(line)==null);
+                    return (hasZeroIndent ? "" : indentBefore) + line.trimStart();
                 }
                 else{
                     const indentAfter = /^(\s*).*$/.exec(transformedLines[commentBlockEndLineIndex + 1])?.[1]??"";

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1963,10 +1963,22 @@ export const useStore = defineStore("app", {
                 // Find the frame before, if any:
                 const index = this.getIndexInParent(newFrame.id);
                 if (index == 0) {
-                    this.setCurrentFrame({id: newFrame.parentId, caretPosition: CaretPosition.body});
+                    // If we have added a joint frame (like "else"), the new caret's position is the last child of the root joint element (or it's body if empty).
+                    const newPos= (newFrame.frameType.isJointFrame)
+                        ? ((this.frameObjects[newFrame.jointParentId].childrenIds.length > 0) 
+                            ? {id: this.frameObjects[newFrame.jointParentId].childrenIds.at(-1) as number, caretPosition: CaretPosition.below}
+                            : {id: newFrame.jointParentId, caretPosition: CaretPosition.body})
+                        : {id: newFrame.parentId, caretPosition: CaretPosition.body};               
+                    this.setCurrentFrame(newPos);
                 }                
                 else {
-                    this.setCurrentFrame({id: this.frameObjects[newFrame.parentId].childrenIds[index - 1], caretPosition: CaretPosition.below});
+                    // If we have added a joint frame (like "else"), the new caret's position is the last child of the previous joint element (or it's body if empty).
+                    const newPos= (newFrame.frameType.isJointFrame)
+                        ? ((this.frameObjects[this.frameObjects[newFrame.jointParentId].jointFrameIds[index-1]].childrenIds.length > 0) 
+                            ? {id: this.frameObjects[this.frameObjects[newFrame.jointParentId].jointFrameIds[index-1]].childrenIds.at(-1) as number, caretPosition: CaretPosition.below}
+                            : {id: this.frameObjects[newFrame.jointParentId].jointFrameIds[index-1], caretPosition: CaretPosition.body})
+                        : {id: this.frameObjects[newFrame.parentId].childrenIds[index - 1], caretPosition: CaretPosition.below};       
+                    this.setCurrentFrame(newPos);
                 }
                 await Vue.nextTick();
                 availablePositions = getAvailableNavigationPositions();


### PR DESCRIPTION
For the first fix:
In Python, comments are not subject to indentation check, for example the code below is valid:
```
while True :
# a comment <-- should rather be aligned to next line, but Python accepts it
   doSomething()
```
However, this generates issues when we try to copy or open some Python code inside Strype, as comments are transformed for Skulpt to manage the code parsing. Therefore, Skulpt cannot know the transform comment was a comment.

We try to fix the indentation so that we can still open/paste the code.

For the second fix: see #482 