### PR TITLE
Fix autocomplete in libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "sortablejs": "^1.15.0",
                 "splitpanes": "^2.4.1",
                 "textarea-caret": "^3.1.0",
-                "tigerpython-parser": "git+https://github.com/Tobias-Kohn/TigerPython-Parser.git",
+                "tigerpython-parser": "git+https://github.com/neilccbrown/TigerPython-Parser.git",
                 "timed-cache": "^2.0.0",
                 "ts-node": "^10.9.1",
                 "ts-node-dev": "^2.0.0",
@@ -17986,8 +17986,8 @@
             "dev": true
         },
         "node_modules/tigerpython-parser": {
-            "version": "1.1.0",
-            "resolved": "git+ssh://git@github.com/Tobias-Kohn/TigerPython-Parser.git#5d6a54b23fb3ab6c99b1726af61a15d5c11b86c3",
+            "version": "1.1.1",
+            "resolved": "git+ssh://git@github.com/neilccbrown/TigerPython-Parser.git#9a2f29bf282c2e89ef4d26da9f86c51ca9177263",
             "license": "MPL-2.0"
         },
         "node_modules/timed-cache": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "sortablejs": "^1.15.0",
         "splitpanes": "^2.4.1",
         "textarea-caret": "^3.1.0",
-        "tigerpython-parser": "git+https://github.com/Tobias-Kohn/TigerPython-Parser.git",
+        "tigerpython-parser": "git+https://github.com/neilccbrown/TigerPython-Parser.git",
         "timed-cache": "^2.0.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",

--- a/src/helpers/python-pyi.ts
+++ b/src/helpers/python-pyi.ts
@@ -46,16 +46,15 @@ export function extractPYI(original : string) : string {
         if (funcDefMatch) {
             const [indent, fnName, args] = funcDefMatch.slice(1);
             const argNames = args.trim() ? args.split(",").map((s) => s.replace(/=.*/, "").trim()) : [];
+            if (indent != "") {
+                // If we're indented, we're a class, so remove first argName as it's self:
+                argNames.shift();
+            }
             let argTypeList : string[];
             let returnType : string;
             if (typeMatch) {
                 let argTypes;
                 [argTypes, returnType] = typeMatch[1].trim().split("->").map((s) => s.trim());
-
-                if (indent != "") {
-                    // If we're indented, we're a class, so remove first argName as it's self:
-                    argNames.shift();
-                }
                 argTypeList = splitTopLevelArgs(argTypes.slice(1, -1)).map((s) => s.trim());
             }
             else {
@@ -79,7 +78,7 @@ export function extractPYI(original : string) : string {
             }
             //output.push(`${indent}${name}: ${type}`);
         }
-        if (lines[i].match(/^import/)) {
+        if (lines[i].match(/^import\s+/) || lines[i].match(/^from\s+.*import/)) {
             output.push(lines[i]);
         }
     }

--- a/tests/cypress/e2e/autocomplete-graphics-libs.cy.ts
+++ b/tests/cypress/e2e/autocomplete-graphics-libs.cy.ts
@@ -350,4 +350,18 @@ describe("Modules from libraries", () => {
             checkAutocompleteSorted(acIDSel, true);
         }, true);
     });
+
+    it("Shows completions for return of makeSound", () => {
+        focusEditorAC();
+        // Add graphics import:
+        cy.get("body").type("{uparrow}{uparrow}lhttp://localhost:8089/test-library{rightarrow}fmediacomp{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        // Add a function call frame and trigger auto-complete:
+        cy.get("body").type(" ");
+        cy.wait(500);
+        cy.get("body").type("makeSound('a').{ctrl} ");
+        withAC((acIDSel, frameId) => {
+            cy.get(acIDSel).should("be.visible");
+            checkExactlyOneItem(acIDSel, null, "get_samples()");
+        }, false);
+    });
 });


### PR DESCRIPTION
This adds and fixes a test for autocomplete in libraries, which originally failed because TigerPython didn't deal with "import strype.graphics as _graphics" which is present in the mediacomp libraries; it then didn't recognise the module "_graphics".  The intention is to switch back to the central repository of TigerPython once the PR is merged in.