### PR TITLE
Fix cursor position and after click, and loading/saving of dividers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1201,7 +1201,7 @@ export default Vue.extend({
         onStrypeCommandsSplitPaneResize(event: any, useSpecificPEALayout?: StrypePEALayoutMode){
             // Save the new size of the RHS pane of the editor/commands splitter
             if(this.appStore.editorCommandsSplitterPane2Size != undefined) {
-                this.appStore.editorCommandsSplitterPane2Size[useSpecificPEALayout??(this.appStore.peaLayoutMode??StrypePEALayoutMode.tabsCollapsed)] = event[1].size;                
+                Vue.set(this.appStore.editorCommandsSplitterPane2Size, useSpecificPEALayout??(this.appStore.peaLayoutMode??StrypePEALayoutMode.tabsCollapsed), event[1].size);
             }
             else {
                 // The tricky case of when the state property has never been set

--- a/src/assets/style/_export.module.scss
+++ b/src/assets/style/_export.module.scss
@@ -50,7 +50,6 @@
   peaNoTabsPlaceholderSpanClassName: $strype-classname-pea-no-tabs-placeholder-span;
   noPEACommandsClassName: $strype-classname-no-pea-commands;
   // app wide related
-  editorFileInputClassName: $strype-classname-editor-file-input;
   messageBannerContainerClassName: $strype-classname-message-banner-container;
   messageBannerCrossClassName: $strype-classname-message-banner-cross;
   projectTargetButtonClassName: $strype-classname-project-target-button;

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -446,7 +446,7 @@ export default Vue.extend({
                     let cursorPos = 0;
                     if(clickXValue < (slotXPos + (slotWidth / 2))) {
                         neighbourSlotInfos = previousNeighbourSlotInfos; 
-                        cursorPos = (document.getElementById(getLabelSlotUID(previousNeighbourSlotInfos))?.textContent??"").length;                       
+                        cursorPos = (document.getElementById(getLabelSlotUID(previousNeighbourSlotInfos))?.textContent?.replace(/\u200B/g, "")??"").length;                       
                     }
                   
                     // Focus on the nearest neighbour to the click

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -909,7 +909,7 @@ export default Vue.extend({
                         headers.set("peaLayoutMode", this.appStore.peaLayoutMode === undefined ? undefined : StrypePEALayoutMode[this.appStore.peaLayoutMode]);
                         headers.set("peaCommandsSplitterPane2Size", saveDivider(this.appStore.peaCommandsSplitterPane2Size));
                         headers.set("peaSplitViewSplitterPane1Size", saveDivider(this.appStore.peaSplitViewSplitterPane1Size));
-                        headers.set("editorCommandsSplitterPane2Size", saveDivider(this.appStore.peaExpandedSplitterPane2Size));
+                        headers.set("peaExpandedSplitterPane2Size", saveDivider(this.appStore.peaExpandedSplitterPane2Size));
                         /* FITRUE_isPython */
                         saveContent = Array.from(headers.entries()).filter(([k, v]) => v !== undefined).map((e) => "#" + AppSPYPrefix + " " + e[0] + ":" + e[1] + "\n").join("") + saveContent;
                         if(canBrowserSaveFilePicker()){

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -152,7 +152,8 @@
                 :accept="acceptedInputFileFormat"
                 ref="importFileInput" 
                 @change="selectedFile" 
-                :class="scssVars.editorFileInputClassName"
+                :id="importFileInputId"
+                style="display: none;"
             /> 
         </div>
         <div class="menu-icons-div">
@@ -193,7 +194,7 @@ import Vue from "vue";
 import { useStore, settingsStore } from "@/store/store";
 import {saveContentToFile, readFileContent, fileNameRegex, strypeFileExtension, isMacOSPlatform} from "@/helpers/common";
 import { AppEvent, CaretPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, Locale, MessageDefinitions, MIMEDesc, PythonExecRunningState, SaveRequestReason, ShareProjectMode, SlotCoreInfos, SlotCursorInfos, SlotType, StrypePEALayoutMode, StrypeSyncTarget } from "@/types/types";
-import {countEditorCodeErrors, CustomEventTypes, fileImportSupportedFormats, getAppLangSelectId, getAppSimpleMsgDlgId, getEditorCodeErrorsHTMLElements, getEditorMenuUID, getFrameHeaderUID, getFrameUID, getGoogleDriveComponentRefId, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getNearestErrorIndex, getSaveAsProjectModalDlg, getSaveStrypeProjectToFSButtonId, getStrypeSaveProjectNameInputId, isElementEditableLabelSlotInput, isElementUIDFrameHeader, isIdAFrameId, parseFrameHeaderUID, parseFrameUID, parseLabelSlotUID, setDocumentSelection, sharedStrypeProjectIdKey, sharedStrypeProjectTargetKey, getSaveProjectLinkId, getNewProjectLinkId} from "@/helpers/editor";
+import {countEditorCodeErrors, CustomEventTypes, fileImportSupportedFormats, getAppLangSelectId, getAppSimpleMsgDlgId, getEditorCodeErrorsHTMLElements, getEditorMenuUID, getFrameHeaderUID, getFrameUID, getGoogleDriveComponentRefId, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getNearestErrorIndex, getSaveAsProjectModalDlg, getSaveStrypeProjectToFSButtonId, getStrypeSaveProjectNameInputId, isElementEditableLabelSlotInput, isElementUIDFrameHeader, isIdAFrameId, parseFrameHeaderUID, parseFrameUID, parseLabelSlotUID, setDocumentSelection, sharedStrypeProjectIdKey, sharedStrypeProjectTargetKey, getSaveProjectLinkId, getNewProjectLinkId, getImportFileInputId} from "@/helpers/editor";
 import { Slide } from "vue-burger-menu";
 import { mapStores } from "pinia";
 import GoogleDrive from "@/components/GoogleDrive.vue";
@@ -406,6 +407,10 @@ export default Vue.extend({
         
         saveProjectLinkId(): string {
             return getSaveProjectLinkId();
+        },
+        
+        importFileInputId(): string {
+            return getImportFileInputId();
         },
 
         saveProjectKBShortcut(): string {
@@ -1288,10 +1293,6 @@ export default Vue.extend({
     margin-top: 10px !important;
     margin-bottom: 10px !important;
 }
-
-.#{$strype-classname-editor-file-input} {
-    display: none;
-} 
 
 .show-menu-btn {
     border: none;

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -499,6 +499,10 @@ export function getSaveProjectLinkId(): string {
     return "saveStrypeProjLink";
 }
 
+export function getImportFileInputId(): string {
+    return "importFileInput";
+}
+
 export function getGoogleDriveComponentRefId(): string {
     return "googleDriveComponent";
 }

--- a/src/helpers/load-save.ts
+++ b/src/helpers/load-save.ts
@@ -6,9 +6,8 @@ export function saveDivider(divider: StrypeLayoutDividerSettings | undefined) : 
     }
     const obj: Record<string, number> = {};
     Object.entries(divider).forEach(([key, value]) => {
-        const name = StrypePEALayoutMode[key as unknown as number]; // Get name instead of number; makes it easier to accommodate future code changes
         if (value !== undefined) {
-            obj[name] = Math.round(value * 100) / 100; // round to 2 decimals
+            obj[key] = Math.round(value * 100) / 100; // round to 2 decimals
         }
     });
     return JSON.stringify(obj);    

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import AsyncComputed from "vue-async-computed";
 import { StrypePlatform } from "./types/types";
 import scssVars  from "@/assets/style/_export.module.scss";
 import { WINDOW_STRYPE_HTMLIDS_PROPNAME, WINDOW_STRYPE_SCSSVARS_PROPNAME } from "./helpers/sharedIdCssWithTests";
-import {getAppLangSelectId, getEditorID, getEditorMenuUID, getFrameBodyUID, getFrameContainerUID, getFrameHeaderUID, getFrameLabelSlotsStructureUID, getFrameUID, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getNewProjectLinkId, getSaveProjectLinkId, getSaveStrypeProjectToFSButtonId, getStrypeSaveProjectNameInputId} from "./helpers/editor";
+import {getAppLangSelectId, getEditorID, getEditorMenuUID, getFrameBodyUID, getFrameContainerUID, getFrameHeaderUID, getFrameLabelSlotsStructureUID, getFrameUID, getImportFileInputId, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getNewProjectLinkId, getSaveProjectLinkId, getSaveStrypeProjectToFSButtonId, getStrypeSaveProjectNameInputId} from "./helpers/editor";
 /* IFTRUE_isPython */
 import {getPEATabContentContainerDivId} from "./helpers/editor";
 /* FITRUE_isPython */
@@ -70,6 +70,7 @@ export function getLocaleBuildDate(): string {
     getLoadProjectLinkId: getLoadProjectLinkId,
     getLoadFromFSStrypeButtonId: getLoadFromFSStrypeButtonId,
     getSaveProjectLinkId: getSaveProjectLinkId,
+    getImportFileInputId: getImportFileInputId,
     getAppLangSelectId: getAppLangSelectId,
     getFrameLabelSlotId: getLabelSlotUID,
     getStrypeSaveProjectNameInputId: getStrypeSaveProjectNameInputId,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1140,10 +1140,10 @@ export interface Locale {
 }
 
 export enum StrypePEALayoutMode {
-    tabsCollapsed, // the default layout mode where PEA is collapsed and using tabs for console/graphics (and selected mode for the micro:bit version)
-    tabsExpanded, // the layout mode where PEA is expanded and using tabs for console/graphics
-    splitCollapsed, // the layout mode where PEA is collapsed and console/graphics windows are (horizontally) split
-    splitExpanded, // the layout mode where PEA is expanded and console/graphics windows are (vertically) split
+    tabsCollapsed = "tabsCollapsed", // the default layout mode where PEA is collapsed and using tabs for console/graphics (and selected mode for the micro:bit version)
+    tabsExpanded = "tabsExpanded", // the layout mode where PEA is expanded and using tabs for console/graphics
+    splitCollapsed = "splitCollapsed", // the layout mode where PEA is collapsed and console/graphics windows are (horizontally) split
+    splitExpanded = "splitExpanded", // the layout mode where PEA is expanded and console/graphics windows are (vertically) split
 }
 export interface StrypePEALayoutData {
     mode: StrypePEALayoutMode, // The layout view for the PEA in Strype, see related enum
@@ -1158,10 +1158,10 @@ export type StrypeLayoutDividerSettings = {
 };
 
 export const defaultEmptyStrypeLayoutDividerSettings: StrypeLayoutDividerSettings = {
-    "0": undefined,
-    "1": undefined,
-    "2": undefined,
-    "3": undefined,
+    [StrypePEALayoutMode.tabsCollapsed]: undefined,
+    [StrypePEALayoutMode.tabsExpanded]: undefined,
+    [StrypePEALayoutMode.splitCollapsed]: undefined,
+    [StrypePEALayoutMode.splitExpanded]: undefined,
 };
 
 export interface LoadedMedia {

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -103,7 +103,7 @@ function testRoundTripImportAndDownload(filepath: string) {
         // The "button" for the target selection is now a div element.
         cy.get("#" + strypeElIds.getLoadFromFSStrypeButtonId()).click();
         // Must force because the <input> is hidden:
-        cy.get("." + scssVars.editorFileInputClassName).selectFile(filepath, {force : true});
+        cy.get("#" + strypeElIds.getImportFileInputId()).selectFile(filepath, {force : true});
         cy.wait(2000);
         
         // We must make sure there are no comment frames starting "(=>" because that would indicate

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -67,7 +67,7 @@ function checkDownloadedFileEquals(fullContent: string, filename: string, firstS
 
     cy.readFile(destFile).then((p : string) => {
         // Print out full version in message (without escaped \n), to make it easier to diff:
-        expect(p, "Actual unescaped:\n" + p).to.equal(fullContent);
+        expect(p, "Actual unescaped:\n" + p).to.equal(fullContent.replaceAll("\r\n", "\n"));
     });
 }
 

--- a/tests/cypress/e2e/translation.cy.ts
+++ b/tests/cypress/e2e/translation.cy.ts
@@ -205,7 +205,7 @@ describe("Locale persistence", () => {
         // Part 2 : open the project saved in Preparation 1 and check that content is compliant, locale isn't changed.
         // Due to the Cypress environment, we need to by-pass Strype's mechanism that opens the file selector via the UI.
         // Instead, we directly use Strype's input-file HTML element that would be used in a normal workflow.
-        cy.get("input." + scssVars.editorFileInputClassName).selectFile(path.join(downloadsFolder, "My project.spy"), {force: true});
+        cy.get("#" + strypeElIds.getImportFileInputId()).selectFile(path.join(downloadsFolder, "My project.spy"), {force: true});
         // Wait a bit for the download, and compare that ... 
         cy.wait(1000);
         // 1) the file content is the same as expected (and they aren't empty!)

--- a/tests/cypress/fixtures/project-layout-tabs-expanded-collapsed.spy
+++ b/tests/cypress/fixtures/project-layout-tabs-expanded-collapsed.spy
@@ -1,6 +1,6 @@
 #(=> Strype:1:std
-#(=> editorCommandsSplitterPane2Size:{"tabsExpanded":50}
 #(=> peaLayoutMode:tabsCollapsed
+#(=> peaExpandedSplitterPane2Size:{"tabsCollapsed":50,"tabsExpanded":50}
 #(=> Section:Imports
 #(=> Section:Definitions
 #(=> Section:Main

--- a/tests/cypress/fixtures/project-layout-tabs-expanded-collapsed.spy
+++ b/tests/cypress/fixtures/project-layout-tabs-expanded-collapsed.spy
@@ -1,6 +1,6 @@
 #(=> Strype:1:std
 #(=> peaLayoutMode:tabsCollapsed
-#(=> peaExpandedSplitterPane2Size:{"tabsCollapsed":50,"tabsExpanded":50}
+#(=> peaExpandedSplitterPane2Size:{"tabsExpanded":50}
 #(=> Section:Imports
 #(=> Section:Definitions
 #(=> Section:Main

--- a/tests/cypress/fixtures/project-layout-tabs-expanded.spy
+++ b/tests/cypress/fixtures/project-layout-tabs-expanded.spy
@@ -1,6 +1,6 @@
 #(=> Strype:1:std
-#(=> editorCommandsSplitterPane2Size:{"tabsExpanded":50}
 #(=> peaLayoutMode:tabsExpanded
+#(=> peaExpandedSplitterPane2Size:{"tabsExpanded":50}
 #(=> Section:Imports
 #(=> Section:Definitions
 #(=> Section:Main

--- a/tests/cypress/support/paste-test-support.ts
+++ b/tests/cypress/support/paste-test-support.ts
@@ -143,7 +143,7 @@ export function testRoundTripImportAndDownload(filepath: string, expected?: stri
         // The "button" for the target selection is now a div element.
         cy.get("#" + strypeElIds.getLoadFromFSStrypeButtonId()).click();
         // Must force because the <input> is hidden:
-        cy.get("." + scssVars.editorFileInputClassName).selectFile(filepath, {force : true});
+        cy.get("#" + strypeElIds.getImportFileInputId()).selectFile(filepath, {force : true});
         cy.wait(2000);
 
         checkDownloadedCodeEquals(expected ?? py);

--- a/tests/playwright/e2e/load-save-dividers.spec.ts
+++ b/tests/playwright/e2e/load-save-dividers.spec.ts
@@ -18,9 +18,13 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
 });
 
 
-async function loadCode(page: Page, spyToLoad: string) : Promise<void> {
+async function loadHeader(page: Page, spyToLoad: string) : Promise<void> {
     const path = "tests/cypress/downloads/toload.spy";
-    fs.writeFileSync(path, spyToLoad);
+    fs.writeFileSync(path, spyToLoad + `
+#(=> Section:Imports
+#(=> Section:Definitions
+#(=> Section:Main
+#(=> Section:End`.trimStart());
     await load(page, path);
 }
 
@@ -41,43 +45,91 @@ async function dragDividerTo(page: Page, locator: string, x: number, y: number) 
     
     await page.mouse.move(currentX, currentY);
     await page.mouse.down();
-    await page.mouse.move(x, y, { steps: 100 });
+    await page.mouse.move(x, y, { steps: 1 });
     await page.mouse.up();
 
 }
 
-test.describe("Divider states", () => {
-    test("Saves main divider state", async ({page}) => {
-        await page.waitForTimeout(10 * 1000);
-        await dragDividerTo(page, ".strype-split-theme.splitpanes.splitpanes--vertical > .splitpanes__splitter", 10, 300);
-        const path = await save(page);
-        const saved = fs.readFileSync(path, "utf8");
-        expect(saved).toEqual(`
-#(=> Strype:1:std
-#(=> editorCommandsSplitterPane2Size:{"tabsCollapsed":67}
+async function saveAndCheck(page: Page, dividerStates: RegExp[]) {
+    const path = await save(page);
+    const saved = fs.readFileSync(path, "utf8");
+    const savedLines = saved.split(/\r?\n/);
+    expect(savedLines[0]).toEqual("#(=> Strype:1:std");
+    for (let i = 0; i < dividerStates.length; i++) {
+        expect(savedLines[1 + i]).toMatch(/^#\(=> .*/);
+        expect(savedLines[1 + i].slice("#(=> ".length)).toMatch(dividerStates[i]);
+    }
+    expect(savedLines.slice(1 + dividerStates.length)).toEqual(`
 #(=> Section:Imports
 #(=> Section:Definitions
 #(=> Section:Main
 myString  = "Hello from Python!" 
 print(myString) 
 #(=> Section:End
-`.trimStart());
-        
+`.trimStart().split(/\r?\n/));
+}
+
+const CODE_VS_SIDEBAR = ".strype-split-theme.splitpanes.splitpanes--vertical > .splitpanes__splitter";
+const COMMANDS_VS_PEA = ".splitpanes.splitpanes--horizontal.strype-commands-pea-splitter-theme > .splitpanes__splitter";
+
+test.describe("Divider states", () => {
+    test("Saves main divider state", async ({page}) => {
+        await page.waitForTimeout(10 * 1000);
+        await dragDividerTo(page, CODE_VS_SIDEBAR, 10, 300);
+        await saveAndCheck(page, [/editorCommandsSplitterPane2Size:\{"tabsCollapsed":67\}/]);
     });
+    test("Saves secondary divider state", async ({page}) => {
+        await page.waitForTimeout(10 * 1000);
+        await dragDividerTo(page, COMMANDS_VS_PEA, 1000, 10);
+        await saveAndCheck(page, [/peaCommandsSplitterPane2Size:\{"tabsCollapsed":9[0-9].?[0-9]*\}/]);
+    });
+    test("Saves main and secondary divider state", async ({page}) => {
+        await page.waitForTimeout(10 * 1000);
+        await dragDividerTo(page, COMMANDS_VS_PEA, 1000, 10);
+        await page.waitForTimeout(5 * 1000);
+        await dragDividerTo(page, CODE_VS_SIDEBAR, 10, 300);
+        
+        await saveAndCheck(page, [/editorCommandsSplitterPane2Size:\{"tabsCollapsed":67\}/, /peaCommandsSplitterPane2Size:\{"tabsCollapsed":9[0-9].?[0-9]*\}/]);
+    });
+    
     test("Loads main divider state", async ({page}) => {
-        loadCode(page, `
+        loadHeader(page, `
 #(=> Strype:1:std
 #(=> editorCommandsSplitterPane2Size:{"tabsCollapsed":50}
 #(=> peaLayoutMode:tabsCollapsed
-#(=> Section:Imports
-#(=> Section:Definitions
-#(=> Section:Main
-#(=> Section:End
 `.trimStart());
         await page.waitForTimeout(10 * 1000);
         // Now check divider is in right position:
-        const pos = await getSplitterPos(page, ".strype-split-theme.splitpanes.splitpanes--vertical > .splitpanes__splitter");
+        const pos = await getSplitterPos(page, CODE_VS_SIDEBAR);
         const viewport = page.viewportSize();
         expect(Math.abs((viewport?.width ?? 9999) / 2 - pos.x)).toBeLessThanOrEqual(5);
     });
+    test("Loads secondary divider state", async ({page}) => {
+        loadHeader(page, `
+#(=> Strype:1:std
+#(=> peaCommandsSplitterPane2Size:{"tabsCollapsed":50}
+#(=> peaLayoutMode:tabsCollapsed
+`.trimStart());
+        await page.waitForTimeout(10 * 1000);
+        // Now check divider is in right position:
+        const pos = await getSplitterPos(page, COMMANDS_VS_PEA);
+        const viewport = page.viewportSize();
+        expect(Math.abs((viewport?.height ?? 9999) / 2 - pos.y)).toBeLessThanOrEqual(5);
+    });
+    test("Loads main and secondary divider state", async ({page}) => {
+        loadHeader(page, `
+#(=> Strype:1:std
+#(=> editorCommandsSplitterPane2Size:{"tabsCollapsed":50}
+#(=> peaCommandsSplitterPane2Size:{"tabsCollapsed":50}
+#(=> peaLayoutMode:tabsCollapsed
+`.trimStart());
+        await page.waitForTimeout(10 * 1000);
+        // Now check divider is in right position:
+        const posA = await getSplitterPos(page, CODE_VS_SIDEBAR);
+        const posB = await getSplitterPos(page, COMMANDS_VS_PEA);
+        const viewport = page.viewportSize();
+        expect(Math.abs((viewport?.width ?? 9999) / 2 - posA.x)).toBeLessThanOrEqual(5);
+        expect(Math.abs((viewport?.height ?? 9999) / 2 - posB.y)).toBeLessThanOrEqual(5);
+    });
 });
+

--- a/tests/playwright/e2e/load-save-dividers.spec.ts
+++ b/tests/playwright/e2e/load-save-dividers.spec.ts
@@ -75,7 +75,7 @@ print(myString)
 
 const CODE_VS_SIDEBAR = ".strype-split-theme.splitpanes.splitpanes--vertical > .splitpanes__splitter";
 const COMMANDS_VS_PEA = ".splitpanes.splitpanes--horizontal.strype-commands-pea-splitter-theme > .splitpanes__splitter";
-const TOP_VS_EXPANDED_BOTTOM = ".expanded-PEA-splitter-overlay.strype-split-theme.splitpanes.splitpanes--horizontal > .splitpanes__splitter"
+const TOP_VS_EXPANDED_BOTTOM = ".expanded-PEA-splitter-overlay.strype-split-theme.splitpanes.splitpanes--horizontal > .splitpanes__splitter";
 
 test.describe("Saves divider states", () => {
     test("Saves main divider state", async ({page}) => {

--- a/tests/playwright/e2e/load-save-dividers.spec.ts
+++ b/tests/playwright/e2e/load-save-dividers.spec.ts
@@ -1,0 +1,83 @@
+import {Page, test, expect} from "@playwright/test";
+import {load, save} from "../support/loading-saving";
+import fs from "fs";
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+
+    await page.goto("./", {waitUntil: "load"});
+    await page.waitForSelector("body");
+    //scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
+    //strypeElIds = await page.evaluate(() => (window as any)["StrypeHTMLELementsIDsGlobals"]);
+    await page.evaluate(() => {
+        (window as any).Playwright = true;
+    });
+    // Make browser's console.log output visible in our logs (useful for debugging):
+    page.on("console", (msg) => {
+        console.log("Browser log:", msg.text());
+    });
+});
+
+
+async function loadCode(page: Page, spyToLoad: string) : Promise<void> {
+    const path = "tests/cypress/downloads/toload.spy";
+    fs.writeFileSync(path, spyToLoad);
+    await load(page, path);
+}
+
+async function getSplitterPos(page: Page, locator: string) {
+    const splitter = await page.locator(locator);
+    const box = await splitter.boundingBox({timeout: 5000});
+    if (!box) {
+        throw new Error("Could not get splitter position");
+    }
+    return box;
+}
+
+async function dragDividerTo(page: Page, locator: string, x: number, y: number) : Promise<void> {
+    const box = await getSplitterPos(page, locator);
+
+    const currentX = box.x + box.width / 2;
+    const currentY = box.y + box.height / 2;
+    
+    await page.mouse.move(currentX, currentY);
+    await page.mouse.down();
+    await page.mouse.move(x, y, { steps: 100 });
+    await page.mouse.up();
+
+}
+
+test.describe("Divider states", () => {
+    test("Saves main divider state", async ({page}) => {
+        await page.waitForTimeout(10 * 1000);
+        await dragDividerTo(page, ".strype-split-theme.splitpanes.splitpanes--vertical > .splitpanes__splitter", 10, 300);
+        const path = await save(page);
+        const saved = fs.readFileSync(path, "utf8");
+        expect(saved).toEqual(`
+#(=> Strype:1:std
+#(=> editorCommandsSplitterPane2Size:{"tabsCollapsed":67}
+#(=> Section:Imports
+#(=> Section:Definitions
+#(=> Section:Main
+myString  = "Hello from Python!" 
+print(myString) 
+#(=> Section:End
+`.trimStart());
+        
+    });
+    test("Loads main divider state", async ({page}) => {
+        loadCode(page, `
+#(=> Strype:1:std
+#(=> editorCommandsSplitterPane2Size:{"tabsCollapsed":50}
+#(=> peaLayoutMode:tabsCollapsed
+#(=> Section:Imports
+#(=> Section:Definitions
+#(=> Section:Main
+#(=> Section:End
+`.trimStart());
+        await page.waitForTimeout(10 * 1000);
+        // Now check divider is in right position:
+        const pos = await getSplitterPos(page, ".strype-split-theme.splitpanes.splitpanes--vertical > .splitpanes__splitter");
+        const viewport = page.viewportSize();
+        expect(Math.abs((viewport?.width ?? 9999) / 2 - pos.x)).toBeLessThanOrEqual(5);
+    });
+});

--- a/tests/playwright/e2e/load-save-dividers.spec.ts
+++ b/tests/playwright/e2e/load-save-dividers.spec.ts
@@ -23,6 +23,8 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
 
 
 async function loadHeader(page: Page, spyToLoad: string) : Promise<void> {
+    // The recursive option stops it failing if the dir exists:
+    fs.mkdirSync("tests/cypress/downloads/", { recursive: true });
     const path = "tests/cypress/downloads/toload.spy";
     fs.writeFileSync(path, spyToLoad + `
 #(=> Section:Imports

--- a/tests/playwright/e2e/load-save-random.spec.ts
+++ b/tests/playwright/e2e/load-save-random.spec.ts
@@ -359,7 +359,7 @@ async function load(page: Page, filepath: string) : Promise<void> {
     // The "button" for the target selection is now a div element.
     await page.click("#" + await strypeElIds.getLoadFromFSStrypeButtonId());
     // Must force because the <input> is hidden:
-    await page.setInputFiles("." + scssVars.editorFileInputClassName, filepath);
+    await page.setInputFiles("#" + await strypeElIds.getImportFileInputId(), filepath);
     await page.waitForTimeout(2000);
 }
 

--- a/tests/playwright/e2e/load-save-random.spec.ts
+++ b/tests/playwright/e2e/load-save-random.spec.ts
@@ -11,20 +11,7 @@ import {Page, test, expect, ElementHandle, JSHandle} from "@playwright/test";
 import { rename } from "fs/promises";
 import {checkFrameXorTextCursor, typeIndividually} from "../support/editor";
 import {readFileSync} from "node:fs";
-
-function createBrowserProxy(page: Page, objectName: string) : any {
-    return new Proxy({}, {
-        get(_, prop: string) {
-            return async (...args: any[]) => {
-                return await page.evaluate(
-                    ([objectName, method, args]) =>
-                        (window as any)[objectName as string][method as string](...args),
-                    [objectName, prop, args]
-                );
-            };
-        },
-    });
-}
+import {createBrowserProxy} from "../support/proxy";
 
 let scssVars: {[varName: string]: string};
 let strypeElIds: {[varName: string]: (...args: any[]) => Promise<string>};

--- a/tests/playwright/e2e/structured-expressions-navigation.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-navigation.spec.ts
@@ -57,7 +57,7 @@ async function loadPY(page: Page, filepath: string) {
     await clickId(page, () => (window as any)["StrypeHTMLELementsIDsGlobals"].getEditorMenuUID());
     await clickId(page, () => (window as any)["StrypeHTMLELementsIDsGlobals"].getLoadProjectLinkId());
     // The "button" for the target selection is now a div element.
-    await page.locator("." + scssVars.editorFileInputClassName).setInputFiles(path.join(__dirname, filepath));
+    await page.locator("#" + await strypeElIds.getImportFileInputId()).setInputFiles(path.join(__dirname, filepath));
     await clickId(page, () => (window as any)["StrypeHTMLELementsIDsGlobals"].getLoadFromFSStrypeButtonId());
     // Wait for everything to settle:
     await page.waitForTimeout(2000);

--- a/tests/playwright/e2e/structured-expressions-navigation.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-navigation.spec.ts
@@ -1,14 +1,19 @@
 import {Page, test, expect} from "@playwright/test";
 import path from "path";
-import {checkFrameXorTextCursor} from "../support/editor";
+import {checkFrameXorTextCursor, doPagePaste} from "../support/editor";
+import fs from "fs";
+import {WINDOW_STRYPE_HTMLIDS_PROPNAME} from "@/helpers/sharedIdCssWithTests";
+import {createBrowserProxy} from "../support/proxy";
+import en from "@/localisation/en/en_main.json";
+import {readFileSync} from "node:fs";
 
 let scssVars: {[varName: string]: string};
-//let strypeElIds: {[varName: string]: (...args: any[]) => string};
+let strypeElIds: {[varName: string]: (...args: any[]) => string};
 test.beforeEach(async ({ page }) => {
     await page.goto("./", {waitUntil: "load"});
     await page.waitForSelector("body");
     scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
-    //strypeElIds = await page.evaluate(() => (window as any)["StrypeHTMLELementsIDsGlobals"]);
+    strypeElIds = createBrowserProxy(page, WINDOW_STRYPE_HTMLIDS_PROPNAME);
     await page.evaluate(() => {
         (window as any).Playwright = true;
     });
@@ -17,6 +22,31 @@ test.beforeEach(async ({ page }) => {
         console.log("Browser log:", msg.text());
     });
 });
+
+async function save(page: Page, firstSave = true) : Promise<string> {
+    // Save is located in the menu, so we need to open it first, then find the link and click on it:
+    await page.click("#" + await strypeElIds.getEditorMenuUID());
+
+    let download;
+    if (firstSave) {
+        await page.click("#" + await strypeElIds.getSaveProjectLinkId());
+        // For testing, we always want to save to this device:
+        await page.getByText(en.appMessage.targetFS).click();
+        [download] = await Promise.all([
+            page.waitForEvent("download"),
+            page.click("button.btn:has-text('OK')"),
+        ]);
+    }
+    else {
+        [download] = await Promise.all([
+            page.waitForEvent("download"),
+            page.click("#" + await strypeElIds.getSaveProjectLinkId()),
+        ]);
+    }
+    const filePath = await download.path();
+    return filePath;
+}
+
 
 async function clickId(page: Page, getIdClientSide: () => void) {
     const id = await page.evaluate(getIdClientSide);
@@ -48,7 +78,7 @@ async function loadPY(page: Page, filepath: string) {
 // machine and it works fine, but I see in the video that the test fails in Playwright
 // (pressing right out of a comment frame puts the cursor at the beginning and makes a frame cursor).
 // Since it works in the real browsers, and on Webkit and Firefox, we just skip the tests in Chromium
-test.describe("Check navigation", async () => {
+test.describe("Check navigation", () => {
     test("Starts valid", async ({page}) => {
         await checkFrameXorTextCursor(page);
     });
@@ -125,5 +155,41 @@ test.describe("Check navigation", async () => {
             await page.keyboard.press("Tab");
             await page.waitForTimeout(75);
         }
+    });
+});
+
+test.describe("Check clicking near image literal", () => {
+    // Bug https://github.com/k-pet-group/Strype/issues/473:
+    test("Click near image literal", async ({page}) => {
+        await page.keyboard.press("Delete");
+        await page.keyboard.press("Delete");
+        await page.keyboard.type(" ");
+        await page.keyboard.type("Actor(");
+        const image = fs.readFileSync("public/graphics_images/cat-test.jpg").toString("base64");
+        await doPagePaste(page, image, "image/jpeg");
+        await page.waitForTimeout(500);
+        const element = await page.$("." + scssVars.labelSlotMediaClassName);
+        if (!element) {
+            throw new Error("Element not found");
+        }
+        const box = await element.boundingBox();
+        if (!box) {
+            throw new Error("Bounding box not available");
+        }
+        const clickX = box.x + box.width + 5; // 5px to the right
+        const clickY = box.y + box.height / 2; // vertically centered
+        await page.mouse.click(clickX, clickY);
+        await page.keyboard.type(".foo", {delay: 100});
+
+        const savePath = await save(page);
+        const contents = readFileSync(savePath, "utf8");
+        expect(contents).toEqual(`
+#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+#(=> Section:Main
+Actor(load_image("data:image/jpeg;base64,${image}").foo) 
+#(=> Section:End
+`.trimStart());
     });
 });

--- a/tests/playwright/support/loading-saving.ts
+++ b/tests/playwright/support/loading-saving.ts
@@ -1,0 +1,39 @@
+import {strypeElIds} from "./proxy";
+import {Page} from "@playwright/test";
+import en from "../../../src/localisation/en/en_main.json";
+
+
+export async function load(page: Page, filepath: string) : Promise<void> {
+
+    await page.click("#" + await strypeElIds(page).getEditorMenuUID());
+    await page.click("#" + await strypeElIds(page).getLoadProjectLinkId());
+    // The "button" for the target selection is now a div element.
+    await page.click("#" + await strypeElIds(page).getLoadFromFSStrypeButtonId());
+    // Must force because the <input> is hidden:
+    await page.setInputFiles("#" + await strypeElIds(page).getImportFileInputId(), filepath);
+    await page.waitForTimeout(2000);
+}
+
+export async function save(page: Page, firstSave = true) : Promise<string> {
+    // Save is located in the menu, so we need to open it first, then find the link and click on it:
+    await page.click("#" + await strypeElIds(page).getEditorMenuUID());
+
+    let download;
+    if (firstSave) {
+        await page.click("#" + await strypeElIds(page).getSaveProjectLinkId());
+        // For testing, we always want to save to this device:
+        await page.getByText(en.appMessage.targetFS).click();
+        [download] = await Promise.all([
+            page.waitForEvent("download"),
+            page.click("button.btn:has-text('OK')"),
+        ]);
+    }
+    else {
+        [download] = await Promise.all([
+            page.waitForEvent("download"),
+            page.click("#" + await strypeElIds(page).getSaveProjectLinkId()),
+        ]);
+    }
+    const filePath = await download.path();
+    return filePath;
+}

--- a/tests/playwright/support/proxy.ts
+++ b/tests/playwright/support/proxy.ts
@@ -1,0 +1,15 @@
+import {Page} from "@playwright/test";
+
+export function createBrowserProxy(page: Page, objectName: string) : any {
+    return new Proxy({}, {
+        get(_, prop: string) {
+            return async (...args: any[]) => {
+                return await page.evaluate(
+                    ([objectName, method, args]) =>
+                        (window as any)[objectName as string][method as string](...args),
+                    [objectName, prop, args]
+                );
+            };
+        },
+    });
+}

--- a/tests/playwright/support/proxy.ts
+++ b/tests/playwright/support/proxy.ts
@@ -1,4 +1,5 @@
 import {Page} from "@playwright/test";
+import {WINDOW_STRYPE_HTMLIDS_PROPNAME} from "@/helpers/sharedIdCssWithTests";
 
 export function createBrowserProxy(page: Page, objectName: string) : any {
     return new Proxy({}, {
@@ -12,4 +13,9 @@ export function createBrowserProxy(page: Page, objectName: string) : any {
             };
         },
     });
+}
+
+// Since the proxy is just a tiny wrapper, it's fine to recreate it every time we need it:
+export function strypeElIds(page: Page): {[varName: string]: (...args: any[]) => Promise<string>} {
+    return createBrowserProxy(page, WINDOW_STRYPE_HTMLIDS_PROPNAME);
 }


### PR DESCRIPTION
This fixes two bugs:
 - The cursor position not being right after clicking.  It put the cursor position after the invisible zero-width space in an empty slot before bracket, which messed things up.  Instead it should put it before that zero-width space.  (All the other code with keyboard clicking etc accounts for this, but not if you clicked the left-hand half of an operator or bracket.)
 - Dividers were not being saved properly.  This was down to a repeated name overwriting divider info, and an issue with Vue reactivity inside a splitter object.  From what GPT tells me, Vue reactivity works with string keys but we were using int keys that were auto converted to strings.  Certainly, when I swapped the enum to have string values rather than ints, the tests passed so that does seem to be the right fix.  We were already saving with string names so it doesn't affect .SPY loading.  Loading existing local browser state will momentarily forget the dividers in the first time after deploying but I think users will survive the one-off issue.

In the end, both bugs were short fixes.  But I added a bunch of tests to show up the errors and that's actually the bulk of the commits!  Might need a little more manual testing with the dividers to be sure we're happy, but I think it's not a critical bug even if needs further work in future.  