### PR TITLE
Improve line wrapping in frames, and fix another bug

### DIFF
--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -1215,6 +1215,7 @@ export default Vue.extend({
 .#{$strype-classname-frame-header} {
     border-radius: 5px;
     display: flex; 
+    flex-wrap: nowrap;
     justify-content: space-between;
 }
 

--- a/src/components/FrameHeader.vue
+++ b/src/components/FrameHeader.vue
@@ -101,7 +101,7 @@ export default Vue.extend({
 
 .label-slots-struct-wrapper  {
     max-width:100%;
-    flex-wrap:wrap;
+    flex-wrap: nowrap;
 }
 
 .hidden {

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -47,7 +47,7 @@ export const retrieveParentSlotFromSlotInfos = (slotInfos: SlotCoreInfos): Field
 // for example if the root slot has only 3 same level children (field/operator/field), ids will respectively be "0", "0" and "1"
 // if the root slot as 3 level children and the second of them has 3 same level children (again field/operator/field), ids will respectively be:
 // "0", "1,0", "1,0", "1,1", "2"
-export const generateFlatSlotBases = (slotStructure: SlotsStructure, parentId?: string, flatSlotConsumer?: (slot: FlatSlotBase, besidesOp: boolean, opAfter?: string) => void, transformEachLevel?: (oneLevel: SlotsStructure) => SlotsStructure): FlatSlotBase[] => {
+export const generateFlatSlotBases = (slotStructure: SlotsStructure, parentId?: string, flatSlotConsumer?: (slot: FlatSlotBase, besidesOp: boolean, opAfter?: string) => void, transformEachLevel?: (oneLevel: SlotsStructure, topLevel?: {frameType: string, slotIndex: number}) => SlotsStructure, topLevel?: {frameType: string, slotIndex: number}): FlatSlotBase[] => {
     // The operators always get in between the fields, and we always have one 1 root structure for a label,
     // and bracketed structures can never be found at 1st or last position
     let currIndex = -1;
@@ -61,7 +61,7 @@ export const generateFlatSlotBases = (slotStructure: SlotsStructure, parentId?: 
     };
     
     if (transformEachLevel) {
-        slotStructure = transformEachLevel(slotStructure);
+        slotStructure = transformEachLevel(slotStructure, topLevel);
     }
 
     slotStructure.operators.forEach((operatorSlot, index) => {

--- a/tests/playwright/e2e/load-save-random.spec.ts
+++ b/tests/playwright/e2e/load-save-random.spec.ts
@@ -993,4 +993,14 @@ test.describe("Enters, saves and loads specific frames", () => {
             {frameType: "funccall", slotContent: ["_0üB!_1_#[(B\\üB0)@{+ not in  not }( is not ) is not ]"]},
         ]]);
     });
+
+    test("Invalid commas", async ({page}) => {
+        await testSpecific(page, [[], [], [
+            {frameType: "if", slotContent: ["a,b,c==d"], body: [], joint: []},
+            {frameType: "while", slotContent: ["a,b,c==d"], body: []},
+            {frameType: "with", slotContent: ["a,b,c==d", "x,y,z"], body: []},
+            {frameType: "for", slotContent: ["a,b,c", "x,y,z==d"], body: [], joint: []},
+            {frameType: "varassign", slotContent: ["a,b,c", "x,y,z+5"]},
+        ]]);
+    });
 });


### PR DESCRIPTION
Two separate commits: one fixes a load/save bug I found (if you write "if a, b, c:" it would save but not load).  The other is about line-wrapping.

Here's the logic: we force all the nodes in a frame header to fit on one line.  Wrapping can occur within those nodes, but for example the trailing colon will always be on the end rather than wrapped.  I think this produces a better result.  Here's the *before*:

![long-identifiers-before](https://github.com/user-attachments/assets/94ae3c42-bffe-42d3-a871-de568b8c3bcc)

Note how the keywords tend to stack on top of their associated slot content: the awkward from and import being vertically stacked, ditto for with/as.

Here's the *after* behaviour of the same code:

![long-identifiers-after](https://github.com/user-attachments/assets/33c3ac5f-3acc-40c6-a393-1a5ed34a3639)

It's not 100% ideal but I think it's better.  The slots don't get bumped down and the keywords are more obviously in the right order.

(I'm merging this now because the docs work builds on this; if we're not happy then better to know now, before I add to it.)