### PR TITLE
Small patch for shared projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "strype-editor",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "strype-editor",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "dependencies": {
                 "@fortawesome/free-solid-svg-icons": "^5.15.4",
                 "@microbit/microbit-fs": "^0.9.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -640,6 +640,8 @@ export default Vue.extend({
                                 ).then(() => {
                                     alertMsgKey = "appMessage.retrievedSharedGenericProject";
                                     alertParams = this.appStore.projectName;
+                                    // A generic project is saved in memory, so we must make sure there is no target destination saved.
+                                    (this.$refs[this.menuUID] as InstanceType<typeof Menu>).saveTargetChoice(StrypeSyncTarget.none);
                                 },
                                 (reason) => {
                                     alertMsgKey = "errorMessage.retrievedSharedGenericProject";


### PR DESCRIPTION
Generic non Google Drive shared projects were showing as saved on the File System instead of none, once loaded.
This is a simple fix, and because of the CAS North East worskhop tomorrow, I'll deploy it on our server.
(Note that the reference for the build will be 1.1.1 to only bring up this change live - I will use this branch (the one to merge) as a patch and tag it for reference internally.