### PR TITLE
Simplify the autocomplete code

### DIFF
--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -270,11 +270,7 @@ export default Vue.extend({
         errorHeader(): string{
             return this.appStore.getErrorHeaderForSlot(this.coreSlotInfo);
         },
-
-        debugAC(): boolean{
-            return this.appStore.debugAC;
-        },
-
+        
         isDraggingFrame(): boolean{
             return this.appStore.isDraggingFrame;
         },
@@ -585,43 +581,42 @@ export default Vue.extend({
             // and that our slot still exists.  If we shouldn't exist any more, we should
             // just do nothing and exit quietly:
             if(this.appStore.frameObjects[this.frameId] != undefined && retrieveSlotFromSlotInfos(this.coreSlotInfo)){
-                if(!this.debugAC) {
-                    this.showAC = false;
-                    this.acRequested = false;
-                    if((this.appStore.bypassEditableSlotBlurErrorCheck && !keepIgnoreKeyEventFlagOn) || this.appStore.isSelectingMultiSlots){
-                        this.appStore.setEditableFocus(
-                            {
-                                ...this.coreSlotInfo,
-                                focused: false,
-                            }
-                        );
-                    }
-                    else{
-                        this.appStore.validateSlot(
-                            {
-                                ...this.coreSlotInfo,
-                                code: this.getSlotContent().replace(/\u200B/g, "").trim(),
-                                initCode: this.initCode,
-                                isFirstChange: this.isFirstChange,
-                            }   
-                        );
-                    }
-                    //reset the flag for first code change
-                    this.isFirstChange = true;
-
-                    // As we leave a slot, we reset the slot cursor infos EXCEPT when the keyboard event is ignored
-                    // or when we are doing multislot selection
-                    if(!this.appStore.ignoreKeyEvent && !this.appStore.isSelectingMultiSlots){
-                        this.appStore.setSlotTextCursors(undefined, undefined);
-                    }
-                    
-                    if(!keepIgnoreKeyEventFlagOn){
-                        this.appStore.ignoreKeyEvent = false;
-                    }
-
-                    // And we hide the error popover. Note that we do it programmatically as it seems the focus trigger on popover isn't working in our configuration
-                    (this.$refs.errorPopover as InstanceType<typeof BPopover>)?.$emit("close");
+                this.showAC = false;
+                this.acRequested = false;
+                if((this.appStore.bypassEditableSlotBlurErrorCheck && !keepIgnoreKeyEventFlagOn) || this.appStore.isSelectingMultiSlots){
+                    this.appStore.setEditableFocus(
+                        {
+                            ...this.coreSlotInfo,
+                            focused: false,
+                        }
+                    );
                 }
+                else{
+                    this.appStore.validateSlot(
+                        {
+                            ...this.coreSlotInfo,
+                            code: this.getSlotContent().replace(/\u200B/g, "").trim(),
+                            initCode: this.initCode,
+                            isFirstChange: this.isFirstChange,
+                        }   
+                    );
+                }
+                //reset the flag for first code change
+                this.isFirstChange = true;
+
+                // As we leave a slot, we reset the slot cursor infos EXCEPT when the keyboard event is ignored
+                // or when we are doing multislot selection
+                if(!this.appStore.ignoreKeyEvent && !this.appStore.isSelectingMultiSlots){
+                    this.appStore.setSlotTextCursors(undefined, undefined);
+                }
+                
+                if(!keepIgnoreKeyEventFlagOn){
+                    this.appStore.ignoreKeyEvent = false;
+                }
+
+                // And we hide the error popover. Note that we do it programmatically as it seems the focus trigger on popover isn't working in our configuration
+                (this.$refs.errorPopover as InstanceType<typeof BPopover>)?.$emit("close");
+            
             }
         },
 
@@ -714,7 +709,7 @@ export default Vue.extend({
             if(this.showAC && this.acRequested) {
                 event.preventDefault();
                 event.stopPropagation();
-                this.showAC = this.debugAC;
+                this.showAC = false;
                 this.acRequested = false;
                 return;
             }
@@ -805,7 +800,7 @@ export default Vue.extend({
                     );
                 }
             }
-            this.showAC = this.debugAC;
+            this.showAC = false;
             this.acRequested = false;
         },
 
@@ -1627,7 +1622,7 @@ export default Vue.extend({
                 }
             }        
             
-            this.showAC = this.debugAC;
+            this.showAC = false;
             this.acRequested = false;
         },
    

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -60,7 +60,7 @@
 
         <AutoCompletion
             v-show="focused && showAC"
-            :class="{ac: true, hidden: !acRequested}"
+            :class="{ac: true}"
             :slotId="UID"
             ref="AC"
             :key="AC_UID"
@@ -141,7 +141,6 @@ export default Vue.extend({
             //as we don't want to save each single change of the content, but the full content change itself.
             isFirstChange: true,
             showAC: false,
-            acRequested: false,
             contextAC: "",
             // tokenAC can be null if code completion is invalid here
             tokenAC: "" as string | null,
@@ -534,7 +533,6 @@ export default Vue.extend({
                     if (this.tokenAC.includes(",")) {
                         this.tokenAC = this.tokenAC.substring(this.tokenAC.lastIndexOf(",") + 1); 
                     }
-                    this.showAC = true;
                     this.contextAC = "";
                     this.$nextTick(() => {
                         const ac = this.$refs.AC as InstanceType<typeof AutoCompletion>;
@@ -553,7 +551,6 @@ export default Vue.extend({
                 }
                 else {
                     const resultsAC = getCandidatesForAC(frame.labelSlotsDict[this.labelSlotsIndex].slotStructures, new RegExp("[0-9,]+$").exec(this.slotId)?.[0]?.trim()?.split(",")?.map((x) => parseInt(x)) ?? []);
-                    this.showAC = true;
                     this.contextAC = resultsAC.contextAC;
                     this.tokenAC = resultsAC.tokenAC;
   
@@ -576,7 +573,6 @@ export default Vue.extend({
             // just do nothing and exit quietly:
             if(this.appStore.frameObjects[this.frameId] != undefined && retrieveSlotFromSlotInfos(this.coreSlotInfo)){
                 this.showAC = false;
-                this.acRequested = false;
                 if((this.appStore.bypassEditableSlotBlurErrorCheck && !keepIgnoreKeyEventFlagOn) || this.appStore.isSelectingMultiSlots){
                     this.appStore.setEditableFocus(
                         {
@@ -633,7 +629,7 @@ export default Vue.extend({
                 // If the AutoCompletion is on we just browse through it's contents
                 // The `results` check, prevents `changeSelection()` when there are no results matching this token
                 // And instead, since there is no AC list to show, moves to the next slot
-                if(this.showAC && this.acRequested && (this.$refs.AC as any)?.areResultsToShow()) {
+                if(this.showAC && (this.$refs.AC as any)?.areResultsToShow()) {
                     event.stopImmediatePropagation();
                     event.stopPropagation();
                     event.preventDefault();
@@ -700,11 +696,10 @@ export default Vue.extend({
             }
 
             // If the AC is loaded we want to close it with an ESC and stay focused on the editableSlot
-            if(this.showAC && this.acRequested) {
+            if(this.showAC) {
                 event.preventDefault();
                 event.stopPropagation();
                 this.showAC = false;
-                this.acRequested = false;
                 return;
             }
 
@@ -723,7 +718,7 @@ export default Vue.extend({
         onTabKeyDown(event: KeyboardEvent){
             // We replicate the default browser behaviour when tab is pressed AND we're not having AC on, otherwise just do nothing
             // (the default behaviour doesn't work at least on Windows+Chrome)
-            if(!(this.showAC && this.acRequested && this.getSelectedACItem())) {
+            if(!(this.showAC && this.getSelectedACItem())) {
                 // First move the cursor to the correct end of the slot
                 const goToNextSlot = !event.shiftKey;
                 const newCursorPosition = (goToNextSlot) ? this.code.length : 0;
@@ -750,7 +745,7 @@ export default Vue.extend({
             }
 
             // If the AC is loaded we want to select the AC suggestion the user chose and stay focused on the editableSlot
-            if(this.showAC && this.acRequested && this.getSelectedACItem()) {
+            if(this.showAC && this.getSelectedACItem()) {
                 event.preventDefault();
                 event.stopPropagation();
                 // We set the code to what it was up to the point before the token, and we replace the token with the selected Item
@@ -795,7 +790,6 @@ export default Vue.extend({
                 }
             }
             this.showAC = false;
-            this.acRequested = false;
         },
 
         onKeyDown(event: KeyboardEvent){
@@ -806,7 +800,7 @@ export default Vue.extend({
 
             // We capture the key shortcut for opening the a/c
             if((event.metaKey || event.ctrlKey) && event.key == " "){
-                this.acRequested = true;
+                this.showAC = true;
                 event.preventDefault();
                 event.stopPropagation();
                 event.stopImmediatePropagation();
@@ -1617,7 +1611,6 @@ export default Vue.extend({
             }        
             
             this.showAC = false;
-            this.acRequested = false;
         },
    
         isImportFrame(): boolean {

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -82,7 +82,7 @@ import { getCandidatesForAC } from "@/autocompletion/acManager";
 import { mapStores } from "pinia";
 import { checkCodeErrors, evaluateSlotType, getFlatNeighbourFieldSlotInfos, getOutmostDisabledAncestorFrameId, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isFrameLabelSlotStructWithCodeContent, retrieveParentSlotFromSlotInfos, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
 import Parser from "@/parser/parser";
-import { cloneDeep, debounce } from "lodash";
+import { cloneDeep } from "lodash";
 import LabelSlotsStructure from "./LabelSlotsStructure.vue";
 import { BPopover } from "bootstrap-vue";
 import Frame from "@/components/Frame.vue";
@@ -132,12 +132,6 @@ export default Vue.extend({
 
     beforeDestroy() {
         this.appStore.removePreCompileErrors(this.UID);
-    },
-    
-    created() {
-        // Stop updateAC firing until 500ms after last time it is requested.
-        // More efficient than running on every keystroke:
-        this.updateAC = debounce(this.updateAC, 500, {trailing: true});
     },
 
     data: function() {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -65,9 +65,6 @@ export const useStore = defineStore("app", {
             /** these flags need checking when a build is done **/
             debugging: initialState.debugging,
 
-            // Flag used to keep the AC shown for debug purposes
-            debugAC: false,
-
             showKeystroke: initialState.showKeystroke,
 
             frameObjects: cloneDeep(initialState.initialState),

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -136,7 +136,7 @@ function testEntryDisableAndSave(commands: string, disableFrames: string[], file
         cy.get("body").type(commands);
         
         disableFrames.forEach((txt) => {
-            cy.contains("span", txt).rightclick();
+            cy.contains("span." + scssVars.labelSlotInputClassName, txt).rightclick();
             cy.contains("*", i18n.t("contextMenu.disable") as string).click();
         });
 


### PR DESCRIPTION
This makes a few changes:
 - Remove the debugAC flag; I think we can live without it
 - Combine acRequested and showAC, and remove the debounc.  They seem to be almost identical, you can see the via the diff that they are usually manipulated together.  I think the only way this is different is that the AC shows immediately rather than waiting for updateAC; but since I've removed the debounce on updateAC (less necessary because the method it calls is now async, and we are using TigerPython rather than firing up Skulpt) I think this won't make any practical difference any more.

See what you think; it's not strictly a necessary change but I need to poke the AC code a little while doing the work on wrapping and comments so it seemed a good time to simplify things first.