### PR TITLE
Add documentation slot to function frames

### DIFF
--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -1214,8 +1214,6 @@ export default Vue.extend({
 
 .#{$strype-classname-frame-header} {
     border-radius: 5px;
-    display: flex; 
-    flex-wrap: nowrap;
     justify-content: space-between;
 }
 

--- a/src/components/FrameHeader.vue
+++ b/src/components/FrameHeader.vue
@@ -1,15 +1,17 @@
 <template>
     <div tabindex="-1" @focus="onFocus(true)" @blur="onFocus(false)" style="outline: none;">
-        <div class="frame-header-div">
+        <div :class="'frame-header-div-line' + (groupIndex > 0 ? ' frame-header-later-line' : '')"
+             v-for="(group, groupIndex) in splitAtNewLines(labels)"
+             :key="groupIndex">
             <div
-                class="next-to-eachother label-slots-struct-wrapper"
-                v-for="(item, index) in labels"
-                :key="item.label + frameId"
+                :class="'next-to-eachother label-slots-struct-wrapper' + (item.label=='\'\'\'' ? ' magicdoc' : '')"
+                v-for="({ item, originalIndex }) in group"
+                :key="originalIndex"
             >
                 <!-- the class isn't set on the parent div so the size of hidden editable slots can still be evaluated correctly -->
                 <div 
                     style="font-weight: 600;"
-                    :class="{['next-to-eachother ' + scssVars.framePythonTokenClassName]: true, hidden: isLabelHidden(item), leftMargin: index > 0, rightMargin: (item.label.length > 0), [scssVars.frameColouredLabelClassName]: !isCommentFrame}"
+                    :class="{['next-to-eachother ' + scssVars.framePythonTokenClassName]: true, hidden: isLabelHidden(item), leftMargin: originalIndex > 0, rightMargin: (item.label.length > 0), [scssVars.frameColouredLabelClassName]: !isCommentFrame}"
                     v-html="item.label"
                 >
                 </div>
@@ -18,7 +20,7 @@
                     :isDisabled="isDisabled"
                     :default-text="item.defaultText"
                     :frameId="frameId"
-                    :labelIndex="index"
+                    :labelIndex="originalIndex"
                 />
             </div>
         </div>
@@ -81,14 +83,38 @@ export default Vue.extend({
         areSlotsShown(labelDetails: FrameLabel): boolean {
             return labelDetails.showSlots??true;
         },
+
+        // Splits into a list of lists (each outer list is a line, with 1 or more items on it)
+        // by looking at the newLine flag in the FrameLabel.
+        splitAtNewLines(labels : FrameLabel[]) : {item: FrameLabel, originalIndex: number}[][] {
+            const result : {item: FrameLabel, originalIndex: number}[][] = [];
+            let currentGroup : {item: FrameLabel, originalIndex: number}[] = [];
+            labels.forEach((item, index) => {
+                if (item.newLine && currentGroup.length > 0) {
+                    result.push(currentGroup);
+                    currentGroup = [];
+                }
+                currentGroup.push({ item, originalIndex: index });
+            });
+            if (currentGroup.length > 0) {
+                result.push(currentGroup);
+            }
+            return result;
+        },
     },
 });
 </script>
 
 <style lang="scss">
-.frame-header-div {
+.frame-header-div-line {
     display: flex;
     width: 100%;
+}
+.frame-header-later-line {
+    margin-left: 30px;
+    margin-right: 28px;
+    margin-bottom: 10px;
+    width: auto !important;
 }
 
 .#{$strype-classname-frame-python-token} {

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -688,7 +688,7 @@ export default Vue.extend({
             // For Enter, if AC is not loaded or no selection is available, we want to take the focus out the slot,
             // except for comment frame that will generate a line return when Control/Shift is combined with Enter
             else if(event.key === "Enter"){
-                if(this.frameType == AllFrameTypesIdentifier.comment && (event.shiftKey || event.ctrlKey)){
+                if(this.slotType == SlotType.comment && (event.shiftKey || event.ctrlKey)){
                     const isAnchorBeforeFocus = (getSelectionCursorsComparisonValue()??0) <= 0;
                     const focusSlotCursorInfos = this.appStore.focusSlotCursorInfos as SlotCursorInfos;
                     const startSlotCursorInfos = (isAnchorBeforeFocus) ? this.appStore.anchorSlotCursorInfos as SlotCursorInfos : focusSlotCursorInfos;

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -275,9 +275,9 @@ export default Vue.extend({
                 return false;
             }            
             let firstVisibleLabelSlotsIndex = -1;
-            const isEmpty = !(Object.values(this.appStore.frameObjects[this.frameId].labelSlotsDict).some((labelSlotContent, index) => {
+            const isEmpty = !(Object.entries(this.appStore.frameObjects[this.frameId].labelSlotsDict).some(([index, labelSlotContent]) => {
                 if((labelSlotContent.shown??true) && firstVisibleLabelSlotsIndex < 0 ){
-                    firstVisibleLabelSlotsIndex = index;
+                    firstVisibleLabelSlotsIndex = Number(index);
                 }
                 return ((labelSlotContent.shown??true) && isFrameLabelSlotStructWithCodeContent(labelSlotContent.slotStructures));
             })

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -412,7 +412,7 @@ export default Vue.extend({
 
             // If we arrive here by a click, and the slot is a bracket, a quote or an operator, we should get the focus to the nearest editable frame.
             // We should have neigbours because brackets, quotes and operators are always surronded by fields, but keep TS happy
-            if(this.slotType != SlotType.code && this.slotType != SlotType.string){
+            if(this.slotType != SlotType.code && this.slotType != SlotType.string && this.slotType != SlotType.comment){
                 const clickXValue = event.x;
                 const slotWidth = document.getElementById(getLabelSlotUID(this.coreSlotInfo))?.offsetWidth??0;
                 const slotXPos = document.getElementById(getLabelSlotUID(this.coreSlotInfo))?.getBoundingClientRect().x??0; 

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -525,7 +525,7 @@ export function copyFramesFromParsedPython(codeLines: string[], currentStrypeLoc
     useStore().copiedSelectionFrameIds = [];
     try {
         // Use the next available ID to avoid clashing with any existing IDs:
-        copyFramesFromPython(parsedBySkulpt.parseTree, {nextId: useStore().nextAvailableId, addToNonJoint: useStore().copiedSelectionFrameIds, addToJoint: undefined, loadedFrames: useStore().copiedFrames, disabledLines: transformed.disabledLines, parent: null, jointParent: null, lastLineProcessed: 0, lineNumberToIndentation: indents, isSPY: transformed.strypeDirectives.size > 0});
+        copyFramesFromPython(parsedBySkulpt.parseTree, {nextId: useStore().nextAvailableId, addToNonJoint: useStore().copiedSelectionFrameIds, addToJoint: undefined, loadedFrames: useStore().copiedFrames, disabledLines: transformed.disabledLines, parent: null, jointParent: null, lastLineProcessed: 0, lineNumberToIndentation: indents, isSPY: transformed.strypeDirectives.size > 0, transformTopComment: undefined});
         // At this stage, we can make a sanity check that we can copy the given Python code in the current position in Strype (for example, no "import" in a function definition section)
         if(!canPastePythonAtStrypeLocation(currentStrypeLocation)){
             useStore().copiedFrames = {};

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -41,6 +41,7 @@ interface CopyState {
     jointParent: FrameObject | null; // The joint parent, if any, for borrowing the parent ID
     disabledLines: number[]; // The line numbers which had a Disabled: prefix
     lineNumberToIndentation: Map<number, string>; // Maps a line number to a string of indentation
+    transformTopComment: ((content: SlotsStructure) => void) | undefined; // If defined, consumes the top docstring-style comment rather than adding it as a frame.
     isSPY: boolean;
 }
 
@@ -865,7 +866,7 @@ function getRealLineNo(p: ParsedConcreteTree) : number | undefined {
 }
 
 // the given index for the body, and call addFrame on it.
-function makeAndAddFrameWithBody(p: ParsedConcreteTree, frameType: string, keywordIndexForLineno: number, childrenIndicesForSlots: (number | number[])[], childIndexForBody: number, s : CopyState) : {s: CopyState, frame: FrameObject} {
+function makeAndAddFrameWithBody(p: ParsedConcreteTree, frameType: string, keywordIndexForLineno: number, childrenIndicesForSlots: (number | number[])[], childIndexForBody: number, s : CopyState, transformTopComment?: (content: SlotsStructure, frame: FrameObject) => void) : {s: CopyState, frame: FrameObject} {
     const slots : { [index: number]: LabelSlotsContent} = {};
     for (let slotIndex = 0; slotIndex < childrenIndicesForSlots.length; slotIndex++) {
         slots[slotIndex] = {slotStructures : toSlots(applyIndex(p, childrenIndicesForSlots[slotIndex]))};
@@ -873,7 +874,7 @@ function makeAndAddFrameWithBody(p: ParsedConcreteTree, frameType: string, keywo
     const frame = makeFrame(frameType, slots, s.isSPY);    
     s = addFrame(frame, applyIndex(p, keywordIndexForLineno).lineno, s);
     const frameChildren = children(p);
-    const afterChild = copyFramesFromPython(frameChildren[childIndexForBody], {...s, addToNonJoint: frame.childrenIds, addToJoint: undefined, parent: frame});
+    const afterChild = copyFramesFromPython(frameChildren[childIndexForBody], {...s, addToNonJoint: frame.childrenIds, addToJoint: undefined, parent: frame, transformTopComment: transformTopComment ? ((s) => transformTopComment(s, frame)) : undefined});
     s = {...s, nextId: afterChild.nextId, lastLineProcessed: afterChild.lastLineProcessed};
     return {s: s, frame: frame};
 }
@@ -899,6 +900,8 @@ function copyFramesFromPython(p: ParsedConcreteTree, s : CopyState) : CopyState 
         // Wrappers where we just skip to the children:
         for (const child of children(p)) {
             s = copyFramesFromPython(child, s);
+            // After the first, it's no longer the top comment:
+            s.transformTopComment = undefined;
         }
         break;
     case Sk.ParseTables.sym.expr_stmt:
@@ -926,7 +929,14 @@ function copyFramesFromPython(p: ParsedConcreteTree, s : CopyState) : CopyState 
                 }
                 else {
                     // Everything else goes in method call:
-                    s = addFrame(makeFrame(AllFrameTypesIdentifier.funccall, {0: {slotStructures: slots}}, s.isSPY), p.lineno, s);
+                    const misc = makeFrame(AllFrameTypesIdentifier.funccall, {0: {slotStructures: slots}}, s.isSPY);
+                    if (misc.frameType.type == AllFrameTypesIdentifier.comment && s.transformTopComment) {
+                        s.transformTopComment(misc.labelSlotsDict[0].slotStructures);
+                        s = {...s, transformTopComment: undefined};
+                    }
+                    else {
+                        s = addFrame(misc, p.lineno, s);
+                    }
                 }
             }
         }
@@ -1089,10 +1099,18 @@ function copyFramesFromPython(p: ParsedConcreteTree, s : CopyState) : CopyState 
             }
         }
         break;
-    case Sk.ParseTables.sym.funcdef:
+    case Sk.ParseTables.sym.funcdef: {
         // First child is keyword, second is the name, third is params, fourth is colon, fifth is body
-        s = makeAndAddFrameWithBody(p, AllFrameTypesIdentifier.funcdef, 0, [1, 2], 4, s).s;
+        const r = makeAndAddFrameWithBody(p, AllFrameTypesIdentifier.funcdef, 0, [1, 2], 4, s, (comment : SlotsStructure, frame : FrameObject) => {
+            frame.labelSlotsDict[3] = {slotStructures: comment};
+        });
+        s = r.s;
+        // If we didn't find a top comment, add blank:
+        if (!(3 in r.frame.labelSlotsDict)) {
+            r.frame.labelSlotsDict[3] = {slotStructures: {operators: [], fields: [{code: ""}]}};
+        }
         break;
+    }
     }
     return s;
 }

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -2,7 +2,7 @@ import { getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
 import Parser from "@/parser/parser";
 import { useStore } from "@/store/store";
-import { AllFrameTypesIdentifier, BaseSlot, CaretPosition, CurrentFrame, EditorFrameObjects, FieldSlot, FlatSlotBase, FrameObject, getFrameDefType, isFieldBracketedSlot, isFieldStringSlot, isFieldMediaSlot, isSlotBracketType, isSlotCodeType, NavigationPosition, SlotCoreInfos, SlotCursorInfos, SlotInfos, SlotsStructure, SlotType, StrypePlatform } from "@/types/types";
+import { AllFrameTypesIdentifier, AllowedSlotContent, BaseSlot, CaretPosition, CurrentFrame, EditorFrameObjects, FieldSlot, FlatSlotBase, FrameLabel, FrameObject, getFrameDefType, isFieldBracketedSlot, isFieldMediaSlot, isFieldStringSlot, isSlotBracketType, isSlotCodeType, NavigationPosition, SlotCoreInfos, SlotCursorInfos, SlotInfos, SlotsStructure, SlotType, StrypePlatform } from "@/types/types";
 import Vue from "vue";
 import { checkEditorCodeErrors, countEditorCodeErrors, getCaretContainerUID, getLabelSlotUID, getMatchingBracket, parseLabelSlotUID } from "./editor";
 import { nextTick } from "@vue/composition-api";
@@ -27,6 +27,13 @@ export const retrieveSlotFromSlotInfos = (slotCoreInfos: SlotCoreInfos): FieldSl
         : (currentSlotStruct.fields[parseInt(slotsLevelPos.at(-1) as string)]);
 };
 
+// The parameter can accept a SlotCoreInfos although it doesn't need all of those fields.
+export const getSlotDefFromInfos = (slotCoreInfos: { frameId: number, labelSlotsIndex: number }): FrameLabel => {
+    // Get the slot definition from the frame type:    
+    return useStore().frameObjects[slotCoreInfos.frameId].frameType.labels[slotCoreInfos.labelSlotsIndex];
+};
+
+
 export const retrieveParentSlotFromSlotInfos = (slotInfos: SlotCoreInfos): FieldSlot | undefined => {
     // If the ID of the slot does not indicate any level, then there is no parent and we return undefined
     if(!slotInfos.slotId.includes(",")){
@@ -47,7 +54,8 @@ export const retrieveParentSlotFromSlotInfos = (slotInfos: SlotCoreInfos): Field
 // for example if the root slot has only 3 same level children (field/operator/field), ids will respectively be "0", "0" and "1"
 // if the root slot as 3 level children and the second of them has 3 same level children (again field/operator/field), ids will respectively be:
 // "0", "1,0", "1,0", "1,1", "2"
-export const generateFlatSlotBases = (slotStructure: SlotsStructure, parentId?: string, flatSlotConsumer?: (slot: FlatSlotBase, besidesOp: boolean, opAfter?: string) => void, transformEachLevel?: (oneLevel: SlotsStructure, topLevel?: {frameType: string, slotIndex: number}) => SlotsStructure, topLevel?: {frameType: string, slotIndex: number}): FlatSlotBase[] => {
+// The first argument can be passed a FrameLabel, or just the allowedSlotContent part.
+export const generateFlatSlotBases = (slot: { allowedSlotContent?: AllowedSlotContent }, slotStructure: SlotsStructure, parentId?: string, flatSlotConsumer?: (slot: FlatSlotBase, besidesOp: boolean, opAfter?: string) => void, transformEachLevel?: (oneLevel: SlotsStructure, topLevel?: {frameType: string, slotIndex: number}) => SlotsStructure, topLevel?: {frameType: string, slotIndex: number}): FlatSlotBase[] => {
     // The operators always get in between the fields, and we always have one 1 root structure for a label,
     // and bracketed structures can never be found at 1st or last position
     let currIndex = -1;
@@ -74,7 +82,7 @@ export const generateFlatSlotBases = (slotStructure: SlotsStructure, parentId?: 
             // 1) add the opening bracket
             addFlatSlot({id: slotId, code: fieldSlot.openingBracketValue as string, type:SlotType.openingBracket}, false);
             // 2) add what is inside the brackets
-            flatSlotBases.push(...generateFlatSlotBases(fieldSlot as SlotsStructure, slotId, flatSlotConsumer, transformEachLevel));
+            flatSlotBases.push(...generateFlatSlotBases(slot, fieldSlot as SlotsStructure, slotId, flatSlotConsumer, transformEachLevel));
             // 3) add the closing bracket
             addFlatSlot({id: slotId, code: getMatchingBracket(fieldSlot.openingBracketValue as string, true), type:SlotType.closingBracket}, false);
 
@@ -97,7 +105,7 @@ export const generateFlatSlotBases = (slotStructure: SlotsStructure, parentId?: 
                 ((operatorSlot.code !== "" && (index == 0 || slotStructure.operators[index - 1].code != ""))
                 || (index > 0 && slotStructure.operators[index - 1].code != "" && operatorSlot.code !== ""))
                 && !["not", "~"].includes(operatorSlot.code.trim());
-            addFlatSlot({...(fieldSlot as BaseSlot), id: slotId, type: evaluateSlotType(fieldSlot)}, adjacentOp, operatorSlot.code);
+            addFlatSlot({...(fieldSlot as BaseSlot), id: slotId, type: evaluateSlotType(slot, fieldSlot)}, adjacentOp, operatorSlot.code);
         }   
 
         // Add this operator only if it is not blank
@@ -108,7 +116,7 @@ export const generateFlatSlotBases = (slotStructure: SlotsStructure, parentId?: 
 
     // Add the last remaining field and call the consumer (if provided)
     currIndex++;
-    addFlatSlot({...(slotStructure.fields.at(-1) as BaseSlot), id: getSlotIdFromParentIdAndIndexSplit(parentId??"", currIndex), type: evaluateSlotType(slotStructure.fields.at(-1) as FieldSlot)}, slotStructure.operators.length > 0 && slotStructure.operators.at(-1)?.code != "");
+    addFlatSlot({...(slotStructure.fields.at(-1) as BaseSlot), id: getSlotIdFromParentIdAndIndexSplit(parentId??"", currIndex), type: evaluateSlotType(slot, slotStructure.fields.at(-1) as FieldSlot)}, slotStructure.operators.length > 0 && slotStructure.operators.at(-1)?.code != "");
 
     return flatSlotBases;
 };
@@ -175,12 +183,12 @@ export const getFlatNeighbourFieldSlotInfos = (slotInfos: SlotCoreInfos, findNex
         // The flat neighbour is a sibling of that node, that's easy we just return that sibling
         const neighbourSlotId = getSlotIdFromParentIdAndIndexSplit(parentId, slotIndex + (findNext ? 1 : -1));
         const neighbourSlot = retrieveSlotFromSlotInfos({...slotInfos, slotId: neighbourSlotId}); 
-        const type = evaluateSlotType(neighbourSlot);
+        const type = evaluateSlotType(getSlotDefFromInfos(slotInfos), neighbourSlot);
         if(isSlotBracketType(type) && !stopAtStructure){
             // Get the field inside the bracket: first child field if looking for next neighbour, last otherwise.
             const childFieldId = (findNext) ? 0 : (neighbourSlot as SlotsStructure).fields.length - 1;
             const noTypeChildSlotInfos = {...slotInfos, slotId: neighbourSlotId + "," + childFieldId};
-            const childType = evaluateSlotType(retrieveSlotFromSlotInfos(noTypeChildSlotInfos));
+            const childType = evaluateSlotType(getSlotDefFromInfos(noTypeChildSlotInfos), retrieveSlotFromSlotInfos(noTypeChildSlotInfos));
             return {...noTypeChildSlotInfos, slotType: childType};
         }
         return {...slotInfos, slotId: neighbourSlotId, slotType: type};
@@ -219,7 +227,11 @@ export function isFrameLabelSlotStructWithCodeContent(slotsStruct: SlotsStructur
     return hasContent;
 }
 
-export const evaluateSlotType = (slot: FieldSlot): SlotType => {
+// You can pass FrameLabel for the first arg
+export const evaluateSlotType = (def: { allowedSlotContent?: AllowedSlotContent }, slot: FieldSlot): SlotType => {
+    if (def.allowedSlotContent === AllowedSlotContent.FREE_TEXT_DOCUMENTATION) {
+        return SlotType.comment;
+    }
     if(isFieldBracketedSlot(slot)){
         return SlotType.bracket;
     }
@@ -810,7 +822,7 @@ export function checkPrecompiledErrorsForFrame(frameId: number): void {
     // ONLY on code type slots
     const frameObject = useStore().frameObjects[frameId];
     Object.values(frameObject.labelSlotsDict).forEach((labelSlotStruct, labelSlotsIndex) => {
-        generateFlatSlotBases(labelSlotStruct.slotStructures, "", (flatSlot: FlatSlotBase) => {
+        generateFlatSlotBases(getSlotDefFromInfos({frameId, labelSlotsIndex}), labelSlotStruct.slotStructures, "", (flatSlot: FlatSlotBase) => {
             if(isSlotCodeType(flatSlot.type)){
                 const slotInfos = {
                     frameId: frameId,

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -821,12 +821,12 @@ export function checkPrecompiledErrorsForFrame(frameId: number): void {
     // so we use the FlatSlotBase generator (only on that frame), and apply the error checks for each flat slot
     // ONLY on code type slots
     const frameObject = useStore().frameObjects[frameId];
-    Object.values(frameObject.labelSlotsDict).forEach((labelSlotStruct, labelSlotsIndex) => {
-        generateFlatSlotBases(getSlotDefFromInfos({frameId, labelSlotsIndex}), labelSlotStruct.slotStructures, "", (flatSlot: FlatSlotBase) => {
+    Object.entries(frameObject.labelSlotsDict).forEach(([labelSlotsIndex, labelSlotStruct]) => {
+        generateFlatSlotBases(getSlotDefFromInfos({frameId, labelSlotsIndex: Number(labelSlotsIndex)}), labelSlotStruct.slotStructures, "", (flatSlot: FlatSlotBase) => {
             if(isSlotCodeType(flatSlot.type)){
                 const slotInfos = {
                     frameId: frameId,
-                    labelSlotsIndex: labelSlotsIndex,
+                    labelSlotsIndex: Number(labelSlotsIndex),
                     slotId: flatSlot.id,
                     slotType: flatSlot.type,
                     code: flatSlot.code,

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -784,7 +784,6 @@ export const checkPrecompiledErrorsForSlot = (slotInfos: SlotInfos): void => {
     // This method for checking errors is called when a frame has been edited (and lost focus), or during undo/redo changes. As we don't have a way to
     // find which errors are from TigerPython or precompiled errors, and that we wouldn't know what specific error to remove anyway,
     // we clear the errors completely for that frame/slot before we check the errors again for it.
-    console.log("Check errors: " + JSON.stringify(slotInfos));
     const slot = retrieveSlotFromSlotInfos(slotInfos);
     const currentErrorMessage = (slot as BaseSlot).error;
     useStore().setSlotErroneous(

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -496,6 +496,18 @@ export const restoreSavedStateFrameTypes = function(state:{[id: string]: any}): 
             const correspondingFrameObj = getFrameDefType(frameTypeValue);
             if(correspondingFrameObj  !== undefined) {
                 state["frameObjects"][frameId].frameType = correspondingFrameObj;
+                // Make sure all label slots are in the frame state.  They might not be if we have added one
+                // (as we did for the documentation for methods) so we should make sure to add a blank value
+                // to stop exceptions in the code while accessing that value.
+                for (let i = 0; i < state["frameObjects"][frameId].frameType.labels.length; i++) {
+                    if ((state["frameObjects"][frameId].frameType.labels[i].showSlots ?? true) 
+                        && !(i in state["frameObjects"][frameId].labelSlotsDict)) {
+                        state["frameObjects"][frameId].labelSlotsDict[i] = {
+                            shown: !state["frameObjects"][frameId].frameType.labels[i].hidableLabelSlots,
+                            slotStructures: {fields: [{code: ""}], operators: []},
+                        };
+                    }
+                }
                 return true;
             }
             success = false;
@@ -772,6 +784,7 @@ export const checkPrecompiledErrorsForSlot = (slotInfos: SlotInfos): void => {
     // This method for checking errors is called when a frame has been edited (and lost focus), or during undo/redo changes. As we don't have a way to
     // find which errors are from TigerPython or precompiled errors, and that we wouldn't know what specific error to remove anyway,
     // we clear the errors completely for that frame/slot before we check the errors again for it.
+    console.log("Check errors: " + JSON.stringify(slotInfos));
     const slot = retrieveSlotFromSlotInfos(slotInfos);
     const currentErrorMessage = (slot as BaseSlot).error;
     useStore().setSlotErroneous(

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,12 +1,13 @@
 import Compiler from "@/compiler/compiler";
-/*IFTRUE_isPython */
-import {actOnTurtleImport, hasEditorCodeErrors, trimmedKeywordOperators} from "@/helpers/editor";
+import {hasEditorCodeErrors, trimmedKeywordOperators} from "@/helpers/editor";
 import {generateFlatSlotBases, retrieveSlotByPredicate} from "@/helpers/storeMethods";
 import i18n from "@/i18n";
 import {useStore} from "@/store/store";
 import {AllFrameTypesIdentifier, AllowedSlotContent, BaseSlot, ContainerTypesIdentifiers, FieldSlot, FlatSlotBase, FrameContainersDefinitions, FrameObject, getLoopFramesTypeIdentifiers, isFieldBaseSlot, isFieldBracketedSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, LabelSlotPositionsAndCode, LabelSlotsPositions, LineAndSlotPositions, MediaSlot, ParserElements, SlotsStructure, SlotType, StringSlot} from "@/types/types";
 import {ErrorInfo, TPyParser} from "tigerpython-parser";
 import {AppSPYPrefix} from "@/main";
+/*IFTRUE_isPython */
+import { actOnTurtleImport } from "@/helpers/editor";
 /*FITRUE_isPython */
 import {STRYPE_DUMMY_FIELD, STRYPE_EXPRESSION_BLANK, STRYPE_INVALID_OP, STRYPE_INVALID_OPS_WRAPPER, STRYPE_INVALID_SLOT} from "@/helpers/pythonToFrames";
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -633,7 +633,7 @@ export default class Parser {
             slotTypes.push(type);
         };
 
-        generateFlatSlotBases(slotStructures, "", (flatSlot: FlatSlotBase, besidesOp: boolean, opAfter: undefined | string) => {
+        generateFlatSlotBases({allowedSlotContent: allowed }, slotStructures, "", (flatSlot: FlatSlotBase, besidesOp: boolean, opAfter: undefined | string) => {
             if(isSlotQuoteType(flatSlot.type) || isSlotBracketType(flatSlot.type) || flatSlot.type === SlotType.media){
                 // a quote or a bracket is a 1 character token, shown in the code
                 // but it's not editable so we don't include it in the slot positions

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -339,6 +339,9 @@ export default class Parser {
                 if (hasDocContent) {
                     output = output.trimEnd() + "'''";
                 }
+                else if (label.allowedSlotContent == AllowedSlotContent.FREE_TEXT_DOCUMENTATION) {
+                    output = output.trimEnd();
+                }
             }            
         });
         

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -303,16 +303,19 @@ export default class Parser {
         }
             
         statement.frameType.labels.forEach((label, labelSlotsIndex) => {
-            if (label.newLine ?? false) {
-                this.line += 1;
-                // Newlines indent below, e.g. comments in funcdef frames:
-                output += "\n" + indentation + "    ";
-            } 
-            
+            let hasDocContent = false;
             // For varassign frames, the symbolic assignment on the UI should be replaced by the Python "=" symbol
             if(label.showLabel??true){
                 if (label.allowedSlotContent == AllowedSlotContent.FREE_TEXT_DOCUMENTATION) {
-                    output += "'''";
+                    if (useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields.length > 1 || (useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields[0] as BaseSlot).code.trim().length > 0) {
+                        if (label.newLine ?? false) {
+                            this.line += 1;
+                            // Newlines indent below, e.g. comments in funcdef frames:
+                            output += "\n" + indentation + "    ";
+                        }
+                        output += "'''";
+                        hasDocContent = true;
+                    }
                 }
                 else {
                     output += ((label.label.length > 0 && statement.frameType.type === AllFrameTypesIdentifier.varassign) ? " = " : label.label);
@@ -333,7 +336,7 @@ export default class Parser {
                 // add their code to the output
                 output += slotStartsLengthsAndCode.code.trimStart() + " ";
 
-                if (label.allowedSlotContent == AllowedSlotContent.FREE_TEXT_DOCUMENTATION) {
+                if (hasDocContent) {
                     output = output.trimEnd() + "'''";
                 }
             }            

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,7 +2,7 @@ import Vue from "vue";
 import { FrameObject, CurrentFrame, CaretPosition, MessageDefinitions, ObjectPropertyDiff, AddFrameCommandDef, EditorFrameObjects, MainFramesContainerDefinition, FuncDefContainerDefinition, StateAppObject, UserDefinedElement, ImportsContainerDefinition, EditableFocusPayload, SlotInfos, FramesDefinitions, EmptyFrameObject, NavigationPosition, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, generateAllFrameDefinitionTypes, AllFrameTypesIdentifier, BaseSlot, SlotType, SlotCoreInfos, SlotsStructure, LabelSlotsContent, FieldSlot, SlotCursorInfos, StringSlot, areSlotCoreInfosEqual, StrypeSyncTarget, ProjectLocation, MessageDefinition, PythonExecRunningState, AddShorthandFrameCommandDef, isFieldBaseSlot, StrypePEALayoutMode, SaveRequestReason, RootContainerFrameDefinition, StrypeLayoutDividerSettings, MediaSlot, SlotInfosOptionalMedia } from "@/types/types";
 import { getObjectPropertiesDifferences, getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
-import { checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getFrameSectionIdFromFrameId, getParentOrJointParent, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos } from "@/helpers/storeMethods";
+import {checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getFrameSectionIdFromFrameId, getParentOrJointParent, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos} from "@/helpers/storeMethods";
 import { AppPlatform, AppVersion, vm } from "@/main";
 import initialStates from "@/store/initial-states";
 import { defineStore } from "pinia";
@@ -235,7 +235,7 @@ export const useStore = defineStore("app", {
             // Flatten the imbricated slots of associated with a label and return the corresponding array of FlatSlotBase objects
             // The operators always get in between the fields, and we always have one 1 root structure for a label,
             // and bracketed structures can never be found at 1st or last position
-            return generateFlatSlotBases(state.frameObjects[frameId].labelSlotsDict[labelIndex].slotStructures);
+            return generateFlatSlotBases(state.frameObjects[frameId].frameType.labels[labelIndex], state.frameObjects[frameId].labelSlotsDict[labelIndex].slotStructures);
         },
 
         getJointFramesForFrameId: (state) => (frameId: number) => {
@@ -2311,7 +2311,7 @@ export const useStore = defineStore("app", {
                     slotType: SlotType.code, // we can only focus a code slot
                 };
                 const nextSlot = retrieveSlotFromSlotInfos(nextSlotCoreInfos);
-                nextSlotCoreInfos.slotType = evaluateSlotType(nextSlot);
+                nextSlotCoreInfos.slotType = evaluateSlotType(getSlotDefFromInfos(nextSlotCoreInfos), nextSlot);
 
                 this.setEditableFocus(
                     {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1929,10 +1929,10 @@ export const useStore = defineStore("app", {
             const newFramesCaretPositions: NavigationPosition[] = [];
             
             //first add the slots
-            Object.values(newFrame.labelSlotsDict).forEach((element,index) => {
+            Object.entries(newFrame.labelSlotsDict).forEach(([index, element]) => {
                 if(element.shown??true){
                     // we would only have 1 empty slot for this label, so its ID is "0"
-                    newFramesCaretPositions.push({frameId: newFrame.id, isSlotNavigationPosition:true, labelSlotsIndex: index, slotId: "0"});
+                    newFramesCaretPositions.push({frameId: newFrame.id, isSlotNavigationPosition:true, labelSlotsIndex: Number(index), slotId: "0"});
                 }
             });
       

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1862,8 +1862,11 @@ export const useStore = defineStore("app", {
                     // For each label defined by the frame type, if the label allows slots, we create an empty "field" slot (code type)
                     // optionalLabel is false by default, and if value is true, the label is hidden when created.
                     // For an function call frame, we set the default slots (of the first label) as "<function name>()" rather than only a single code slot
-                    frame.labels.filter((el)=> el.showSlots??true).reduce(
+                    frame.labels.reduce(
                         (acc, cur, idx) => {
+                            if (!(cur.showSlots??true)) {
+                                return acc;
+                            }
                             const labelContent: LabelSlotsContent = {
                                 shown: (!cur.hidableLabelSlots),
                                 slotStructures: (frame.type == AllFrameTypesIdentifier.funccall) 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -100,6 +100,7 @@ export enum SlotType {
     // "no type", which can be used for undo/redo difference marking
     // media type
     media = 0o70000, // meta category
+    comment = 0o700000, // meta category
     none = 0,
 }
 
@@ -147,7 +148,9 @@ export interface FrameObject {
 export enum AllowedSlotContent {
     ONLY_NAMES,
     ONLY_NAMES_OR_STAR,
-    TERMINAL_EXPRESSION
+    TERMINAL_EXPRESSION,
+    FREE_TEXT_DOCUMENTATION,
+    LIBRARY_ADDRESS
 }
 
 export interface FrameLabel {
@@ -545,7 +548,7 @@ export function generateAllFrameDefinitionTypes(regenerateExistingFrames?: boole
         ...StatementDefinition,
         type: ImportFrameTypesIdentifiers.library,
         labels: [
-            { label: "library ", defaultText: i18n.t("frame.defaultText.libraryAddress") as string, acceptAC: false },
+            { label: "library ", defaultText: i18n.t("frame.defaultText.libraryAddress") as string, acceptAC: false, allowedSlotContent: AllowedSlotContent.LIBRARY_ADDRESS},
         ],
         colour: "#B4C8DC",
     };
@@ -553,7 +556,7 @@ export function generateAllFrameDefinitionTypes(regenerateExistingFrames?: boole
     const CommentDefinition: FramesDefinitions = {
         ...StatementDefinition,
         type: StandardFrameTypesIdentifiers.comment,
-        labels: [{ label: "# ", defaultText: i18n.t("frame.defaultText.comment") as string, optionalSlot: true, acceptAC: false }],
+        labels: [{ label: "# ", defaultText: i18n.t("frame.defaultText.comment") as string, optionalSlot: true, acceptAC: false, allowedSlotContent: AllowedSlotContent.FREE_TEXT_DOCUMENTATION}],
         colour: scssVars.mainCodeContainerBackground,
     };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -658,6 +658,7 @@ export function generateAllFrameDefinitionTypes(regenerateExistingFrames?: boole
             { label: "def ", defaultText: i18n.t("frame.defaultText.name") as string, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_NAMES },
             { label: "(", defaultText: i18n.t("frame.defaultText.parameters") as string, optionalSlot: true, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_NAMES },
             { label: ") :", showSlots: false, defaultText: "" },
+            { label: "‘‘‘", newLine: true, showSlots: true, acceptAC: false, optionalSlot: false, defaultText: "Describe the function", allowedSlotContent: AllowedSlotContent.FREE_TEXT_DOCUMENTATION},
         ],
         colour: "#ECECC8",
     };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -162,6 +162,7 @@ export interface FrameLabel {
     optionalSlot?: boolean; //default false (indicate that this label does not require at least 1 slot value)
     acceptAC?: boolean; //default true
     allowedSlotContent?: AllowedSlotContent; // default TERMINAL_EXPRESSION; what the slot accepts
+    newLine?: boolean; //default false; this item starts a new line
 }
 
 export enum CaretPosition {

--- a/tests/cypress/e2e/autocomplete-user-defined.cy.ts
+++ b/tests/cypress/e2e/autocomplete-user-defined.cy.ts
@@ -69,7 +69,7 @@ describe("User-defined items", () => {
         focusEditorAC();
         // Make an assignment frame that says "myVar=<string>", then make a function definition:
         cy.get("body").type("=myVar=\"hello\"{enter}");
-        cy.get("body").type("{uparrow}{uparrow}ffoo{rightarrow}{rightarrow} ");
+        cy.get("body").type("{uparrow}{uparrow}ffoo{rightarrow}{rightarrow}{rightarrow} ");
         cy.wait(500);
         // Trigger auto-completion:
         cy.get("body").type("{ctrl} ");
@@ -110,7 +110,7 @@ describe("User-defined items", () => {
         focusEditorAC();
         // Make a function frame with "foo(myParam)" 
         // then make a function call frame inside:
-        cy.get("body").type("{uparrow}ffoo(myParam{rightarrow} ");
+        cy.get("body").type("{uparrow}ffoo(myParam{rightarrow}{rightarrow} ");
         // Trigger auto-completion:
         cy.get("body").type("{ctrl} ");
         withAC((acIDSel) => {

--- a/tests/playwright/e2e/load-save-random.spec.ts
+++ b/tests/playwright/e2e/load-save-random.spec.ts
@@ -502,7 +502,7 @@ test.describe("Enters, saves and loads specific frames", () => {
 
     test("Blanks at the end of funcdef", async ({page}) => {
         await testSpecific(page, [[], [
-            {frameType: "funcdef", slotContent: ["foo", ""], body: [
+            {frameType: "funcdef", slotContent: ["foo", "", ""], body: [
                 {frameType: "blank", slotContent: []},
                 {frameType: "while", slotContent: ["foo"], body: [
                     {frameType: "comment", slotContent: ["Inside def"]},
@@ -520,7 +520,7 @@ test.describe("Enters, saves and loads specific frames", () => {
 
     test("Blanks at the end of funcdef #2", async ({page}) => {
         await testSpecific(page, [[], [
-            {frameType: "funcdef", slotContent: ["foo", ""], body: [
+            {frameType: "funcdef", slotContent: ["foo", "", ""], body: [
                 {frameType: "blank", slotContent: []},
                 {frameType: "blank", slotContent: []},
                 {frameType: "blank", slotContent: []},
@@ -544,7 +544,7 @@ test.describe("Enters, saves and loads specific frames", () => {
 
     test("Comments at the end of funcdefs", async ({page}) => {
         await testSpecific(page, [[], [
-            {frameType: "funcdef", slotContent: ["foo", ""], body: [
+            {frameType: "funcdef", slotContent: ["foo", "", ""], body: [
                 {frameType: "varassign", slotContent: ["1_", "#!0"]},
                 {frameType: "while", slotContent: ["foo"], body: []},
                 {frameType: "comment", slotContent: ["Inside def"]},


### PR DESCRIPTION
This isn't huge, but it may still be easiest to understand one commit at a time, as it involved several successive stages.  The overall effect is to add documentation slots in function frames on a second line.  To do this I added support for multiple lines in the frame header, which got complicated as it means we have one label ") :" in a function call frame with no slot, followed by another one "'''" [triple quote] which does have a slot, which was something we didn't have before.  I also added a new slot type for comments.

I will follow this up with another PR to fiddle with the visuals and add support for the documentation slot at the very top of the project (before imports?) which would finish this feature.