### PR TITLE
Fix an small bug with Google Drive

### DIFF
--- a/src/components/GoogleDrive.vue
+++ b/src/components/GoogleDrive.vue
@@ -270,9 +270,14 @@ export default Vue.extend({
         doLoadFile() {
             if(this.oauthToken != null){
                 // When we load for the very first time, we may not have a Drive location to look for. In that case, we look for a Strype folder existence 
-                // (however we do not create it here, we would do this on a save action). If a location is already set, we make sure it still exists. 
+                // (however we do not create it here, we would do this on a save action). If a location is already set*, we make sure it still exists. 
                 // If it doesn't exist anymore, we set the default location to the Strype folder (if available) or just the Drive itself if not.
                 // NOTE: we do not need to check a folder when opening a shared project
+                // (*) so the logic is like so we always check a folder location in Google Drive - if the strypeProjectLocation is a non-empty string 
+                // then we check that folder name; if it's an empty string, or not a string (i.e. when we were on a project opened on the File System)
+                // then we check for "Strype", because it is our default location.
+
+                
                 if(this.openSharedProjectFileId.length == 0){
                     this.checkDriveStrypeOrOtherFolder(false, !(this.appStore.strypeProjectLocation) || (typeof this.appStore.strypeProjectLocation != "string"), (strypeFolderId) => {
                         if(this.appStore.strypeProjectLocation && (typeof this.appStore.strypeProjectLocation == "string")){


### PR DESCRIPTION
Fix an issue with a condition for detecting if the Strype folder or another specific folder should be checked.
The issue made the access to Google Drive (to load a project) raising an error when coming from a project saved on the file system - the picker wouldn't load.

Note: this fix is included in a release that's been tagged and deployed, but not documented in the history.