### PR TITLE
Documentation slot fixes

### DIFF
--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -876,7 +876,10 @@ export default Vue.extend({
             // to selectionEnd, below.
             const hasTextSelection = !!this.appStore.mostRecentSelectedText;
             let refactorFocusSpanUID = this.UID; // by default the focus stays where we are
-            const cursorPos = (getTextStartCursorPositionOfHTMLElement(inputSpanField) ?? inputString.length) - inputString.length;
+            let fieldPos = getTextStartCursorPositionOfHTMLElement(inputSpanField);
+            // Account for any zero width spaces:
+            fieldPos -= (inputSpanFieldContent.substring(0, fieldPos).match(/\u200B/g) || []).length; 
+            const cursorPos = fieldPos - inputString.length;
             
             // Our position will no longer have a selection, it's just us at the given cursor pos:
             this.appStore.setSlotTextCursors({slotInfos: this.coreSlotInfo, cursorPos: cursorPos + inputString.length}, {slotInfos: this.coreSlotInfo, cursorPos: cursorPos + inputString.length});

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1460,7 +1460,9 @@ export default Vue.extend({
             // To avoid unwanted deletion, we "force" a delay before removing the frame.
             const anchor = this.appStore.anchorSlotCursorInfos;
             const focus = this.appStore.focusSlotCursorInfos;
-            if(this.isFrameEmptyAndAtLabelSlotStart && (!anchor || !focus || areSlotCoreInfosEqual(anchor.slotInfos, focus.slotInfos))){
+            if(this.isFrameEmptyAndAtLabelSlotStart && (!anchor || !focus || areSlotCoreInfosEqual(anchor.slotInfos, focus.slotInfos))
+                // Backspace can't delete from documentation slots in other frames (e.g. project doc, funcdef doc), only from comment frames themselves:
+                && (this.coreSlotInfo.slotType != SlotType.comment || this.frameType == AllFrameTypesIdentifier.comment)){
                 event.stopPropagation();
                 event.stopImmediatePropagation();
                 event.preventDefault();

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2251,7 +2251,13 @@ export const useStore = defineStore("app", {
                 // Retrieve the slot that currently has focus in the current frame by looking up in the DOM
                 const foundSlotCoreInfos = this.focusSlotCursorInfos?.slotInfos as SlotCoreInfos;
                 currentFramePosition = availablePositions.findIndex((e) => e.isSlotNavigationPosition && e.frameId === this.currentFrame.id 
-                        && e.labelSlotsIndex === foundSlotCoreInfos.labelSlotsIndex && e.slotId === foundSlotCoreInfos.slotId);     
+                        && e.labelSlotsIndex === foundSlotCoreInfos.labelSlotsIndex && e.slotId === foundSlotCoreInfos.slotId);
+                
+                if (currentFramePosition == 0 && directionDelta < 0) {
+                    // Nowhere to go (start of project doc slot), stay here:
+                    return;
+                }
+                
                 // Now we can effectively ask the slot to "lose focus" because we could retrieve it (and we need to get it blurred so further actions are not happening in the span)
                 document.getElementById(getLabelSlotUID(foundSlotCoreInfos))?.dispatchEvent(new CustomEvent(CustomEventTypes.editableSlotLostCaret));         
             }


### PR DESCRIPTION
Fixed the bug you saw with cursor moving back one (due to an exception), then realised there were a few more cursor key related bugs with the new slots.  Best to look one commit at a time as they are independent small fixes for different issues.