### PR TITLE
Context menu shortcuts and caret height fix

### DIFF
--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -348,7 +348,10 @@ export default Vue.extend({
 }
 
 .static-caret-container{
-    height: $caret-height-value + px;
+    // Put cursor in middle of the reserved gap, and still add height (i.e. use padding not height) to avoid later 
+    // sections moving up and down by the caret height as the caret moves in and out of a reserved gap.
+    padding-top: ($caret-height-value/2) + px !important;
+    padding-bottom: ($caret-height-value/2) + px !important;
 }
 
 .#{$strype-classname-caret-container}:not(.#{$strype-classname-dragging-frame}):hover{

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -469,8 +469,8 @@ export default Vue.extend({
 
             // If there's a windows and Mac shortcut they are put in an array:
             this.frameContextMenuItems = [
-                {name: this.$i18n.t("contextMenu.cut") as string, method: this.cut, actionName: FrameContextMenuActionName.cut, shortcut: ["Ctrl-X", "⌘X"]},
-                {name: this.$i18n.t("contextMenu.copy") as string, method: this.copy, actionName: FrameContextMenuActionName.copy, shortcut: ["Ctrl-C", "⌘C"]},
+                {name: this.$i18n.t("contextMenu.cut") as string, method: this.cut, actionName: FrameContextMenuActionName.cut, shortcut: [(this.$i18n.t("shortcut.ctrlPlus") as string) + "X", "⌘X"]},
+                {name: this.$i18n.t("contextMenu.copy") as string, method: this.copy, actionName: FrameContextMenuActionName.copy, shortcut: [(this.$i18n.t("shortcut.ctrlPlus") as string) + "C", "⌘C"]},
                 {name: this.$i18n.t("contextMenu.downloadAsImg") as string, method: this.downloadAsImg},
                 {name: this.$i18n.t("contextMenu.duplicate") as string, method: this.duplicate},
                 {name: "", method: () => {}, type: "divider"},
@@ -479,7 +479,7 @@ export default Vue.extend({
                 {name: "", method: () => {}, type: "divider"},
                 {name: this.$i18n.t("contextMenu.disable") as string, method: this.disable},
                 {name: "", method: () => {}, type: "divider"},
-                {name: this.$i18n.t("contextMenu.delete") as string, method: this.delete, actionName: FrameContextMenuActionName.delete, shortcut: "Delete"},
+                {name: this.$i18n.t("contextMenu.delete") as string, method: this.delete, actionName: FrameContextMenuActionName.delete, shortcut: this.$i18n.t("shortcut.delete") as string},
                 {name: this.$i18n.t("contextMenu.deleteOuter") as string, method: this.deleteOuter}];
 
             // Not all frames should be duplicated (e.g. Else)

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -249,5 +249,9 @@
     "builtinConsole": "Console",
     "builtinTurtle": "Turtle",
     "builtinMicrobit": "micro:bit"
+  },
+  "shortcut": {
+    "delete": "Delete",
+    "ctrlPlus": "Ctrl+"
   }
 }

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -249,5 +249,9 @@
     "builtinConsole": "Console",
     "builtinTurtle": "Turtle",
     "builtinMicrobit": "micro:bit"
+  },
+  "shortcut": {
+    "delete": "Suppr",
+    "ctrlPlus": "Ctrl+"
   }
 }


### PR DESCRIPTION
Two small separate commits for items discussed in the meeting yesterday.  These aren't specific to the OOP branch so I thought I'd merge them into main then pull them to OOP later.  The shortcuts look like this (on Windows):

<img width="565" height="304" alt="image" src="https://github.com/user-attachments/assets/4910c3af-fe35-4047-b613-ebc6e8055d3f" />

The new gap looks like this with the frame cursor in it:

<img width="241" height="282" alt="image" src="https://github.com/user-attachments/assets/f41f7fa8-c505-4807-b38d-83e21946e7cf" />
