### PR TITLE
Add support for collapsing on context menu and keyboard shortcut, plus other small fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -472,6 +472,17 @@ export default Vue.extend({
                 event.stopPropagation();
                 return;
             }
+            
+            // If we are at a frame cursor and they hit ctrl-x/ctrl-c then we do cut/copy:
+            if(!this.appStore.isEditing && !this.isPythonExecuting && (event.ctrlKey || event.metaKey) && (event.key.toLowerCase() === "c" || event.key.toLowerCase() === "x")) {
+                // We emit an event to be picked up by the first frame in the current selection:
+                // The frames themselves decide whether to act based on whether they are the first frame in the selection:
+                this.$root.$emit(event.key.toLowerCase() === "c" ? CustomEventTypes.copyFrameSelection : CustomEventTypes.cutFrameSelection);
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                event.stopPropagation();
+                return;
+            }
         });
 
         // There are only a few cases when we need to handle key up events

--- a/src/App.vue
+++ b/src/App.vue
@@ -1544,6 +1544,11 @@ $divider-grey: darken($background-grey, 15%);
     border:0
 }
 
+.v-context > li.v-context-disabled > a,
+.v-context ul > li.v-context-disabled > a {
+    color: grey !important;
+}
+
 .v-context > li > a:focus,
 .v-context ul > li > a:focus,
 .#{$strype-classname-ac-item}.#{$strype-classname-ac-item-selected} {

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -88,8 +88,13 @@ export default Vue.extend({
             // for such frames (meaning if there are more than 1 frame, all but last caret container should be static)
             const frameType = this.appStore.frameObjects[this.frameId].frameType.type;
             const parentFrame = this.appStore.frameObjects[this.appStore.frameObjects[this.frameId].parentId];
-            return (frameType == AllFrameTypesIdentifier.funcdef && this.caretAssignedPosition == CaretPosition.below &&
-             parentFrame.childrenIds.length > 1 && parentFrame.childrenIds.at(-1) != this.frameId);
+            return (
+                // We are a class or function:
+                (frameType == AllFrameTypesIdentifier.funcdef || frameType == AllFrameTypesIdentifier.classdef)
+                // We're below a frame (i.e. not the top caret position in the container:
+                && this.caretAssignedPosition == CaretPosition.below
+                // We are one of multiple children, and not the last one:
+                && parentFrame.childrenIds.length > 1 && parentFrame.childrenIds.at(-1) != this.frameId);
         },
 
         // Needed in order to use the `CaretPosition` type in the v-show

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -41,7 +41,7 @@ import Vue, { PropType } from "vue";
 import VueContext, { VueContextConstructor } from "vue-context";
 import { useStore } from "@/store/store";
 import Caret from"@/components/Caret.vue";
-import {AllFrameTypesIdentifier, CaretPosition, Position, MessageDefinitions, PythonExecRunningState, FrameContextMenuActionName, CurrentFrame} from "@/types/types";
+import {AllFrameTypesIdentifier, CaretPosition, Position, MessageDefinitions, PythonExecRunningState, FrameContextMenuActionName, CurrentFrame, CollapsedState } from "@/types/types";
 import { getCaretUID, adjustContextMenuPosition, setContextMenuEventClientXY, getAddFrameCmdElementUID, CustomEventTypes, getCaretContainerUID } from "@/helpers/editor";
 import { mapStores } from "pinia";
 import { cloneDeep } from "lodash";
@@ -94,7 +94,12 @@ export default Vue.extend({
                 // We're below a frame (i.e. not the top caret position in the container:
                 && this.caretAssignedPosition == CaretPosition.below
                 // We are one of multiple children, and not the last one:
-                && parentFrame.childrenIds.length > 1 && parentFrame.childrenIds.at(-1) != this.frameId);
+                && parentFrame.childrenIds.length > 1 && parentFrame.childrenIds.at(-1) != this.frameId
+                // And we and are our neighbour are not both folded in (i.e. at least one of us is unfolded)
+                && (((this.appStore.frameObjects[this.frameId].collapsedState ?? CollapsedState.FULLY_VISIBLE) != CollapsedState.ONLY_HEADER_VISIBLE)
+                    // We know there is a frame after us because of the check we just did:
+                    || ((this.appStore.frameObjects[parentFrame.childrenIds[parentFrame.childrenIds.indexOf(this.frameId) + 1]].collapsedState ?? CollapsedState.FULLY_VISIBLE) != CollapsedState.ONLY_HEADER_VISIBLE))
+            );
         },
 
         // Needed in order to use the `CaretPosition` type in the v-show

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -19,9 +19,9 @@
             <!-- Make sure the click events are stopped in the links because otherwise, events pass through and mess the toggle of the caret in the editor.
                 Also, the element MUST have the hover event handled for proper styling (we want hovering and selecting to go together) -->
             <vue-context :id="getFrameContextMenuUID" ref="menu" v-show="allowContextMenu" @open="handleContextMenuOpened" @close="handleContextMenuClosed">
-                <li v-for="menuItem, index in frameContextMenuItems" :key="`frameContextMenuItem_${frameId}_${index}`" :action-name="menuItem.actionName" class="context-menu-item">
+                <li v-for="menuItem, index in frameContextMenuItems" :key="`frameContextMenuItem_${frameId}_${index}`" :action-name="menuItem.actionName" :class="{'context-menu-item': true, 'v-context-disabled': menuItem.disabled}">
                     <hr v-if="menuItem.type === 'divider'" />
-                    <a v-else @click.stop="menuItem.method();closeContextMenu();" @mouseover="handleContextMenuHover">
+                    <a v-else @click.stop="!menuItem.disabled && (menuItem.method(), closeContextMenu())" @mouseover="handleContextMenuHover">
                         <span>{{menuItem.name}}</span>
                         <span class="context-menu-item-shortcut" v-if="menuItem.shortcut">{{typeof menuItem.shortcut === "string" ? menuItem.shortcut : menuItem.shortcut[isMacOSPlatform() ? 1 : 0]}}</span>
                     </a>
@@ -98,7 +98,7 @@ import { useStore } from "@/store/store";
 import { DefaultFramesDefinition, CaretPosition, CollapsedState, CurrentFrame, NavigationPosition, AllFrameTypesIdentifier, Position, PythonExecRunningState, FrameContextMenuActionName } from "@/types/types";
 import VueContext, {VueContextConstructor}  from "vue-context";
 import { getAboveFrameCaretPosition, getAllChildrenAndJointFramesIds, getLastSibling, getNextSibling, getOutmostDisabledAncestorFrameId, getParentId, getParentOrJointParent, isFramePartOfJointStructure, isLastInParent } from "@/helpers/storeMethods";
-import { CustomEventTypes, getFrameBodyUID, getFrameContextMenuUID, getFrameHeaderUID, getFrameUID, isIdAFrameId, getFrameBodyRef, getJointFramesRef, getCaretContainerRef, setContextMenuEventClientXY, adjustContextMenuPosition, getActiveContextMenu, notifyDragStarted, getCaretUID, getHTML2CanvasFramesSelectionCropOptions, parseFrameUID } from "@/helpers/editor";
+import { CustomEventTypes, getFrameBodyUID, getFrameContextMenuUID, getFrameHeaderUID, getFrameUID, isIdAFrameId, getFrameBodyRef, getJointFramesRef, getCaretContainerRef, setContextMenuEventClientXY, adjustContextMenuPosition, getActiveContextMenu, notifyDragStarted, getCaretUID, getHTML2CanvasFramesSelectionCropOptions, parseFrameUID, calculateNextCollapseState } from "@/helpers/editor";
 import { mapStores } from "pinia";
 import { BPopover } from "bootstrap-vue";
 import html2canvas from "html2canvas";
@@ -147,7 +147,7 @@ export default Vue.extend({
         return {
             scssVars, // just to be able to use in template
             // Prepare an empty version of the menu: it will be updated as required in handleClick()
-            frameContextMenuItems: [] as {name: string; method: VoidFunction; type?: "divider", actionName?: FrameContextMenuActionName, shortcut?: string | string[]}[],
+            frameContextMenuItems: [] as {name: string; method: VoidFunction; type?: "divider", actionName?: FrameContextMenuActionName, shortcut?: string | string[], disabled?: boolean}[],
             // Flag to indicate a frame is selected via the context menu (differs from a user selection)
             contextMenuEnforcedSelect: false,
             // And an associated observer used to check when the menu made hidden to change the flag above
@@ -479,6 +479,11 @@ export default Vue.extend({
 
             // If there's a windows and Mac shortcut they are put in an array:
             this.frameContextMenuItems = [
+                // Important these first three are in the same order as the enum CollapsedState:
+                {name: this.$i18n.t("contextMenu.collapseHeader") as string, method: this.collapseToHeader, actionName: FrameContextMenuActionName.collapseToHeader},
+                {name: this.$i18n.t("contextMenu.collapseDocumentation") as string, method: this.collapseToDocumentation, actionName: FrameContextMenuActionName.collapseToDocumentation},
+                {name: this.$i18n.t("contextMenu.collapseFull") as string, method: this.collapseToFull, actionName: FrameContextMenuActionName.collapseToFull},
+                {name: "", method: () => {}, type: "divider"},
                 {name: this.$i18n.t("contextMenu.cut") as string, method: this.cut, actionName: FrameContextMenuActionName.cut, shortcut: [(this.$i18n.t("shortcut.ctrlPlus") as string) + "X", "⌘X"]},
                 {name: this.$i18n.t("contextMenu.copy") as string, method: this.copy, actionName: FrameContextMenuActionName.copy, shortcut: [(this.$i18n.t("shortcut.ctrlPlus") as string) + "C", "⌘C"]},
                 {name: this.$i18n.t("contextMenu.downloadAsImg") as string, method: this.downloadAsImg},
@@ -492,6 +497,47 @@ export default Vue.extend({
                 {name: this.$i18n.t("contextMenu.delete") as string, method: this.delete, actionName: FrameContextMenuActionName.delete, shortcut: this.$i18n.t("shortcut.delete") as string},
                 {name: this.$i18n.t("contextMenu.deleteOuter") as string, method: this.deleteOuter}];
 
+            // Not all frames can be collapsed; only show menu items that are possible for at least one of the frames,
+            // disable the item if all frames are already in that state, and show the dot shortcut next to whatever it would do:
+            const collapseFrames = (this.isPartOfSelection ? this.appStore.selectedFrames : [this.frameId]).map((id) => this.appStore.frameObjects[id]);
+            const combinedCollapse = collapseFrames.reduce(
+                (acc, item) => {
+                    acc.states.add(item.collapsedState ?? CollapsedState.FULLY_VISIBLE);
+                    item.frameType.allowedCollapsedStates.forEach((s) => acc.allowedStates.add(s));
+                    return acc;
+                },
+                { states: new Set<CollapsedState>(), allowedStates: new Set<CollapsedState>() }
+            );
+            let nextWouldBe;
+            // Important to do this before next step as we might then remove some:
+            if (combinedCollapse.states.size === 1) {
+                const commonState : CollapsedState = combinedCollapse.states.keys().next().value;
+                this.frameContextMenuItems[commonState as number].disabled = true;
+                nextWouldBe = calculateNextCollapseState(commonState, collapseFrames);
+            }
+            else {
+                nextWouldBe = calculateNextCollapseState(undefined, collapseFrames);
+            }
+            let someCollapseShowing = false;
+            // Loops through all possible enum values, backwards so we can remove without upsetting the later-processed indexes:
+            for (const c of Object.values(CollapsedState).filter((v) => typeof v === "number").map((v) => v as number).sort((a, b) => b - a)) {
+                // If state is impossible for all frames, don't show it in the menu:
+                // Also, if there's only one allowed state for all frames (which would be fully visible), remove all items:
+                if (!combinedCollapse.allowedStates.has(c as CollapsedState) || combinedCollapse.allowedStates.size === 1) {
+                    this.frameContextMenuItems.splice(c,1);
+                }
+                else {
+                    someCollapseShowing = true;
+                    if (nextWouldBe as number === c) {
+                        this.frameContextMenuItems[c].shortcut = ".";
+                    }
+                }
+            }
+            if (!someCollapseShowing) {
+                // Remove the divider, which will now be position 0:
+                this.frameContextMenuItems.splice(0,1);
+            }
+            
             // Not all frames should be duplicated (e.g. Else)
             // The target id, for a duplication, should be the same as the copied frame 
             // except if that frame has joint frames: the target is the last joint frame.
@@ -1206,6 +1252,27 @@ export default Vue.extend({
             this.appStore.deleteOuterFrames(this.frameId);
         },
 
+        setCollapse(collapsedState: CollapsedState) {
+            const frames = this.isPartOfSelection ? this.appStore.selectedFrames : [this.frameId];
+            for (let frame of frames) {
+                if (this.appStore.frameObjects[frame].frameType.allowedCollapsedStates.includes(collapsedState)) {
+                    this.appStore.setCollapseStatusContainer({frameId: frame, collapsed: collapsedState});
+                }
+            }
+        },
+        
+        collapseToHeader() : void {
+            this.setCollapse(CollapsedState.ONLY_HEADER_VISIBLE); 
+        },
+
+        collapseToDocumentation() : void {
+            this.setCollapse(CollapsedState.HEADER_AND_DOC_VISIBLE);
+        },
+
+        collapseToFull() : void {
+            this.setCollapse(CollapsedState.FULLY_VISIBLE);
+        },
+
         showFrameParseErrorPopupOnHeaderFocus(isFocusing: boolean): void{
             // We need to be able to show the frame error popup programmatically
             // (if applies) when we navigate to the error - we make sure the frame still exists.
@@ -1274,6 +1341,7 @@ export default Vue.extend({
 
 .context-menu-item-shortcut {
     margin-left: auto;
+    padding-left: 1em;
     font-size: 70%;
     color: grey;
 }

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -345,7 +345,8 @@ export default Vue.extend({
     },
 
     mounted() {
-        window.addEventListener("keydown", this.onKeyDown);
+        this.$root.$on(CustomEventTypes.cutFrameSelection, this.cutIfFirstInSelection);
+        this.$root.$on(CustomEventTypes.copyFrameSelection, this.copyIfFirstInSelection);
 
         // Observe when the context menu when the context menu is closed
         // in order to reset the enforced selection flag
@@ -370,8 +371,6 @@ export default Vue.extend({
     },
 
     destroyed() {
-        window.removeEventListener("keydown", this.onKeyDown);
-
         // Probably not required but for safety, remove the observer set up in mounted()
         this.contextMenuObserver.disconnect();
 
@@ -389,19 +388,20 @@ export default Vue.extend({
 
     methods: {
         isMacOSPlatform,
-        onKeyDown(event: KeyboardEvent) {
+        cutIfFirstInSelection() {
             // Cutting/copying by shortcut is only available for a frame selection*, and if the user's code isn't being executed.
             // To prevent the command to be called on all frames, but only once (first of a selection), we check that the current frame is a first of a selection.
             // * "this.isPartOfSelection" is necessary because it is only set at the right value in a subsequent call. 
-            if(!this.isPythonExecuting && this.isPartOfSelection && (this.appStore.getFrameSelectionPosition(this.frameId) as string).startsWith("first") && (event.ctrlKey || event.metaKey) && (event.key.toLowerCase() === "c" || event.key.toLowerCase() === "x")) {
-                if(event.key.toLowerCase() === "c"){
-                    this.copy();
-                }
-                else{
-                    this.cut();
-                }
-                event.preventDefault();
-                return;
+            if(!this.isPythonExecuting && this.isPartOfSelection && (this.appStore.getFrameSelectionPosition(this.frameId) as string).startsWith("first")) {
+                this.cut();
+            }
+        },
+        copyIfFirstInSelection() {
+            // Cutting/copying by shortcut is only available for a frame selection*, and if the user's code isn't being executed.
+            // To prevent the command to be called on all frames, but only once (first of a selection), we check that the current frame is a first of a selection.
+            // * "this.isPartOfSelection" is necessary because it is only set at the right value in a subsequent call. 
+            if(!this.isPythonExecuting && this.isPartOfSelection && (this.appStore.getFrameSelectionPosition(this.frameId) as string).startsWith("first")) {
+                this.copy();
             }
         },
 

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -529,7 +529,7 @@ export default Vue.extend({
                 else {
                     someCollapseShowing = true;
                     if (nextWouldBe as number === c) {
-                        this.frameContextMenuItems[c].shortcut = ".";
+                        this.frameContextMenuItems[c].shortcut = this.$i18n.t("shortcut.period") as string;
                     }
                 }
             }

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -59,6 +59,8 @@ export enum CustomEventTypes {
     openSharedFileDone = "openSharedFileDone",
     dropFramePositionsUpdated = "dropFramePositionsUpdated",
     resetLSOnShareProjectLoadConfirmed = "resetLSOnShareProjectLoadConfirmed",
+    cutFrameSelection = "cutFrameSelection",
+    copyFrameSelection = "copyFrameSelection",
     /* IFTRUE_isPython */
     pythonExecAreaMounted = "peaMounted",
     pythonExecAreaExpandCollapseChanged = "peaExpandCollapsChanged",

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -2096,6 +2096,11 @@ export function getCurrentFrameSelectionScope(): SelectAllFramesFuncDefScope {
             && useStore().frameObjects[currentFrameId].childrenIds.length == 0){
             return SelectAllFramesFuncDefScope.wholeFunctionBody;
         }
+        
+        if (useStore().frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.classdef) {
+            // Need to think about how this should work:
+            return SelectAllFramesFuncDefScope.frame;
+        }
 
         return SelectAllFramesFuncDefScope.none;
     }

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -2073,7 +2073,7 @@ export function getCurrentFrameSelectionScope(): SelectAllFramesFuncDefScope {
     // This method checks the current selection scope that we need to know when doing select-all (for function definitions).
     // If we are not in function definitions, for commodity, we return SelectAllFramesFuncDefScope.frame as it will the same
     // logics for the other sections (selecting all the frames in the section)
-    if(getFrameSectionIdFromFrameId(useStore().currentFrame.id) != useStore().functionDefContainerId){
+    if(getFrameSectionIdFromFrameId(useStore().currentFrame.id) != useStore().defsContainerId){
         return SelectAllFramesFuncDefScope.frame;
     }
 
@@ -2084,7 +2084,7 @@ export function getCurrentFrameSelectionScope(): SelectAllFramesFuncDefScope {
     // (no selection *and inside empty container* doesn't need to be considered, because it won't have any effect in the selection loops)
     if(currentFrameSelection.length == 0) {
         const {id: currentFrameId, caretPosition: currentFrameCaretPos} = useStore().currentFrame;
-        if(currentFrameId == useStore().functionDefContainerId){
+        if(currentFrameId == useStore().defsContainerId){
             return SelectAllFramesFuncDefScope.functionsContainerBody;
         }
     

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1,6 +1,6 @@
 import i18n from "@/i18n";
 import { useStore } from "@/store/store";
-import {AddFrameCommandDef, AddShorthandFrameCommandDef, AllFrameTypesIdentifier, areSlotCoreInfosEqual, BaseSlot, CaretPosition, FieldSlot, FrameContextMenuActionName, FrameContextMenuShortcut, FramesDefinitions, getFrameDefType, isFieldBaseSlot, isFieldBracketedSlot, isFieldMediaSlot, isFieldStringSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, MediaSlot, ModifierKeyCode, NavigationPosition, Position, SelectAllFramesFuncDefScope, SlotCoreInfos, SlotCursorInfos, SlotsStructure, SlotType, StringSlot} from "@/types/types";
+import {AddFrameCommandDef, AddShorthandFrameCommandDef, AllFrameTypesIdentifier, areSlotCoreInfosEqual, BaseSlot, CaretPosition, CollapsedState, FieldSlot, FrameContextMenuActionName, FrameContextMenuShortcut, FrameObject, FramesDefinitions, getFrameDefType, isFieldBaseSlot, isFieldBracketedSlot, isFieldMediaSlot, isFieldStringSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, MediaSlot, ModifierKeyCode, NavigationPosition, Position, SelectAllFramesFuncDefScope, SlotCoreInfos, SlotCursorInfos, SlotsStructure, SlotType, StringSlot} from "@/types/types";
 import { getAboveFrameCaretPosition, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFrameBelowCaretPosition, getFrameContainer, getFrameSectionIdFromFrameId } from "./storeMethods";
 import { splitByRegexMatches, strypeFileExtension } from "./common";
 import {getContentForACPrefix} from "@/autocompletion/acManager";
@@ -2281,4 +2281,46 @@ export function slotStructureToString(ss: SlotsStructure) : string {
         r.push(getMatchingBracket(ss.openingBracketValue, true));
     }
     return r.join("");
+}
+
+// Given the current state of all the frames (or undefined if in a mixed state), gets the next state that would/should be cycled to
+// This is the next state that all frames support.
+export function calculateNextCollapseState(curCommonState : CollapsedState | undefined, frameList: FrameObject[]) : CollapsedState {
+    // The default if anything unexpected happens:
+    let nextState = CollapsedState.FULLY_VISIBLE;
+    // If they are in a mixed state we want next state to be fully collapsed, which is always available for defs:
+    if (curCommonState === undefined) {
+        nextState = CollapsedState.ONLY_HEADER_VISIBLE;
+    }
+    else {
+        // Otherwise, we need to work out the next state.  It should be a state they can all reach, which
+        // depends on the frames present (e.g. the doc state can't be reached if we have a mix of class and
+        // function frames)
+
+        // Step 1: compute remaining states per object
+        const possibleNextStates = (frameList as FrameObject[]).map((f) => {
+            const idx = f.frameType.allowedCollapsedStates.indexOf(f.collapsedState ?? CollapsedState.FULLY_VISIBLE);
+            if (idx < 0) {
+                return []; // safeguard if current not found
+            }
+
+            // everything after current + everything before current
+            return f.frameType.allowedCollapsedStates.slice(idx + 1).concat(f.frameType.allowedCollapsedStates.slice(0, idx));
+        });
+
+        // Step 2: intersect them all
+        let intersection = new Set(possibleNextStates[0]);
+        for (let i = 1; i < possibleNextStates.length; i++) {
+            intersection = new Set(possibleNextStates[i].filter((s) => intersection.has(s)));
+        }
+
+        // Step 3: pick earliest in canonical order (say, the first object’s list)
+        for (const state of possibleNextStates[0]) {
+            if (intersection.has(state)) {
+                nextState = state;
+                break;
+            }
+        }
+    }
+    return nextState;
 }

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -257,6 +257,7 @@
   },
   "shortcut": {
     "delete": "Delete",
-    "ctrlPlus": "Ctrl+"
+    "ctrlPlus": "Ctrl+",
+    "period": "Dot"
   }
 }

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -174,7 +174,10 @@
     "delete": "Delete",
     "deleteOuter": "Delete Outer",
     "insert": "Insert",
-    "screenshotGraphics": "Download screenshot"
+    "screenshotGraphics": "Download screenshot",
+    "collapseHeader": "Collapsed View",
+    "collapseDocumentation": "Interface View",
+    "collapseFull": "Expanded View"
   },
   "appMenu": {
     "downloadHex": "Convert to Hex file",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -101,6 +101,7 @@ export const useStore = defineStore("app", {
             // This is the selected tab index of the Commands' tab panel.
             commandsTabIndex: 0, 
 
+            // Are we editing a text slot?
             isEditing: false,
 
             /* These state properties are for saving the layout of the UI.

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -74,7 +74,7 @@ export const useStore = defineStore("app", {
 
             importContainerId: -1,
 
-            functionDefContainerId: -2,
+            defsContainerId: -2,
             /** END of flags that need checking when a build is done **/
 
             currentFrame: { id: -3, caretPosition: CaretPosition.body } as CurrentFrame,
@@ -670,8 +670,8 @@ export const useStore = defineStore("app", {
                 // - imports container
                 // - function definition container
                 const currentFrame = state.frameObjects[state.currentFrame.id];
-                return (state.currentFrame.caretPosition == CaretPosition.body && currentFrame.id != state.importContainerId && currentFrame.id != state.functionDefContainerId) 
-                    || (state.currentFrame.caretPosition == CaretPosition.below && currentFrame.parentId !== undefined && currentFrame.parentId != state.importContainerId && currentFrame.parentId != state.functionDefContainerId);        
+                return (state.currentFrame.caretPosition == CaretPosition.body && currentFrame.id != state.importContainerId && currentFrame.id != state.defsContainerId) 
+                    || (state.currentFrame.caretPosition == CaretPosition.below && currentFrame.parentId !== undefined && currentFrame.parentId != state.importContainerId && currentFrame.parentId != state.defsContainerId);        
             }
         },
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -210,6 +210,9 @@ export enum FrameContextMenuActionName {
     deleteOuter,
     enable,
     disable,
+    collapseToHeader,
+    collapseToDocumentation,
+    collapseToFull,
 }
 
 export enum ModifierKeyCode {

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -188,6 +188,15 @@ describe("Tests disabling frames", () => {
     });
 });
 
+describe("Tests collapsing frames", () => {
+    it("Loads and saves a simple collapsed project", () => {
+        testRoundTripImportAndDownload("tests/cypress/fixtures/project-basic-trisection-collapse.spy");
+    });
+    it("Loads and saves a complex disable project", () => {
+        testRoundTripImportAndDownload("tests/cypress/fixtures/project-complex-disable-collapse.spy");
+    });
+});
+
 describe("Tests blanks", () => {
     it("Outputs a file with lots of blanks", () => {
         // import x as ___strype_blank

--- a/tests/cypress/fixtures/project-basic-trisection-collapse.spy
+++ b/tests/cypress/fixtures/project-basic-trisection-collapse.spy
@@ -1,0 +1,11 @@
+#(=> Strype:1:std
+#(=> Section:Imports
+import os 
+#(=> Section:Definitions
+#(=> Collapsed:Documentation
+def foo (msg ) :
+    print(msg) 
+#(=> Section:Main
+msg  = "Hello" 
+foo(msg) 
+#(=> Section:End

--- a/tests/cypress/fixtures/project-complex-disable-collapse.spy
+++ b/tests/cypress/fixtures/project-complex-disable-collapse.spy
@@ -1,0 +1,87 @@
+#(=> Strype:1:std
+#(=> Section:Imports
+import foo 
+#(=> Disabled:import bar 
+#(=> Disabled:from time import * 
+from imaginary import imagined 
+#(=> Disabled:from a.b.c import * 
+#(=> Section:Definitions
+#(=> Collapsed:Documentation
+def foo ( ) :
+    return 3 
+    print() 
+    #(=> Disabled:print("a") 
+    #(=> Disabled:if True  :
+    #(=> Disabled:    func(1,2,3) 
+    #(=> Disabled:    return 6 
+    #(=> Disabled:raise 5 
+    if False  :
+        #(=> Disabled:print("Bye") 
+        func(1,2,3) 
+    #(=> Disabled:print("Byeee") 
+def bar ( ) :
+    if True  :
+        print(msg) 
+    #(=> Disabled:elif False  :
+    #(=> Disabled:    print(msg2) 
+    else :
+        print(msg3) 
+    if True  :
+        print(msg) 
+    #(=> Disabled:elif False  :
+    #(=> Disabled:    print(msg4) 
+    #(=> Disabled:else :
+    #(=> Disabled:    print(msg5) 
+    #(=> Disabled:print(msg6) 
+#(=> Disabled:#(=> Collapsed:Header
+#(=> Disabled:def baz ( ) :
+#(=> Disabled:    print(msg) 
+#(=> Disabled:#(=> Collapsed:Header
+#(=> Disabled:class Apple  :
+#(=> Disabled:    #(=> Collapsed:Documentation
+#(=> Disabled:    def baz (self, ) :
+#(=> Disabled:        '''Some method named baz'''
+#(=> Disabled:        print(msg) 
+def whatever ( ) :
+    if True  :
+        pass
+        #(=> Disabled:abs(-76) 
+    while False  :
+        pass
+        #(=> Disabled:abs(34) 
+    try :
+        print(2) 
+    #(=> Disabled:except e  :
+    #(=> Disabled:    print(5) 
+    except f  :
+        pass
+        #(=> Disabled:print(7) 
+    #(=> Disabled:else :
+    #(=> Disabled:    print(9) 
+#(=> Collapsed:Header
+class Foo(Bar)  :
+    def __init__ (self,param ) :
+        self.x  = param 
+#(=> Collapsed:Header
+class Foo2  :
+    #(=> Collapsed:Documentation
+    def __init__ (self,param ) :
+        '''Initialises some parameter.'''
+        self.x  = param 
+    def unfolded (self, ) :
+        if True  :
+            pass
+    #(=> Collapsed:Header
+    def collapsed (self,x ) :
+        return x 
+#(=> Section:Main
+#(=> Disabled:print(hello) 
+msg  = "Hello" 
+try :
+    print(msg10) 
+except ___strype_dummy:
+    pass
+#(=> Disabled:finally :
+#(=> Disabled:    print(msg11) 
+#(=> Disabled:print(msg) 
+#(=> Section:End


### PR DESCRIPTION
This has a few fixes:
 - Fix Ctrl-A inside classes (although we may revisit the behaviour in the next team meeting)
 - Add space between classes, and functions -- unless they are collapsed, in which case don't show the spacing
 - Load and save the collapsed status in the SPY via "#(=> Collapsed:..." comments just before the first line of the frame
 - Add three collapse entries to the context menu which show if available (e.g. they don't show on if frames) for the three states.  They are greyed out if that is the current state.
 - Add support for pressing "." (dot) to cycle the state of the current selection or frame after cursor if no selection.  The item that would be triggered by dot is shown in the context menu as having that shortcut.

Although there are many commits I think it will still be easiest to read one commit at a time as they are generally quite independent.