### PR TITLE
Change how we get the URI for OneDrive

### DIFF
--- a/src/components/OneDriveComponent.vue
+++ b/src/components/OneDriveComponent.vue
@@ -118,10 +118,7 @@ export default Vue.extend({
 
         // These are specific to the OneDrive component.
         siteOrigin(): string {
-            console.log(process.env.npm_config_githubpages);
-            return (process.env.NODE_ENV === "production") 
-                ? "https://www.strype.org" 
-                : ((process.env.npm_config_githubpages) ? "https://k-pet-group.github.io" : "http://localhost:8081");
+            return window.origin;
         },
 
         redirectURI(): string {


### PR DESCRIPTION
This is an updated the previous testing PR for allowing our GitHub page to use the OneDrive access.
Instead of trying to infer what origin to use and set it literally, it is just more logical and basic to directly get it from the window object...
I've changed the code in that direction, hopefully that should be working fine now.
To simply the workflow, Neil did the code review via Teams so this PR can be merged right away.