### PR TITLE
Fixed Ctrl-A in definitions with OOP

### DIFF
--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -351,12 +351,12 @@ export default Vue.extend({
                     if(eventKeyLowCase === "a" && !isEditing){ 
                         if(getActiveContextMenu() == null && !this.appStore.isAppMenuOpened){
                             const frameContainerId = getFrameSectionIdFromFrameId(this.appStore.currentFrame.id);
-                            // If a selection already exists, we clear it, after checking where we are at in the case of function defs (cf. below)
+                            // If a selection already exists, we clear it, after checking where we are at with respect to the select-all action to take
                             const selectAllFramesAction = getCurrentFrameSelectAllAction();
                             this.appStore.unselectAllFrames();
                             switch(selectAllFramesAction){
                             case SelectAllFramesAction.wholeContainer:
-                                // In imports or main code. Or in function definitions with some functions selected, or inside the function defs container.
+                                // In imports or main code. Or in definitions section  with some items selected.
                                 // Position the frame cursor inside the body of the frame container
                                 this.appStore.setCurrentFrame({id: frameContainerId, caretPosition: CaretPosition.body});
                                 // And select all the children frame of the container (if any...)

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -366,11 +366,14 @@ export default Vue.extend({
                                 });     
                                 break;
                             case SelectAllFramesFuncDefScope.none:
+                            case SelectAllFramesFuncDefScope.partClassBody:
                                 // In a function definition with no frame selected or some frames inside a function body (not all).
                                 // We select all the frames of the function's body.
                                 {
                                     let functionDefFrameId = 0, currentFrameId = this.appStore.currentFrame.id, foundFunctionDefFrame = false;
-                                    if(this.appStore.frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.funcdef){
+                                    if(currentFrameSelection == SelectAllFramesFuncDefScope.none ?
+                                        this.appStore.frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.funcdef
+                                        : this.appStore.frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.classdef){
                                         // If we are in the body of the function definition (just inside the body position, not somewhere else)
                                         //then we don't need to look up for the body position as we're already there...
                                         foundFunctionDefFrame = true;
@@ -378,7 +381,9 @@ export default Vue.extend({
                                     }
                                     while(!foundFunctionDefFrame){
                                         functionDefFrameId = this.appStore.frameObjects[currentFrameId].parentId;
-                                        foundFunctionDefFrame = (this.appStore.frameObjects[functionDefFrameId].frameType.type == AllFrameTypesIdentifier.funcdef);
+                                        foundFunctionDefFrame = (currentFrameSelection == SelectAllFramesFuncDefScope.none ?
+                                            this.appStore.frameObjects[functionDefFrameId].frameType.type == AllFrameTypesIdentifier.funcdef
+                                            : this.appStore.frameObjects[functionDefFrameId].frameType.type == AllFrameTypesIdentifier.classdef);
                                         currentFrameId = functionDefFrameId;
                                     }
                                     this.appStore.setCurrentFrame({id: functionDefFrameId, caretPosition: CaretPosition.body});
@@ -395,6 +400,7 @@ export default Vue.extend({
                                 this.appStore.setCurrentFrame({id: this.appStore.selectedFrames.at(-1) as number, caretPosition: CaretPosition.below});   
                                 break;
                             case SelectAllFramesFuncDefScope.wholeFunctionBody:
+                            case SelectAllFramesFuncDefScope.wholeClassBody:
                                 // In function definitions with function body frames selected.
                                 // We select the whole function.
                                 {

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -356,7 +356,7 @@ export default Vue.extend({
                             this.appStore.unselectAllFrames();
                             switch(currentFrameSelection){
                             case SelectAllFramesFuncDefScope.frame:
-                            case SelectAllFramesFuncDefScope.functionsContainerBody:
+                            case SelectAllFramesFuncDefScope.definitionsContainerBody:
                                 // In imports or main code. Or in function definitions with some functions selected, or inside the function defs container.
                                 // Position the frame cursor inside the body of the frame container
                                 this.appStore.setCurrentFrame({id: frameContainerId, caretPosition: CaretPosition.body});

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1,6 +1,6 @@
 import i18n from "@/i18n";
 import { useStore } from "@/store/store";
-import {AddFrameCommandDef, AddShorthandFrameCommandDef, AllFrameTypesIdentifier, areSlotCoreInfosEqual, BaseSlot, CaretPosition, CollapsedState, FieldSlot, FrameContextMenuActionName, FrameContextMenuShortcut, FrameObject, FramesDefinitions, FrozenState, getFrameDefType, isFieldBaseSlot, isFieldBracketedSlot, isFieldMediaSlot, isFieldStringSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, MediaSlot, ModifierKeyCode, NavigationPosition, Position, SelectAllFramesFuncDefScope, SlotCoreInfos, SlotCursorInfos, SlotsStructure, SlotType, StringSlot} from "@/types/types";
+import { AddFrameCommandDef, AddShorthandFrameCommandDef, AllFrameTypesIdentifier, areSlotCoreInfosEqual, BaseSlot, CaretPosition, CollapsedState, FieldSlot, FrameContextMenuActionName, FrameContextMenuShortcut, FrameObject, FramesDefinitions, FrozenState, getFrameDefType, isFieldBaseSlot, isFieldBracketedSlot, isFieldMediaSlot, isFieldStringSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, MediaSlot, ModifierKeyCode, NavigationPosition, Position, SelectAllFramesAction, SlotCoreInfos, SlotCursorInfos, SlotsStructure, SlotType, StringSlot } from "@/types/types";
 import { getAboveFrameCaretPosition, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFrameBelowCaretPosition, getFrameContainer, getFrameSectionIdFromFrameId } from "./storeMethods";
 import { splitByRegexMatches, strypeFileExtension } from "./common";
 import {getContentForACPrefix} from "@/autocompletion/acManager";
@@ -2076,67 +2076,69 @@ export function computeAddFrameCommandContainerSize(isExpandedPEA?: boolean): vo
 /* FITRUE_isPython */
 
 
-export function getCurrentFrameSelectionScope(): SelectAllFramesFuncDefScope {
+export function getCurrentFrameSelectAllAction(): SelectAllFramesAction {
     // This method checks the current selection scope that we need to know when doing select-all (for function definitions).
-    // If we are not in function definitions, for commodity, we return SelectAllFramesFuncDefScope.frame as it will the same
-    // logics for the other sections (selecting all the frames in the section)
+    // If we are not in function definitions, we return wholeContainer
     if(getFrameSectionIdFromFrameId(useStore().currentFrame.id) != useStore().defsContainerId){
-        return SelectAllFramesFuncDefScope.frame;
+        return SelectAllFramesAction.wholeContainer;
     }
+    // Now we know we are in the definitions section, and it's a matter of working out what to do
 
     const currentFrameSelection = useStore().selectedFrames;
-    // No selection *for somewhere non empty inside a function* then we are in the scope "none",
-    // No selection *and inside empty function* then we are in the scope "function body",
-    // No selection *for somewhere inside the function definition container, then it depends where we are (see details below),
-    // (no selection *and inside empty container* doesn't need to be considered, because it won't have any effect in the selection loops)
+    // No selection currently:
     if(currentFrameSelection.length == 0) {
         const {id: currentFrameId, caretPosition: currentFrameCaretPos} = useStore().currentFrame;
+        // We are at top-level, select the whole container:
         if(currentFrameId == useStore().defsContainerId){
-            return SelectAllFramesFuncDefScope.definitionsContainerBody;
-        }
-    
-        if(useStore().frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.funcdef && currentFrameCaretPos == CaretPosition.below){
-            return SelectAllFramesFuncDefScope.belowFunc;
+            // currentLevel and wholeContainer are the same here, really:
+            return SelectAllFramesAction.wholeContainer;
         }
 
-        if(useStore().frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.funcdef && currentFrameCaretPos == CaretPosition.body
-            && useStore().frameObjects[currentFrameId].childrenIds.length == 0){
-            return SelectAllFramesFuncDefScope.wholeFunctionBody;
+        const isClassOrFunc = useStore().frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.funcdef || useStore().frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.classdef;
+        const isOtherInDefs = !isClassOrFunc && useStore().frameObjects[currentFrameId].parentId == useStore().defsContainerId;
+
+        // If we are just below a function or class then we select everything at this level (which might be top level, or not):
+        if((isClassOrFunc || isOtherInDefs) && currentFrameCaretPos == CaretPosition.below){
+            return SelectAllFramesAction.currentLevel;
         }
         
-        if (useStore().frameObjects[currentFrameId].frameType.type == AllFrameTypesIdentifier.classdef) {
-            // Need to think about how this should work:
-            return SelectAllFramesFuncDefScope.wholeClassBody;
+        // If we are just inside an empty function or class, we select the parent as we have effectively
+        // already selected the entire (empty) content
+        if(isClassOrFunc
+            && currentFrameCaretPos == CaretPosition.body
+            && useStore().frameObjects[currentFrameId].childrenIds.length == 0){
+            return SelectAllFramesAction.parent;
         }
 
-        return SelectAllFramesFuncDefScope.none;
+        // Otherwise we select the whole enclosing function or class:
+        return SelectAllFramesAction.functionOrClassContents;
     }
+
+    // We must have a non-empty selection already, so look at the parent:
+    const parentId = useStore().frameObjects[currentFrameSelection[0]].parentId;
     
-    // If there is a selection and the first selected frame is a function definition, then we are in the "frame" scope
-    // (it doesn't matter to know if all functions are alreadys selected or not, the result is the same)
-    if(useStore().frameObjects[currentFrameSelection[0]].frameType.type == AllFrameTypesIdentifier.funcdef
-        || useStore().frameObjects[currentFrameSelection[0]].frameType.type == AllFrameTypesIdentifier.classdef){
-        if (useStore().frameObjects[useStore().frameObjects[currentFrameSelection[0]].parentId].frameType.type == AllFrameTypesIdentifier.classdef) {
-            return SelectAllFramesFuncDefScope.partClassBody;
-        }
-        else {
-            return SelectAllFramesFuncDefScope.frame;
-        }
+    // If we are top level then select everything:
+    if(parentId == useStore().defsContainerId) {
+        return SelectAllFramesAction.wholeContainer;
     }
 
     // At this stage, there is a selection within a function definition but we need to check if that's ALL the frames of 
     // a function definition's body or just some of them, or a selection in a deeper level of the frame hierarchy. 
-    const selectionParentFrame = useStore().frameObjects[useStore().frameObjects[currentFrameSelection[0]].parentId];
+    const selectionParentFrame = useStore().frameObjects[parentId];
     if(selectionParentFrame.frameType.type != AllFrameTypesIdentifier.funcdef && selectionParentFrame.frameType.type != AllFrameTypesIdentifier.classdef){
-        // We are somewhere inside a function definition, but not just at the function's body level
-        return SelectAllFramesFuncDefScope.none;
+        // We are somewhere inside a function definition or class, but not just at the top level:
+        return SelectAllFramesAction.functionOrClassContents;
     }
+    // We must be just inside a function or class; have we selected all of it?
     const functionChildren = selectionParentFrame.childrenIds;
     if(currentFrameSelection[0] == functionChildren[0] && currentFrameSelection.length == functionChildren.length){
-        // All frames of a function's body are already selected
-        return selectionParentFrame.frameType.type == AllFrameTypesIdentifier.funcdef ? SelectAllFramesFuncDefScope.wholeFunctionBody : SelectAllFramesFuncDefScope.wholeClassBody;
+        // All frames of a function's body are already selected, select the parent
+        return SelectAllFramesAction.parent;
     }
-    return SelectAllFramesFuncDefScope.none;
+    else {
+        // Select all of the current level then:
+        return SelectAllFramesAction.currentLevel;
+    }
 }
 
 

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -377,12 +377,6 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
                 mostRecentIndent = "";
             }
         }
-        /*
-            else {
-                
-            }
-        }
-         */
         else if (codeLines[i].trim() === "" && currentTripleQuoteString == null) {
             // Blank line, outside a string:
             // We indent this to the largest of its indent,

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -1284,7 +1284,7 @@ function canPastePythonAtStrypeLocation(currentStrypeLocation : STRYPE_LOCATION)
         removeTopLevelBlankFrames();
         // We are checking if we can paste; the not at the beginning means everything here is actually the cases
         // where we *cannot* paste.
-        return !(topLevelCopiedFrames.some((frame) => ![AllFrameTypesIdentifier.funcdef, AllFrameTypesIdentifier.classdef, AllFrameTypesIdentifier.comment, AllFrameTypesIdentifier.blank].includes(frame.frameType.type))
+        return !(topLevelCopiedFrames.some((frame) => ![AllFrameTypesIdentifier.funcdef, AllFrameTypesIdentifier.classdef, AllFrameTypesIdentifier.varassign, AllFrameTypesIdentifier.comment, AllFrameTypesIdentifier.blank].includes(frame.frameType.type))
             || copiedPythonToFrames.some((frame) =>
                 // Look only at non-top-level (i.e. child) frames    
                 !topLevelCopiedFrameIds.includes(frame.id) &&

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -1278,12 +1278,12 @@ function canPastePythonAtStrypeLocation(currentStrypeLocation : STRYPE_LOCATION)
     switch(currentStrypeLocation){
     case STRYPE_LOCATION.MAIN_CODE_SECTION:
         return !copiedPythonToFrames.some((frame) => [AllFrameTypesIdentifier.import, AllFrameTypesIdentifier.fromimport, AllFrameTypesIdentifier.classdef, AllFrameTypesIdentifier.funcdef, AllFrameTypesIdentifier.global].includes(frame.frameType.type));
-    case  STRYPE_LOCATION.IN_FUNCDEF:
+    case STRYPE_LOCATION.IN_FUNCDEF:
         return !copiedPythonToFrames.some((frame) => [AllFrameTypesIdentifier.import, AllFrameTypesIdentifier.fromimport, AllFrameTypesIdentifier.classdef, AllFrameTypesIdentifier.funcdef].includes(frame.frameType.type));
-    case  STRYPE_LOCATION.DEFS_SECTION:
+    case STRYPE_LOCATION.DEFS_SECTION:
         removeTopLevelBlankFrames();
-        // We are checking if we can paste; the not at the beginning means everything here is actually the cases
-        // where we *cannot* paste.
+        // We are checking if we can paste; the not at the beginning means everything inside the ensuing bracket is actually the cases
+        // where we *cannot* paste, then we invert this to get all the cases we can paste
         return !(topLevelCopiedFrames.some((frame) => ![AllFrameTypesIdentifier.funcdef, AllFrameTypesIdentifier.classdef, AllFrameTypesIdentifier.varassign, AllFrameTypesIdentifier.comment, AllFrameTypesIdentifier.blank].includes(frame.frameType.type))
             || copiedPythonToFrames.some((frame) =>
                 // Look only at non-top-level (i.e. child) frames    

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -17,7 +17,6 @@ import { nextTick } from "@vue/composition-api";
 import { TPyParser } from "tigerpython-parser";
 import AppComponent from "@/App.vue";
 import emptyState from "@/store/initial-states/empty-state";
-import Parser from "@/parser/parser";
 /* IFTRUE_isPython */
 import PEAComponent from "@/components/PythonExecutionArea.vue";
 import CommandsComponent from "@/components/Commands.vue";
@@ -1299,7 +1298,6 @@ export const useStore = defineStore("app", {
                 "copiedSelectionFrameIds",  
                 topLevelCopiedFrames
             );
-
         },
 
         updateState(newState: Record<string, unknown>){
@@ -1664,7 +1662,7 @@ export const useStore = defineStore("app", {
             );
 
             this.copiedFrameId = -100;
-
+            
             Vue.set(
                 this,
                 "copiedSelectionFrameIds",
@@ -2088,7 +2086,7 @@ export const useStore = defineStore("app", {
         // Returns true if the deletion ocurred or false if it did not.
         deleteFrames(key: string, ignoreBackState?: boolean) : boolean {
             const stateBeforeChanges = cloneDeep(this.$state);
-
+            
             // we remove the editable slots from the available positions
             let availablePositions = getAvailableNavigationPositions();
             availablePositions = availablePositions.filter((e) => !e.isSlotNavigationPosition);
@@ -2170,7 +2168,7 @@ export const useStore = defineStore("app", {
                             }
                         }                                        
                     }
-                    
+
                     if(!foundDisabledJointFrameToDelete) {
                         const indexOfCurrentInAvailables = availablePositions.findIndex((e)=> e.frameId === currentFrame.id && e.caretPosition === this.currentFrame.caretPosition);
                         // the "next" position of the current
@@ -2935,9 +2933,7 @@ export const useStore = defineStore("app", {
 
         copyFrame(frameId: number) {
             this.flushCopiedFrames();
-            const text = new Parser(true, "spy").parse({startAtFrameId: frameId, stopAt: {frameId: frameId, includeThisFrame: true}, excludeLoopsAndCommentsAndCloseTry: false, defsLast: false});
             this.doCopyFrame(frameId);
-            navigator.clipboard.writeText(text);
             this.updateNextAvailableId();
         },
 
@@ -2946,9 +2942,7 @@ export const useStore = defineStore("app", {
                 return;
             }
             this.flushCopiedFrames();
-            const text = new Parser(true, "spy").parse({startAtFrameId: this.selectedFrames[0], stopAt: {frameId: this.selectedFrames.at(-1) as number, includeThisFrame: true}, excludeLoopsAndCommentsAndCloseTry: false, defsLast: false});
             this.doCopySelection();
-            navigator.clipboard.writeText(text);
             this.updateNextAvailableId();
         },
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -199,11 +199,13 @@ export enum CaretPosition {
 }
 
 export enum SelectAllFramesFuncDefScope {
-    none, // inside a function body, no frame is selected at all OR some frames are selected but not all
+    none, // inside a function or class body, no frame is selected at all OR some frames are selected but not all
     belowFunc, // below a function definition
     definitionsContainerBody, // inside the body of the function definitions container
     wholeFunctionBody, // all frames for a function def body are selected
-    frame // some function frames are selected
+    frame, // some function frames are selected
+    partClassBody, // some frames in a class are selected
+    wholeClassBody, // all frames a class def are selection
 }
 
 export enum FrameContextMenuActionName {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -201,7 +201,7 @@ export enum CaretPosition {
 export enum SelectAllFramesFuncDefScope {
     none, // inside a function body, no frame is selected at all OR some frames are selected but not all
     belowFunc, // below a function definition
-    functionsContainerBody, // inside the body of the function definitions container
+    definitionsContainerBody, // inside the body of the function definitions container
     wholeFunctionBody, // all frames for a function def body are selected
     frame // some function frames are selected
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -198,14 +198,12 @@ export enum CaretPosition {
     none = "none",
 }
 
-export enum SelectAllFramesFuncDefScope {
-    none, // inside a function or class body, no frame is selected at all OR some frames are selected but not all
-    belowFunc, // below a function definition
-    definitionsContainerBody, // inside the body of the function definitions container
-    wholeFunctionBody, // all frames for a function def body are selected
-    frame, // some function frames are selected
-    partClassBody, // some frames in a class are selected
-    wholeClassBody, // all frames a class def are selection
+// If the user hits Ctrl-A there's a finite set of possibilities of what to do:
+export enum SelectAllFramesAction {
+    currentLevel, // Select all at current level
+    functionOrClassContents, // Select everything in the enclosing function/class
+    wholeContainer, // Select everything in the current container/section
+    parent, // Select the parent (only)
 }
 
 export enum FrameContextMenuActionName {

--- a/tests/playwright/e2e/frame-selection-manipulation.spec.ts
+++ b/tests/playwright/e2e/frame-selection-manipulation.spec.ts
@@ -71,4 +71,76 @@ def foo ( ) :
 #(=> Section:End
 `);
     });
+
+    test("Test Ctrl-A once in a function selects whole function content", async ({page}) => {
+        // Transfers content from src to dest: 
+        await testBeforeAfterPaste(page,`def dest():
+   pass
+def src():
+    print('A')
+    if x > 0:
+        print('B')
+    print('C')
+`, /* We get below print('B'): */ ["End", "ArrowUp", "ArrowUp", "ArrowUp", "ArrowUp", "Control+a"], "cut", ["Home", "ArrowDown"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def dest ( ) :
+    print('A') 
+    if x>0  :
+        print('B') 
+    print('C') 
+def src ( ) :
+    pass
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+
+    test("Test Ctrl-A twice in a function selects function including header", async ({page}) => {
+        // Moves second above first: 
+        await testBeforeAfterPaste(page,`def first():
+   pass
+def second():
+    print('A')
+    if x > 0:
+        print('B')
+    print('C')
+`, /* We get below print('B'): */ ["End", "ArrowUp", "ArrowUp", "ArrowUp", "ArrowUp", "Control+a", "Control+a"], "cut", ["Home"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def second ( ) :
+    print('A') 
+    if x>0  :
+        print('B') 
+    print('C') 
+def first ( ) :
+    pass
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+
+    test("Test Ctrl-A thrice in a function selects all functions", async ({page}) => {
+        // So the paste will end up cutting all functions and pasting them back, so it looks like no change:
+        await testBeforeAfterPaste(page,`def first():
+   print('0') 
+def second():
+    print('A')
+    if x > 0:
+        print('B')
+    print('C')
+`, /* We get below print('B'): */ ["End", "ArrowUp", "ArrowUp", "ArrowUp", "ArrowUp", "Control+a", "Control+a", "Control+a"], "cut", ["Home"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def first ( ) :
+    print('0') 
+def second ( ) :
+    print('A') 
+    if x>0  :
+        print('B') 
+    print('C') 
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
 });

--- a/tests/playwright/e2e/frame-selection-manipulation.spec.ts
+++ b/tests/playwright/e2e/frame-selection-manipulation.spec.ts
@@ -1,0 +1,74 @@
+import {Page, test, expect} from "@playwright/test";
+import { loadContent, save } from "../support/loading-saving";
+import { readFileSync } from "node:fs";
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    if (browserName === "webkit" && process.platform === "win32") {
+        // On Windows+Webkit it just can't seem to load the page for some reason:
+        testInfo.skip(true, "Skipping on Windows + WebKit due to unknown problems");
+    }
+
+    // These tests can take longer than the default 30 seconds:
+    testInfo.setTimeout(90000); // 90 seconds
+
+    await page.goto("./", {waitUntil: "load"});
+    await page.waitForSelector("body");
+    await page.evaluate(() => {
+        (window as any).Playwright = true;
+    });
+    // Make browser's console.log output visible in our logs (useful for debugging):
+    page.on("console", (msg) => {
+        console.log("Browser log:", msg.text());
+    });
+});
+
+async function testBeforeAfterPaste(page: Page, before :string, selectionKeys: string[], operation: "cut" | "copy", moveToDestKeys: string[], afterPaste :string) {
+    // Load:
+    await loadContent(page, before);
+    for (const k of selectionKeys) {
+        await page.keyboard.press(process.platform == "darwin" ? k.replaceAll("Control", "Meta") : k);
+    }
+    // Now cut/copy:
+    if (operation === "cut") {
+        await page.keyboard.press(process.platform == "darwin" ? "Meta+x" : "Control+x");
+    }
+    else {
+        await page.keyboard.press(process.platform == "darwin" ? "Meta+c" : "Control+c");
+    }
+    // Then move:
+    for (const k of moveToDestKeys) {
+        await page.keyboard.press(process.platform == "darwin" ? k.replaceAll("Control", "Meta") : k);
+    }
+    // Paste and check:
+    await page.keyboard.press(process.platform == "darwin" ? "Meta+v" : "Control+v");
+    expect(readFileSync(await save(page, false), "utf-8")).toEqual(afterPaste);
+}
+
+test.describe(() => {
+    test("Cut and paste a simple frame", async ({page}) => {
+        await testBeforeAfterPaste(page, "print('A')\nprint('B')\n", ["End", "Shift+ArrowUp"], "cut", ["End", "ArrowUp"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+#(=> Section:Main
+print('B') 
+print('A') 
+#(=> Section:End
+`);
+    });
+
+    test("Test Ctrl-A in main code", async ({page}) => {
+        await testBeforeAfterPaste(page,`def foo():
+   pass
+print('A')
+print('B')
+`, ["End", "Control+a"], "cut", ["Home", "ArrowUp", "ArrowUp"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def foo ( ) :
+    print('A') 
+    print('B') 
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+});

--- a/tests/playwright/e2e/frame-selection-manipulation.spec.ts
+++ b/tests/playwright/e2e/frame-selection-manipulation.spec.ts
@@ -3,9 +3,10 @@ import { loadContent, save } from "../support/loading-saving";
 import { readFileSync } from "node:fs";
 
 test.beforeEach(async ({ page, browserName }, testInfo) => {
-    if (browserName === "webkit" && process.platform === "win32") {
-        // On Windows+Webkit it just can't seem to load the page for some reason:
-        testInfo.skip(true, "Skipping on Windows + WebKit due to unknown problems");
+    if (browserName === "webkit" && (process.platform === "win32" || process.platform === "linux")) {
+        // On Windows+Webkit it just can't seem to load the page for some reason,
+        // and on Ubuntu+Webkit the paste doesn't seem to work (while it's fine on MacOS):
+        testInfo.skip(true, "Skipping on Windows/Ubuntu + WebKit due to various problems");
     }
 
     // These tests can take longer than the default 30 seconds:

--- a/tests/playwright/e2e/frame-selection-manipulation.spec.ts
+++ b/tests/playwright/e2e/frame-selection-manipulation.spec.ts
@@ -145,13 +145,11 @@ def second ( ) :
     });
     
     const rep = <T>(n: number, x: T) => Array(n).fill(x);
-    
-    test("Test Ctrl-A once in a class function selects whole function content", async ({page}) => {
-        // Transfers content from src to dest functions: 
-        await testBeforeAfterPaste(page,`class Dest:
-   dest_member = 0
-   def dest(self):
-       print('0')
+
+    const classTestInput = `class Dest:
+    dest_member = 0
+    def dest(self):
+        print('0')
 class Src: 
     src_member_1 = 0
     def src(self):
@@ -161,7 +159,10 @@ class Src:
         print('C')
     def src2():
         print('D')
-`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(1, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
+`;
+    test("Test Ctrl-A once in a class function selects whole function content", async ({page}) => {
+        // Transfers content from src to dest functions: 
+        await testBeforeAfterPaste(page,classTestInput, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(1, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
 #(=> Section:Imports
 #(=> Section:Definitions
 class Dest  :
@@ -185,20 +186,7 @@ class Src  :
 
     test("Test Ctrl-A twice in a class function selects whole function", async ({page}) => {
         // Transfers src function to Dest class: 
-        await testBeforeAfterPaste(page,`class Dest:
-   dest_member = 0
-   def dest(self):
-       print('0')
-class Src: 
-    src_member_1 = 0
-    def src(self):
-        print('A')
-        if x > 0:
-            print('B')
-        print('C')
-    def src2():
-        print('D')
-`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(2, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
+        await testBeforeAfterPaste(page, classTestInput, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(2, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
 #(=> Section:Imports
 #(=> Section:Definitions
 class Dest  :
@@ -221,20 +209,7 @@ class Src  :
 
     test("Test Ctrl-A three times in a class function selects whole class content", async ({page}) => {
         // Transfers all class content from Src to Dest: 
-        await testBeforeAfterPaste(page,`class Dest:
-   dest_member = 0 
-   def dest(self):
-       print('0') 
-class Src: 
-    src_member_1 = 0 
-    def src(self):
-        print('A')
-        if x > 0:
-            print('B')
-        print('C') 
-    def src2():
-        print('D') 
-`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(3, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
+        await testBeforeAfterPaste(page, classTestInput, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(3, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
 #(=> Section:Imports
 #(=> Section:Definitions
 class Dest  :
@@ -258,20 +233,7 @@ class Src  :
 
     test("Test Ctrl-A four times in a class function selects whole class", async ({page}) => {
         // Moves Src class above dest: 
-        await testBeforeAfterPaste(page,`class Dest:
-   dest_member = 0
-   def dest(self):
-       print('0')
-class Src: 
-    src_member_1 = 0 
-    def src(self):
-        print('A')
-        if x > 0:
-            print('B')
-        print('C')
-    def src2():
-        print('D')
-`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(4, "Control+a")], "cut", ["Home"],`#(=> Strype:1:std
+        await testBeforeAfterPaste(page, classTestInput, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(4, "Control+a")], "cut", ["Home"],`#(=> Strype:1:std
 #(=> Section:Imports
 #(=> Section:Definitions
 class Src  :
@@ -294,20 +256,7 @@ class Dest  :
 
     test("Test Ctrl-A five times in a class function selects all definitions", async ({page}) => {
         // Basically does nothing because everything ends where it began: 
-        await testBeforeAfterPaste(page,`class Dest:
-   dest_member = 0
-   def dest(self):
-       print('0')
-class Src: 
-    src_member_1 = 0
-    def src(self):
-        print('A')
-        if x > 0:
-            print('B')
-        print('C')
-    def src2():
-        print('D')
-`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(5, "Control+a")], "cut", ["Home"],`#(=> Strype:1:std
+        await testBeforeAfterPaste(page, classTestInput, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(5, "Control+a")], "cut", ["Home"],`#(=> Strype:1:std
 #(=> Section:Imports
 #(=> Section:Definitions
 class Dest  :
@@ -323,6 +272,42 @@ class Src  :
         print('C') 
     def src2 (self, ) :
         print('D') 
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+    
+    const classTestInput2 = `class OneFunc:
+    def theOneFunc():
+        return 42
+class OneVar:
+    theOneVar = 43
+`;
+
+    test("Test Ctrl-A twice below solitary function in class selects whole class", async ({page}) => {
+        // Should move whole class: 
+        await testBeforeAfterPaste(page, classTestInput2, /* We get into the class: */ ["End", ...rep(5, "ArrowUp"), ...rep(2, "Control+a")], "cut", ["End"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class OneVar  :
+    theOneVar  = 43 
+class OneFunc  :
+    def theOneFunc (self, ) :
+        return 42 
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+    test("Test Ctrl-A twice below solitary var in class selects whole class", async ({page}) => {
+        // Should move whole class: 
+        await testBeforeAfterPaste(page, classTestInput2, /* We get into the class: */ ["End", ...rep(2, "ArrowUp"), ...rep(2, "Control+a")], "cut", ["Home"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class OneVar  :
+    theOneVar  = 43 
+class OneFunc  :
+    def theOneFunc (self, ) :
+        return 42 
 #(=> Section:Main
 #(=> Section:End
 `);

--- a/tests/playwright/e2e/frame-selection-manipulation.spec.ts
+++ b/tests/playwright/e2e/frame-selection-manipulation.spec.ts
@@ -120,7 +120,7 @@ def first ( ) :
 `);
     });
 
-    test("Test Ctrl-A thrice in a function selects all functions", async ({page}) => {
+    test("Test Ctrl-A three times in a function selects all functions", async ({page}) => {
         // So the paste will end up cutting all functions and pasting them back, so it looks like no change:
         await testBeforeAfterPaste(page,`def first():
    print('0') 
@@ -139,6 +139,190 @@ def second ( ) :
     if x>0  :
         print('B') 
     print('C') 
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+    
+    const rep = <T>(n: number, x: T) => Array(n).fill(x);
+    
+    test("Test Ctrl-A once in a class function selects whole function content", async ({page}) => {
+        // Transfers content from src to dest functions: 
+        await testBeforeAfterPaste(page,`class Dest:
+   dest_member = 0
+   def dest(self):
+       print('0')
+class Src: 
+    src_member_1 = 0
+    def src(self):
+        print('A')
+        if x > 0:
+            print('B')
+        print('C')
+    def src2():
+        print('D')
+`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(1, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class Dest  :
+    dest_member  = 0 
+    def dest (self, ) :
+        print('A') 
+        if x>0  :
+            print('B') 
+        print('C') 
+        print('0') 
+class Src  :
+    src_member_1  = 0 
+    def src (self, ) :
+        pass
+    def src2 (self, ) :
+        print('D') 
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+
+    test("Test Ctrl-A twice in a class function selects whole function", async ({page}) => {
+        // Transfers src function to Dest class: 
+        await testBeforeAfterPaste(page,`class Dest:
+   dest_member = 0
+   def dest(self):
+       print('0')
+class Src: 
+    src_member_1 = 0
+    def src(self):
+        print('A')
+        if x > 0:
+            print('B')
+        print('C')
+    def src2():
+        print('D')
+`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(2, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class Dest  :
+    dest_member  = 0 
+    def src (self, ) :
+        print('A') 
+        if x>0  :
+            print('B') 
+        print('C') 
+    def dest (self, ) :
+        print('0') 
+class Src  :
+    src_member_1  = 0 
+    def src2 (self, ) :
+        print('D') 
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+
+    test("Test Ctrl-A three times in a class function selects whole class content", async ({page}) => {
+        // Transfers all class content from Src to Dest: 
+        await testBeforeAfterPaste(page,`class Dest:
+   dest_member = 0 
+   def dest(self):
+       print('0') 
+class Src: 
+    src_member_1 = 0 
+    def src(self):
+        print('A')
+        if x > 0:
+            print('B')
+        print('C') 
+    def src2():
+        print('D') 
+`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(3, "Control+a")], "cut", ["Home", "ArrowDown", "ArrowDown"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class Dest  :
+    dest_member  = 0 
+    src_member_1  = 0 
+    def src (self, ) :
+        print('A') 
+        if x>0  :
+            print('B') 
+        print('C') 
+    def src2 (self, ) :
+        print('D') 
+    def dest (self, ) :
+        print('0') 
+class Src  :
+    pass
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+
+    test("Test Ctrl-A four times in a class function selects whole class", async ({page}) => {
+        // Moves Src class above dest: 
+        await testBeforeAfterPaste(page,`class Dest:
+   dest_member = 0
+   def dest(self):
+       print('0')
+class Src: 
+    src_member_1 = 0 
+    def src(self):
+        print('A')
+        if x > 0:
+            print('B')
+        print('C')
+    def src2():
+        print('D')
+`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(4, "Control+a")], "cut", ["Home"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class Src  :
+    src_member_1  = 0 
+    def src (self, ) :
+        print('A') 
+        if x>0  :
+            print('B') 
+        print('C') 
+    def src2 (self, ) :
+        print('D') 
+class Dest  :
+    dest_member  = 0 
+    def dest (self, ) :
+        print('0') 
+#(=> Section:Main
+#(=> Section:End
+`);
+    });
+
+    test("Test Ctrl-A five times in a class function selects all definitions", async ({page}) => {
+        // Basically does nothing because everything ends where it began: 
+        await testBeforeAfterPaste(page,`class Dest:
+   dest_member = 0
+   def dest(self):
+       print('0')
+class Src: 
+    src_member_1 = 0
+    def src(self):
+        print('A')
+        if x > 0:
+            print('B')
+        print('C')
+    def src2():
+        print('D')
+`, /* We get below print('B'): */ ["End", ...rep(8, "ArrowUp"), ...rep(5, "Control+a")], "cut", ["Home"],`#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class Dest  :
+    dest_member  = 0 
+    def dest (self, ) :
+        print('0') 
+class Src  :
+    src_member_1  = 0 
+    def src (self, ) :
+        print('A') 
+        if x>0  :
+            print('B') 
+        print('C') 
+    def src2 (self, ) :
+        print('D') 
 #(=> Section:Main
 #(=> Section:End
 `);

--- a/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
+++ b/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import en from "@/localisation/en/en_main.json";
 import { CollapsedState } from "../../cypress/support/frame-types";
 import {addFakeClipboard} from "../support/clipboard";
+import { checkFrameXorTextCursor } from "../support/editor";
 
 test.beforeEach(async ({ page, browserName }, testInfo) => {
     if (browserName === "webkit" && process.platform === "win32") {
@@ -297,17 +298,12 @@ test.describe("Saves collapsed state after icon clicks", () => {
             await page.keyboard.press((process.platform == "darwin" ? "Alt" : "Control") + "+ArrowUp");
         }
         // Right arrow should go past header and into frame, then right again should go past
-        // the next frame, so right, shift+right, ctrl-c should copy the first frame inside:
+        // the next frame, so right, and right again should both end up with a frame cursor:
         await page.keyboard.press("ArrowRight");
+        checkFrameXorTextCursor(page, true);
         await page.keyboard.press("ArrowRight");
-        await page.keyboard.press("Shift+ArrowDown");
-        await page.keyboard.press((process.platform == "darwin" ? "Meta" : "Control") + "+c");
+        checkFrameXorTextCursor(page, true);
         
-        const clipboardContent : string = await page.evaluate("navigator.clipboard.readText()");
-        expect(clipboardContent).toEqual(`#(=> FrameState:FoldToHeader
-def __init__ (self, ) :
-    self.x  = 7 
-`);
     });
 
     test("Freezing prevents focusing the text slots with clicking", async ({page}) => {

--- a/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
+++ b/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
@@ -1,9 +1,8 @@
 import {Page, test, expect} from "@playwright/test";
-import {load, save} from "../support/loading-saving";
+import {loadContent, save} from "../support/loading-saving";
 import fs from "fs";
 import en from "@/localisation/en/en_main.json";
 import { CollapsedState } from "../../cypress/support/frame-types";
-import { randomUUID } from "node:crypto";
 import {addFakeClipboard} from "../support/clipboard";
 
 test.beforeEach(async ({ page, browserName }, testInfo) => {
@@ -26,15 +25,6 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
         console.log("Browser log:", msg.text());
     });
 });
-
-
-async function loadContent(page: Page, spyToLoad: string) : Promise<void> {
-    // The recursive option stops it failing if the dir exists:
-    fs.mkdirSync("tests/cypress/downloads/", { recursive: true });
-    const path = `tests/cypress/downloads/toload-${randomUUID()}.spy`;
-    fs.writeFileSync(path, spyToLoad);
-    await load(page, path);
-}
 
 async function saveAndCheck(page: Page, expectedSPY: string) {
     const path = await save(page, false);

--- a/tests/playwright/support/loading-saving.ts
+++ b/tests/playwright/support/loading-saving.ts
@@ -2,6 +2,8 @@ import {strypeElIds} from "./proxy";
 import {Page, expect} from "@playwright/test";
 import en from "../../../src/localisation/en/en_main.json";
 import {readFileSync} from "node:fs";
+import fs from "fs";
+import { randomUUID } from "node:crypto";
 
 
 export async function load(page: Page, filepath: string) : Promise<void> {
@@ -14,6 +16,15 @@ export async function load(page: Page, filepath: string) : Promise<void> {
     await page.setInputFiles("#" + await strypeElIds(page).getImportFileInputId(), filepath);
     await page.waitForTimeout(2000);
 }
+
+export async function loadContent(page: Page, spyToLoad: string) : Promise<void> {
+    // The recursive option stops it failing if the dir exists:
+    fs.mkdirSync("tests/cypress/downloads/", { recursive: true });
+    const path = `tests/cypress/downloads/toload-${randomUUID()}.spy`;
+    fs.writeFileSync(path, spyToLoad);
+    await load(page, path);
+}
+
 
 export async function save(page: Page, firstSave = true) : Promise<string> {
     // Save is located in the menu, so we need to open it first, then find the link and click on it:


### PR DESCRIPTION
This is not quite as big as it looks as a lot of it is a new test file.  Essentially, I needed to adjust the Ctrl-A functionality so that it worked for classes, but it was a bit fiddly because functions can be inside classes so some of the previous logic wasn't quite right (e.g. if you're just below a function, you're not necessarily at top-level now because you could be inside a class).  After a few failed attempts I tweaked the enum and rewrote the code a bit.