### PR TITLE
Fix new SPY format publicly shared projects (Google Drive) not supported

### DIFF
--- a/src/components/OneDriveComponent.vue
+++ b/src/components/OneDriveComponent.vue
@@ -306,9 +306,9 @@ export default Vue.extend({
             return Promise.resolve();
         },
         
-        getPublicSharedProjectContent(sharedFileID: string): Promise<{isSuccess: boolean, encodedURIFileContent: string, errorMsg: string}> {            
+        getPublicSharedProjectContent(sharedFileID: string): Promise<{isSuccess: boolean, projectName: string, decodedURIFileContent: string, errorMsg: string}> {            
             // With OneDrive, it seems we can't generate a permanent raw file link, so we won't get here.
-            return Promise.resolve({isSuccess: false, encodedURIFileContent: "", errorMsg: "Not supported."});
+            return Promise.resolve({isSuccess: false, projectName: "", decodedURIFileContent: "", errorMsg: "Not supported."});
         },
 
         async shareCloudDriveFile(saveFileId: string): Promise<boolean>{

--- a/src/types/cloud-drive-types.ts
+++ b/src/types/cloud-drive-types.ts
@@ -133,7 +133,7 @@ export interface CloudDriveComponent {
     checkIsFileLocked: (existingFileId: string, onSuccess: VoidFunction, onFailure: VoidFunction) => void,
     doSaveFile: (saveFileId: string | undefined, projetLocation: string, fullFileName: string, fileContent: string, isExplictSave: boolean, onSuccess: (savedFileId: string) => void, onFailure: (errRespStatus: number) => void) => void,
     getCloudAPIStatusWhenLoadedOrFailed: () => Promise<CloudDriveAPIState>,
-    getPublicSharedProjectContent: (sharedFileId: string) => Promise<{ isSuccess: boolean, encodedURIFileContent: string, errorMsg: string }>,
+    getPublicSharedProjectContent: (sharedFileId: string) => Promise<{ isSuccess: boolean, projectName: string, decodedURIFileContent: string, errorMsg: string }>,
     getCurrentCloudFileCurrentSharingStatus: (saveFileId: string) => Promise<CloudFileSharingStatus>,
     shareCloudDriveFile: (saveFileId: string) => Promise<boolean>,
     restoreCloudDriveFileSharingStatus: (saveFileId: string) => Promise<void>,


### PR DESCRIPTION
This PR fixes #640 (I had missed out this case for support of the new SPY format files in Google Drive)