### PR TITLE
Fix format string loading and saving

### DIFF
--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -804,9 +804,13 @@ function toSlots(p: ParsedConcreteTree) : SlotsStructure {
     // Handle terminal nodes by just plonking them into a single-field slot:
     if (p.children == null || p.children.length == 0) {
         let val = p.value ?? "";
-        if (val.startsWith("\"") || val.startsWith("'")) {
-            const str : StringSlot = {code: val.slice(1, val.length - 1), quote: val.slice(0, 1)};
-            return {fields: [{code: ""}, str, {code: ""}], operators: [{code: ""}, {code: ""}]};
+        // Strings can be prefixed by combinations of rbf (case insensitive):
+        // The regex doesn't enforce that the quotes match, but the parser will have already
+        // made sure that is the case:
+        const strMatch = /([rbfRBF]*)(["'])(.*)["']/.exec(val);
+        if (strMatch) {
+            const str : StringSlot = {code: strMatch[3], quote: strMatch[2]};
+            return {fields: [{code: strMatch[1]}, str, {code: ""}], operators: [{code: ""}, {code: ""}]};
         }
         else {
             if (val == STRYPE_EXPRESSION_BLANK) {

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -805,11 +805,12 @@ function toSlots(p: ParsedConcreteTree) : SlotsStructure {
     if (p.children == null || p.children.length == 0) {
         let val = p.value ?? "";
         // Strings can be prefixed by combinations of rbf (case insensitive):
-        // The regex doesn't enforce that the quotes match, but the parser will have already
-        // made sure that is the case:
-        const strMatch = /([rbfRBF]*)(["'])(.*)["']/.exec(val);
+        // The regex doesn't enforce that the quotes match,
+        // but the parser will have already made sure that is the case:
+        // ([\s\S] matches any char, including newlines, which might be present if it's triple quoted):
+        const strMatch = /^([rbfRBF]*)(["'])([\s\S]+)$/.exec(val);
         if (strMatch) {
-            const str : StringSlot = {code: strMatch[3], quote: strMatch[2]};
+            const str : StringSlot = {code: strMatch[3].slice(0, strMatch[3].length - strMatch[2].length), quote: strMatch[2]};
             return {fields: [{code: strMatch[1]}, str, {code: ""}], operators: [{code: ""}, {code: ""}]};
         }
         else {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -3,7 +3,7 @@ import {hasEditorCodeErrors, trimmedKeywordOperators} from "@/helpers/editor";
 import {generateFlatSlotBases, retrieveSlotByPredicate} from "@/helpers/storeMethods";
 import i18n from "@/i18n";
 import { useStore } from "@/store/store";
-import {AllFrameTypesIdentifier, AllowedSlotContent, BaseSlot, ContainerTypesIdentifiers, FieldSlot, FlatSlotBase, FrameContainersDefinitions, FrameObject, getLoopFramesTypeIdentifiers, isFieldBaseSlot, isFieldBracketedSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, LabelSlotPositionsAndCode, LabelSlotsPositions, LineAndSlotPositions, MediaSlot, OptionalSlotType, ParserElements, SlotsStructure, SlotType, StringSlot} from "@/types/types";
+import {AllFrameTypesIdentifier, AllowedSlotContent, BaseSlot, ContainerTypesIdentifiers, FieldSlot, FlatSlotBase, FrameContainersDefinitions, FrameObject, getLoopFramesTypeIdentifiers, isFieldBaseSlot, isFieldBracketedSlot, isFieldStringSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, LabelSlotPositionsAndCode, LabelSlotsPositions, LineAndSlotPositions, MediaSlot, OptionalSlotType, ParserElements, SlotsStructure, SlotType, StringSlot} from "@/types/types";
 import { ErrorInfo, TPyParser } from "tigerpython-parser";
 import {AppSPYFullPrefix} from "@/main";
 /*IFTRUE_isPython */
@@ -129,10 +129,15 @@ function transformSlotLevel(slots: SlotsStructure, topLevel?: {frameType: string
         // - a round bracket (method call)
         // - a square bracket (list indexing)
         // OR the left-hand side is blank
+        // OR the left-hand side is [rbfRBF]+ and the right-hand side is a string literal
         if (slots.operators[i].code.trim() === "") {
             const before = slots.fields[i];
             const blankBefore = isFieldBaseSlot(before) && before.code.trim() === "";
-            if (!blankBefore) {
+            const rbfBefore = isFieldBaseSlot(before) && before.code.match(/[rbfRBF]+/);
+            if (rbfBefore && isFieldStringSlot(slots.fields[i+1])) {
+                // This is fine, but still need to scan the rest of the items so continue the loop
+            }
+            else if (!blankBefore) {
                 if (i + 1 < slots.fields.length) {
                     const after = slots.fields[i + 1];
                     if (!(isFieldBaseSlot(after) && after.code == "") && !(isFieldBracketedSlot(after) && (after.openingBracketValue == "(" || after.openingBracketValue == "["))) {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -133,7 +133,7 @@ function transformSlotLevel(slots: SlotsStructure, topLevel?: {frameType: string
         if (slots.operators[i].code.trim() === "") {
             const before = slots.fields[i];
             const blankBefore = isFieldBaseSlot(before) && before.code.trim() === "";
-            const rbfBefore = isFieldBaseSlot(before) && before.code.match(/[rbfRBF]+/);
+            const rbfBefore = isFieldBaseSlot(before) && before.code.match(/^[rbfRBF]+$/);
             if (rbfBefore && isFieldStringSlot(slots.fields[i+1])) {
                 // This is fine, but still need to scan the rest of the items so continue the loop
             }

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -285,3 +285,9 @@ describe("Tests loading project descriptions", () => {
         testRoundTripImportAndDownload("tests/cypress/fixtures/project-basic.spy");
     });
 });
+
+describe("Tests loading/saving format strings", () => {
+    it("Loads/saves format strings", () => {
+        testRoundTripImportAndDownload("tests/cypress/fixtures/format-strings.spy");
+    });
+});

--- a/tests/cypress/fixtures/format-strings.spy
+++ b/tests/cypress/fixtures/format-strings.spy
@@ -1,0 +1,11 @@
+#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+#(=> Section:Main
+print(f"Hi there") 
+x  = 7+3 
+print(f"X is: {x} (double quotes)") 
+print(f'X is: {x} (single quotes)') 
+print(1+F"Invalid as missing closing: {x") 
+y  = B'1'-r'2'+rF'3'+print(f"''")-br"1" 
+#(=> Section:End

--- a/tests/playwright/e2e/console-execution.spec.ts
+++ b/tests/playwright/e2e/console-execution.spec.ts
@@ -1,0 +1,70 @@
+import {Page, test, expect} from "@playwright/test";
+import {doPagePaste} from "../support/editor";
+
+let browser = "";
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    browser = browserName;
+    if (browserName === "webkit" && process.platform === "win32") {
+        // On Windows+Webkit it just can't seem to load the page for some reason:
+        testInfo.skip(true, "Skipping on Windows + WebKit due to unknown problems");
+    }
+
+    // These tests can take longer than the default 30 seconds:
+    testInfo.setTimeout(90000); // 90 seconds
+    
+    await page.goto("./", {waitUntil: "load"});
+    await page.waitForSelector("body");
+    await page.evaluate(() => {
+        (window as any).Playwright = true;
+    });
+    // Make browser's console.log output visible in our logs (useful for debugging):
+    page.on("console", (msg) => {
+        console.log("Browser log:", msg.text());
+    });
+});
+
+async function enterCode(page: Page, codeSections : string[]) : Promise<void> {
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("Backspace");
+    await page.keyboard.press("Backspace");
+    await page.waitForTimeout(500);
+    await page.keyboard.press("ArrowUp");
+    await page.keyboard.press("ArrowUp");
+    for (const codeSection of codeSections) {
+        await doPagePaste(page, codeSection);
+        await page.waitForTimeout(1000);
+        await page.keyboard.press("ArrowDown");
+    }
+}
+
+async function checkConsoleContent(page: Page, expectedContent : string) {
+    const actual = await page.locator("#peaConsole").inputValue();
+    expect(actual).toEqual(expectedContent);
+}
+
+async function runToFinish(page: Page) {
+    // It should not be running:
+    const button = page.locator("#runButton");
+    await expect(button).toHaveText("Run");
+    // Click it:
+    await page.click("#runButton");
+    // Then it should not be running again, because it has finished:
+    await expect(button).toHaveText("Run");
+}
+
+test.describe("Check console after execution", () => {
+    test("Check default code works", async ({page}) => {
+        await page.click("#runButton");
+        await runToFinish(page);
+        await checkConsoleContent(page, "Hello from Python!\n");
+    });
+
+    test("Check two prints work", async ({page}) => {
+        await enterCode(page, ["", "", "print('Hello')\nprint('World')\n"]);
+        await page.click("#runButton");
+        await runToFinish(page);
+        await checkConsoleContent(page, "Hello\nWorld\n");
+    });
+});

--- a/tests/playwright/e2e/console-execution.spec.ts
+++ b/tests/playwright/e2e/console-execution.spec.ts
@@ -1,10 +1,7 @@
 import {Page, test, expect} from "@playwright/test";
 import {doPagePaste} from "../support/editor";
 
-let browser = "";
-
 test.beforeEach(async ({ page, browserName }, testInfo) => {
-    browser = browserName;
     if (browserName === "webkit" && process.platform === "win32") {
         // On Windows+Webkit it just can't seem to load the page for some reason:
         testInfo.skip(true, "Skipping on Windows + WebKit due to unknown problems");

--- a/tests/playwright/e2e/console-execution.spec.ts
+++ b/tests/playwright/e2e/console-execution.spec.ts
@@ -67,4 +67,19 @@ test.describe("Check console after execution", () => {
         await runToFinish(page);
         await checkConsoleContent(page, "Hello\nWorld\n");
     });
+
+    test("Check format string works", async ({page}) => {
+        await enterCode(page, ["", "", "x=1\ny=2\nprint(f'X is {x}')\nprint(f'Y is {y}')\nprint(f\"Total is {x+y}\")"]);
+        await page.click("#runButton");
+        await runToFinish(page);
+        await checkConsoleContent(page, "X is 1\nY is 2\nTotal is 3\n");
+    });
+
+    test("Check raw string works", async ({page}) => {
+        // In raw strings with r prefix, newlines should not be recognised as escapes:
+        await enterCode(page, ["", "", "print('Line 1\\nLine 2')\nprint(r\"Line 3.0\\nLine 3.1\")"]);
+        await page.click("#runButton");
+        await runToFinish(page);
+        await checkConsoleContent(page, "Line 1\nLine 2\nLine 3.0\\nLine 3.1\n");
+    });
 });

--- a/tests/playwright/e2e/load-save-random.spec.ts
+++ b/tests/playwright/e2e/load-save-random.spec.ts
@@ -1079,4 +1079,11 @@ test.describe("Enters, saves and loads specific frames", () => {
             {frameType: "library", slotContent: ["(#‘+’_$\\\\) not in "]},
         ], [], []]);
     });
+
+    test("Format strings", async ({page}) => {
+        await testSpecific(page, [[], [], [
+            {frameType: "if", slotContent: ["f‘Hello’"], body: [], joint: []},
+            {frameType: "funccall", slotContent: ["print(f‘{x}’)"]},
+        ]]);
+    });
 });


### PR DESCRIPTION
We weren't properly supporting `f"Result is {x}"` format strings.  Strype was viewing them as invalid (because it sees two operands, `f` and the string, with no operator inbetween) and when it generated Python files was saving them as having invalid operators.  Even if they were saved properly, we weren't loading them properly because we didn't account for the prefixes at the front when detecting strings.  This PR fixes both those issues and adds some tests for them.