### PR TITLE
Prevent folding frames which contain syntax errors 

### DIFF
--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -553,6 +553,7 @@ export default Vue.extend({
             }
             // For freezing, we don't show it for bulk operations:
             let someFrozenShowing = false;
+            const errorsInFrameOrChild = frameOrChildHasErrors(this.frameId);
             // We take it out if the frame doesn't allow it or it's already in that state:
             removeIf(this.frameContextMenuItems, (x) => {
                 if (x.actionName === FrameContextMenuActionName.freeze) {
@@ -563,7 +564,7 @@ export default Vue.extend({
                     someFrozenShowing = someFrozenShowing || !remove;
                     
                     // Check if there are precompile errors on any of our slots anywhere in the frame:
-                    if (frameOrChildHasErrors(this.frameId)) {
+                    if (errorsInFrameOrChild) {
                         x.name = this.$i18n.t("contextMenu.cannotFreezeErrors") as string;
                         x.disabled = true;
                     }
@@ -574,6 +575,13 @@ export default Vue.extend({
                     const remove = this.frozenState as FrozenState === FrozenState.UNFROZEN || !this.frameType.allowedFrozenStates.includes(FrozenState.UNFROZEN);
                     someFrozenShowing = someFrozenShowing || !remove;
                     return remove;
+                }
+                else if (x.actionName === FrameContextMenuActionName.collapseToHeader || x.actionName === FrameContextMenuActionName.collapseToDocumentation) {
+                    if (errorsInFrameOrChild) {
+                        x.name = this.$i18n.t("contextMenu.cannotCollapseErrors") as string;
+                        x.disabled = true;
+                    }
+                    return false;
                 }
                 else {
                     return false; // Leave everything else untouched

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -524,6 +524,10 @@ export function getFrameComponent(frameId: number, innerLookDetails?: {framePare
                 // That frame isn't the one we want, but maybe it contains the one we want so we look into it.
                 // We first look into the children, the joint frames (which may have children as well)
                 const frameBodyComponent = (childFrameComponent.$refs[getFrameBodyRef()] as InstanceType<typeof FrameBody>); // There is 1 body in a frame, no v-for is used, we have 1 element
+                if (!frameBodyComponent){
+                    // This can happen when a frame is folded; have to return undefined:
+                    return undefined;
+                }
                 result = getFrameComponent(frameId, {frameParentComponent: frameBodyComponent, listOfFrameIdToCheck: useStore().frameObjects[childFrameId].childrenIds});
 
                 if(!result){
@@ -542,7 +546,8 @@ export function getFrameComponent(frameId: number, innerLookDetails?: {framePare
         // When we look for the frame from the whole editor, we need to find in wich frame container that frame lives.
         // We don't need to parse recursively for getting the refs/frames as we can just find out what frame container it is in first directly...
         // And if we are already in the container (body), then we just return this component 
-        const frameContainerId = (frameId < 0) ? frameId : getFrameContainer(frameId); 
+        const frameContainerId = (frameId < 0) ? frameId : getFrameContainer(frameId);
+        console.log("fCId: " + frameContainerId + " UID: " + getFrameContainerUID(frameContainerId));
         const containerElementRefs = vm.$root.$children[0].$refs[getFrameContainerUID(frameContainerId)] as (Vue|Element)[]; // Retrieve in App
         if(containerElementRefs) {
             result = (frameId < 0) 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -547,7 +547,6 @@ export function getFrameComponent(frameId: number, innerLookDetails?: {framePare
         // We don't need to parse recursively for getting the refs/frames as we can just find out what frame container it is in first directly...
         // And if we are already in the container (body), then we just return this component 
         const frameContainerId = (frameId < 0) ? frameId : getFrameContainer(frameId);
-        console.log("fCId: " + frameContainerId + " UID: " + getFrameContainerUID(frameContainerId));
         const containerElementRefs = vm.$root.$children[0].$refs[getFrameContainerUID(frameContainerId)] as (Vue|Element)[]; // Retrieve in App
         if(containerElementRefs) {
             result = (frameId < 0) 

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -926,7 +926,8 @@ export function frameOrChildHasErrors(frameId : number) : boolean {
 function changeWherePossible(frames: FrameObject[], target: CollapsedState) : Record<number, CollapsedState> {
     const r : Record<number, CollapsedState> = {};
     frames.forEach((f) => {
-        if (f.frameType.allowedCollapsedStates.includes(target)) {
+        if (f.frameType.allowedCollapsedStates.includes(target) &&
+            (target == CollapsedState.FULLY_VISIBLE || !frameOrChildHasErrors(f.id))) {
             r[f.id] = target;
         }
         else {
@@ -965,9 +966,11 @@ export function calculateNextCollapseState(frameList: FrameObject[], parentIsFro
     const currentAndPossibleStates = new Map<number, {current: CollapsedState, possible: CollapsedState[]}>();
     for (const frame of frameList) {
         const possible : CollapsedState[] = [];
+        const hasError = frameOrChildHasErrors(frame.id);
         for (const candidate of allStates) {
             const allowed = 
                 frame.frameType.allowedCollapsedStates.includes(candidate) &&
+                (candidate == CollapsedState.FULLY_VISIBLE || !hasError) &&
                 !(candidate == CollapsedState.FULLY_VISIBLE && (parentIsFrozen || (frame.frameType.type == AllFrameTypesIdentifier.funcdef && frame.frozenState == FrozenState.FROZEN)));
             if (allowed) {
                 possible.push(candidate);

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -709,8 +709,9 @@ export const getAboveFrameCaretPosition = function (frameId: number): Navigation
     // if we deal with a block frame which is NOT disabled*, we look for the caret position before that block frame "body" position (which is the first position for that block frames)
     // if we deal with a statement frame or a disabled block frame*, we look for the caret position before the statement frame "below" position (which is the first position for that statement frame)
     // (*) that is because a disabled block frame is seen as a "unit", no caret position exist within that disabled block frame
+    const frame = useStore().frameObjects[frameId];
     const referenceFramePosIndex = availablePositions.findIndex((navPos) => navPos.frameId == frameId
-        && navPos.caretPosition == ((useStore().frameObjects[frameId].frameType.allowChildren && !useStore().frameObjects[frameId].isDisabled) ? CaretPosition.body : CaretPosition.below));
+        && navPos.caretPosition == ((frame.frameType.allowChildren && !frame.isDisabled && (frame.collapsedState ?? CollapsedState.FULLY_VISIBLE) == CollapsedState.FULLY_VISIBLE) ? CaretPosition.body : CaretPosition.below));
     
     // step 3 --> get the position before that (a frame is at least contained in a frame container, so position index can't be 0)
     const prevCaretPos = availablePositions[referenceFramePosIndex - 1];

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -187,6 +187,7 @@
     "collapseHeader": "Collapsed View",
     "collapseDocumentation": "Interface View",
     "collapseFull": "Expanded View",
+    "cannotCollapseErrors": "Cannot collapse with errors",
     "freeze": "Freeze",
     "unfreeze": "Unfreeze", 
     "cannotFreezeErrors": "Cannot freeze with errors"

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -189,6 +189,7 @@
     "collapseHeader": "Vue Réduite",
     "collapseDocumentation": "Vue Interface",
     "collapseFull": "Vue Dévelopée",
+    "cannotCollapseErrors": "Réduction impossible avec des erreurs",
     "freeze": "Verrouiller",
     "unfreeze": "Déverrouiller", 
     "cannotFreezeErrors": "Verrouillage impossible avec des erreurs"      

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -297,15 +297,18 @@ describe("Tests loading project descriptions", () => {
 });
 
 describe("Tests loading/saving classes", () => {
-    it("Loads/saves classes", () => {
+    it("Loads/saves classes without images", () => {
         testRoundTripImportAndDownload("tests/cypress/fixtures/oop-crab-no-images.spy");
     });
-    it("Loads/saves classes", () => {
+    it("Loads/saves classes with images", () => {
         if (Cypress.env("mode") == "microbit") {
             // No image literals in microbit mode:
             return;
         }
         testRoundTripImportAndDownload("tests/cypress/fixtures/oop-crab.spy");
+    });
+    it("Loads/saves classes with format strings", () => {
+        testRoundTripImportAndDownload("tests/cypress/fixtures/students.spy");
     });
 });
 

--- a/tests/cypress/fixtures/students.spy
+++ b/tests/cypress/fixtures/students.spy
@@ -1,0 +1,52 @@
+#(=> Strype:1:std
+'''A simple OOP program: 
+Create a class list (list of students)'''
+#(=> Section:Imports
+#(=> Section:Definitions
+class Student  :
+    '''A student object'''
+    #(=> FrameState:FoldToDocumentation
+    def __init__ (self,name,ID="00000" ) :
+        '''Create a student with a given name and default ID'''
+        self.name  = name 
+        self.ID  = ID 
+    #(=> FrameState:FoldToDocumentation
+    def set_ID (self,ID ) :
+        '''Set the student\'s ID number'''
+        self.ID  = ID 
+    #(=> FrameState:FoldToDocumentation
+    def print (self, ) :
+        '''Print the student info to the console'''
+        print(f"Student: {self.name} ({self.ID})") 
+    #(=> FrameState:FoldToDocumentation
+    def __repr__ (self, ) :
+        '''Return a sting representation of this student'''
+        return f"Student: {self.name} ({self.ID})" 
+class LabClass  :
+    '''A class for class lists'''
+    #(=> FrameState:FoldToDocumentation
+    def __init__ (self,max_size ) :
+        '''Create a new, empty class with a maximum capacity'''
+        self.max_size  = max_size 
+        self.students  = [] 
+    #(=> FrameState:FoldToDocumentation
+    def add_student (self,student ) :
+        '''Add a student to this class'''
+        self.students.append(student) 
+    #(=> FrameState:FoldToDocumentation
+    def show_all (self, ) :
+        '''Print out a list of all students in this class'''
+        for student  in self.students  :
+            print(student) 
+#(=> Section:Main
+s1  = Student("Michael","88887") 
+s2  = Student("Neil","88889") 
+s3  = Student("Pierre","12222") 
+
+my_class  = LabClass(12) 
+my_class.add_student(s1) 
+my_class.add_student(s2) 
+my_class.add_student(s3) 
+
+my_class.show_all() 
+#(=> Section:End

--- a/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
+++ b/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
@@ -379,7 +379,7 @@ Alpha(None)
 `;
 
 test.describe("Frozen state deals with errors", () => {
-    test("Cannot freeze if there is a syntax error", async ({page}) => {
+    test("Cannot freeze if there is a syntax error #1", async ({page}) => {
         await loadContent(page, inputWithBlank);
         //await page.getByText("Run").click();
         // Wait a moment for errors to be checked:
@@ -391,7 +391,7 @@ test.describe("Frozen state deals with errors", () => {
         // We should then not be frozen, so should be unmodified state:
         await saveAndCheck(page, inputWithBlank);
     });
-    test("Can freeze if there is a runtime error", async ({page}) => {
+    test("Can freeze if there is a runtime error #1", async ({page}) => {
         await loadContent(page, inputWhichWillRuntimeError);
         // Run to provoke the error, and check it is there:
         await page.getByText("Run").click();
@@ -403,7 +403,7 @@ test.describe("Frozen state deals with errors", () => {
         // We should then be frozen, despite there being an error because it is a runtime error:
         await saveAndCheck(page, testState({"class": "Frozen", "__init__": "FoldToHeader"}, inputWhichWillRuntimeError));
     });
-    test("Frozen frame unfolds if there is a runtime error", async ({page}) => {
+    test("Frozen frame unfolds if there is a runtime error #1", async ({page}) => {
         await loadContent(page, inputWhichWillRuntimeError);
         // Freeze:
         await makeFrozen(page, "class ");
@@ -414,6 +414,30 @@ test.describe("Frozen state deals with errors", () => {
         await page.getByText("Run").click();
         await expect(await page.locator(".fa-exclamation-triangle")).toBeVisible();
         expect(await page.locator("#peaConsole").inputValue()).toContain("object of type 'NoneType' has no len()");
+    });
+    
+    const inputWithTigerPythonError = `#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def foo (name,ID ) :
+    # Mismatched format string:
+    print(f"Student: {name} ({ID)") 
+#(=> Section:Main
+foo("Anon",7) 
+#(=> Section:End
+`;
+
+    test("Cannot freeze if there is a syntax error #2", async ({page}) => {
+        await loadContent(page, inputWithTigerPythonError);
+        //await page.getByText("Run").click();
+        // Wait a moment for errors to be checked:
+        await page.waitForTimeout(2000);
+        // Will Timeout when it doesn't find the menu item:
+        await expect(makeFrozen(page, "def")).rejects.toThrow(/Timeout/i);
+        // Menu remains though so we need to dismiss it:
+        await page.keyboard.press("Escape");
+        // We should then not be frozen, so should be unmodified state:
+        await saveAndCheck(page, inputWithTigerPythonError);
     });
 });
 

--- a/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
+++ b/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
@@ -525,5 +525,6 @@ Alpha(None)
         // We should then only have folded the one without an error:
         await saveAndCheck(page, testState({"hasNoError": "FoldToHeader"}, inputWithNestedTigerPythonError));
     });
-})
+});
+
 

--- a/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
+++ b/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
@@ -35,7 +35,7 @@ async function saveAndCheck(page: Page, expectedSPY: string) {
 
 async function clickFoldFor(page: Page, identifyingText: string) : Promise<void> {
     // Find the span with text "top1"
-    const header = page.locator("span", { hasText: identifyingText });
+    const header = page.locator("span,div", { hasText: identifyingText });
     // Find its frame header ancestor:
     const ancestor = header.locator("xpath=ancestor::*[contains(@class, \"frame-header-div-line\")]");
     const control = ancestor.locator(":scope > .frame-controls-container > .folding-control");
@@ -46,7 +46,7 @@ async function clickFoldFor(page: Page, identifyingText: string) : Promise<void>
 
 async function clickFoldChildrenFor(page: Page, identifyingText: string) : Promise<void> {
     // Find the span with text "top1"
-    const header = page.locator("span", { hasText: identifyingText });
+    const header = page.locator("span,div", { hasText: identifyingText });
     // Find its frame header ancestor:
     const ancestor = header.locator("xpath=ancestor::*[contains(@class, \"frame-header\")]");
     const control = ancestor.locator(":scope > .frame-header-div-line > .fold-children-control");
@@ -68,7 +68,7 @@ async function makeUnfrozen(page: Page, identifyingText: string) : Promise<void>
 }
 
 async function foldViaMenu(page: Page, identifyingText: string, foldTo: CollapsedState) : Promise<void> {
-    const ancestor = page.locator(".frame-header:has(span:has-text('" + identifyingText + "'))");
+    const ancestor = page.locator(".frame-header:has(span:has-text('" + identifyingText + "'), div:has-text('" + identifyingText + "'))");
     await ancestor.click({button: "right"});
     let name : string;
     switch (foldTo) {
@@ -381,7 +381,6 @@ Alpha(None)
 test.describe("Frozen state deals with errors", () => {
     test("Cannot freeze if there is a syntax error #1", async ({page}) => {
         await loadContent(page, inputWithBlank);
-        //await page.getByText("Run").click();
         // Wait a moment for errors to be checked:
         await page.waitForTimeout(2000);
         // Will Timeout when it doesn't find the menu item:
@@ -429,7 +428,6 @@ foo("Anon",7)
 
     test("Cannot freeze if there is a syntax error #2", async ({page}) => {
         await loadContent(page, inputWithTigerPythonError);
-        //await page.getByText("Run").click();
         // Wait a moment for errors to be checked:
         await page.waitForTimeout(2000);
         // Will Timeout when it doesn't find the menu item:
@@ -440,4 +438,92 @@ foo("Anon",7)
         await saveAndCheck(page, inputWithTigerPythonError);
     });
 });
+
+test.describe("Folding state deals with errors", () => {
+    test("Cannot fold if there is a syntax error #1", async ({page}) => {
+        await loadContent(page, inputWithBlank);
+        // Wait a moment for errors to be checked:
+        await page.waitForTimeout(2000);
+        // Will Timeout when it doesn't find the menu item:
+        await expect(foldViaMenu(page, "Alpha", CollapsedState.ONLY_HEADER_VISIBLE)).rejects.toThrow(/Timeout/i);
+        // Menu remains though so we need to dismiss it:
+        await page.keyboard.press("Escape");
+        // Try also via the clickable control:
+        await clickFoldFor(page, "Alpha");
+        
+        // We should then not be folded, so should be unmodified state:
+        await saveAndCheck(page, inputWithBlank);
+    });
+    test("Can fold if there is a runtime error #1", async ({page}) => {
+        await loadContent(page, inputWhichWillRuntimeError);
+        // Run to provoke the error, and check it is there:
+        await page.getByText("Run").click();
+        await expect(await page.locator(".fa-exclamation-triangle")).toBeVisible();
+        expect(await page.locator("#peaConsole").inputValue()).toContain("object of type 'NoneType' has no len()");
+
+        // Then try to fold:
+        await clickFoldFor(page, "class");
+        // We should then be folded, despite there being an error because it is a runtime error:
+        await saveAndCheck(page, testState({"class": "FoldToHeader"}, inputWhichWillRuntimeError));
+    });
+    test("Folded frame unfolds if there is a runtime error #1", async ({page}) => {
+        await loadContent(page, inputWhichWillRuntimeError);
+        // Freeze:
+        await clickFoldFor(page, "class ");
+        // We should then be folded, despite there being an error because it is a runtime error:
+        await saveAndCheck(page, testState({"class": "FoldToHeader"}, inputWhichWillRuntimeError));
+
+        // Run to provoke the error, and check it is there:
+        await page.getByText("Run").click();
+        await expect(await page.locator(".fa-exclamation-triangle")).toBeVisible();
+        expect(await page.locator("#peaConsole").inputValue()).toContain("object of type 'NoneType' has no len()");
+    });
+
+    const inputWithTigerPythonError = `#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def foo (name,ID ) :
+    # Mismatched format string:
+    print(f"Student: {name} ({ID)") 
+#(=> Section:Main
+foo("Anon",7) 
+#(=> Section:End
+`;
+
+    test("Cannot fold if there is a syntax error #2", async ({page}) => {
+        await loadContent(page, inputWithTigerPythonError);
+        // Wait a moment for errors to be checked:
+        await page.waitForTimeout(2000);
+        // Will Timeout when it doesn't find the menu item:
+        await expect(foldViaMenu(page, "def", CollapsedState.HEADER_AND_DOC_VISIBLE)).rejects.toThrow(/Timeout/i);
+        // Menu remains though so we need to dismiss it:
+        await page.keyboard.press("Escape");
+        await clickFoldFor(page, "def");
+        // We should then not be folded, so should be unmodified state:
+        await saveAndCheck(page, inputWithTigerPythonError);
+    });
+    
+    const inputWithNestedTigerPythonError = `#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class Alpha  :
+    def hasNoError (self, ) :
+        return 42 
+    def __init__ (self,y ) :
+        self.x  = f"{len(y)" 
+#(=> Section:Main
+Alpha(None) 
+#(=> Section:End
+`;
+
+    test("Cannot fold if there is a syntax error #3", async ({page}) => {
+        await loadContent(page, inputWithNestedTigerPythonError);
+        // Wait a moment for errors to be checked:
+        await page.waitForTimeout(2000);
+        // Folding all children should not fold it:
+        await clickFoldChildrenFor(page, "class");
+        // We should then only have folded the one without an error:
+        await saveAndCheck(page, testState({"hasNoError": "FoldToHeader"}, inputWithNestedTigerPythonError));
+    });
+})
 


### PR DESCRIPTION
This implements the rule discussed by email, that frames with syntax errors in them should not be able to fold.

(I'm on leave Mon-Wed this week so I'll fix any comments on Thursday.)