### PR TITLE
Save default parameters correctly

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -165,6 +165,7 @@ export interface FrameObject {
 export enum AllowedSlotContent {
     ONLY_NAMES,
     ONLY_NAMES_OR_STAR,
+    ONLY_FORMAL_PARAMS,
     TERMINAL_EXPRESSION,
     FREE_TEXT_DOCUMENTATION,
     LIBRARY_ADDRESS
@@ -709,7 +710,7 @@ export function generateAllFrameDefinitionTypes(regenerateExistingFrames?: boole
         type: DefIdentifiers.funcdef,
         labels: [
             { label: "def ", defaultText: i18n.t("frame.defaultText.name") as string, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_NAMES },
-            { label: "(", defaultText: i18n.t("frame.defaultText.parameters") as string, optionalSlot: OptionalSlotType.HIDDEN_WHEN_UNFOCUSED_AND_BLANK, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_NAMES, appendSelfWhenInClass: true },
+            { label: "(", defaultText: i18n.t("frame.defaultText.parameters") as string, optionalSlot: OptionalSlotType.HIDDEN_WHEN_UNFOCUSED_AND_BLANK, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_FORMAL_PARAMS, appendSelfWhenInClass: true },
             { label: ") :", showSlots: false, defaultText: "" },
             { label: `<img src='${quoteCircleFuncdef}'>`, newLine: true, showSlots: true, acceptAC: false, optionalSlot: OptionalSlotType.PROMPT_WHEN_UNFOCUSED_AND_BLANK, defaultText: i18n.t("frame.defaultText.funcDescription") as string, allowedSlotContent: AllowedSlotContent.FREE_TEXT_DOCUMENTATION},
         ],

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -338,7 +338,7 @@ describe("Tests loading/saving complex expressions", () => {
 });
 
 describe("Tests loading/saving default parameter values", () => {
-    it("Loads/saves expressions with images", () => {
+    it("Loads/saves functions with default parameters", () => {
         testRoundTripImportAndDownload("tests/cypress/fixtures/default-parameter-values.spy");
     });
 });

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -336,3 +336,10 @@ describe("Tests loading/saving complex expressions", () => {
         testRoundTripImportAndDownload("tests/cypress/fixtures/image-expressions.spy");
     });
 });
+
+describe("Tests loading/saving default parameter values", () => {
+    it("Loads/saves expressions with images", () => {
+        testRoundTripImportAndDownload("tests/cypress/fixtures/default-parameter-values.spy");
+    });
+});
+

--- a/tests/cypress/fixtures/default-parameter-values.spy
+++ b/tests/cypress/fixtures/default-parameter-values.spy
@@ -1,0 +1,15 @@
+#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def no_defaults (a,b,c ) :
+    return 0 
+def first_default (a=0,b,c ) :
+    return 1 
+def first_third_default (a=0,b,c="hello" ) :
+    return 2 
+def one_default (a=0.6 ) :
+    return 3 
+def complex_defaults (a=[0.6],b={0.2:0.25,"a":["b"]},c=None ) :
+    return 4 
+#(=> Section:Main
+#(=> Section:End

--- a/tests/cypress/support/frame-types.ts
+++ b/tests/cypress/support/frame-types.ts
@@ -19,6 +19,7 @@ export enum StrypePEALayoutMode {
 export enum AllowedSlotContent {
     ONLY_NAMES,
     ONLY_NAMES_OR_STAR,
+    ONLY_FORMAL_PARAMS,
     TERMINAL_EXPRESSION,
     FREE_TEXT_DOCUMENTATION,
     LIBRARY_ADDRESS,
@@ -407,7 +408,7 @@ export function generateAllFrameDefinitionTypes(): void{
         type: DefIdentifiers.funcdef,
         labels: [
             { label: "def ", defaultText: i18n.t("frame.defaultText.name") as string, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_NAMES },
-            { label: "(", defaultText: i18n.t("frame.defaultText.parameters") as string, optionalSlot: OptionalSlotType.HIDDEN_WHEN_UNFOCUSED_AND_BLANK, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_NAMES },
+            { label: "(", defaultText: i18n.t("frame.defaultText.parameters") as string, optionalSlot: OptionalSlotType.HIDDEN_WHEN_UNFOCUSED_AND_BLANK, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_FORMAL_PARAMS },
             { label: ") :", showSlots: false, defaultText: ""},
             { label: "‘‘‘", newLine: true, showSlots: true, acceptAC: false, optionalSlot: OptionalSlotType.PROMPT_WHEN_UNFOCUSED_AND_BLANK, defaultText: "Describe the function", allowedSlotContent: AllowedSlotContent.FREE_TEXT_DOCUMENTATION},
         ],


### PR DESCRIPTION
This fixes the bug where saving e.g.

```
def foo(a, x =0, y = 0):
    return 0
```

Was saving the params as invalid, because we had notated them as only accepting names and commas.  Now it spots the equals and understands which bits are allowed parameters.