### PR TITLE
Made up from the function description/documentation field go into the params and vice versa

### DIFF
--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -45,7 +45,7 @@ import { useStore } from "@/store/store";
 import { mapStores } from "pinia";
 import FrameHeaderComponent from "@/components/FrameHeader.vue";
 import LabelSlot from "@/components/LabelSlot.vue";
-import { CustomEventTypes, getEditableSelectionText, getFrameLabelSlotLiteralCodeAndFocus, getFrameLabelSlotsStructureUID, getFunctionCallDefaultText, getLabelSlotUID, getMatchingBracket, getSelectionCursorsComparisonValue, getUIQuote, isElementEditableLabelSlotInput, isLabelSlotEditable, openBracketCharacters, parseCodeLiteral, parseLabelSlotUID, setDocumentSelection, STRING_DOUBLEQUOTE_PLACERHOLDER, STRING_SINGLEQUOTE_PLACERHOLDER, stringQuoteCharacters, UIDoubleQuotesCharacters, UISingleQuotesCharacters, getGraphemeLength } from "@/helpers/editor";
+import { CustomEventTypes, getEditableSelectionText, getFrameLabelSlotLiteralCodeAndFocus, getFrameLabelSlotsStructureUID, getFunctionCallDefaultText, getLabelSlotUID, getMatchingBracket, getSelectionCursorsComparisonValue, getUIQuote, isElementEditableLabelSlotInput, isLabelSlotEditable, openBracketCharacters, parseCodeLiteral, parseLabelSlotUID, setDocumentSelection, STRING_DOUBLEQUOTE_PLACERHOLDER, STRING_SINGLEQUOTE_PLACERHOLDER, stringQuoteCharacters, UIDoubleQuotesCharacters, UISingleQuotesCharacters, getGraphemeLength, getFrameHeaderUID } from "@/helpers/editor";
 import { checkCodeErrors, evaluateSlotType, generateFlatSlotBases, getFlatNeighbourFieldSlotInfos, getFrameParentSlotsLength, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, retrieveSlotByPredicate, retrieveSlotFromSlotInfos, getParentId} from "@/helpers/storeMethods";
 import { cloneDeep } from "lodash";
 import { calculateParamPrompt } from "@/autocompletion/acManager";
@@ -748,7 +748,7 @@ export default Vue.extend({
             
             if (!(event.metaKey || event.altKey || event.ctrlKey)) {
                 // Try to move up/down within this item, if we have wrapped:
-                const spans = document.getElementById(this.labelSlotsStructDivId)?.querySelectorAll("span." + scssVars.labelSlotInputClassName + "[contenteditable=\"true\"]") as NodeListOf<HTMLSpanElement>;
+                const spans = document.getElementById(getFrameHeaderUID(this.frameId))?.querySelectorAll("span." + scssVars.labelSlotInputClassName + "[contenteditable=\"true\"]") as NodeListOf<HTMLSpanElement>;
                 if (spans.length > 0) {
                     const dest = handleVerticalCaretMove(Array.from(spans), event.key == "ArrowUp" ? "up" : "down");
                     if (dest) {

--- a/tests/cypress/e2e/autocomplete-modules.cy.ts
+++ b/tests/cypress/e2e/autocomplete-modules.cy.ts
@@ -546,9 +546,9 @@ describe("Underscore handling", () => {
     it("Offers user's own definitions, even if they start with underscores", () => {
         focusEditorAC();
         // Go up to functions section, add a function named "__myFunction" then come down the function definition:
-        cy.get("body").type("{uparrow}f__myFunction{rightarrow}myParam{downarrow}{downarrow}");
+        cy.get("body").type("{uparrow}f__myFunction{rightarrow}myParam{downarrow}{downarrow}{downarrow}");
         // Make a class called _myClass then come back down the "my code" section
-        cy.get("body").type("c__myClass{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}");
+        cy.get("body").type("c__myClass{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}");
         // Make a variable called __myVar:
         cy.get("body").type("=__myVar=42{enter}");
         // Add a function frame and trigger auto-complete:

--- a/tests/cypress/e2e/autocomplete-user-defined.cy.ts
+++ b/tests/cypress/e2e/autocomplete-user-defined.cy.ts
@@ -38,7 +38,7 @@ describe("User-defined items", () => {
     it("Offers auto-complete for user-defined functions with *", () => {
         focusEditorAC();
         // Go up to functions section, add a function named "foo" then come back down and make a function call frame:
-        cy.get("body").type("{uparrow}ffoo(a,*,b){downarrow}{downarrow}{downarrow} ");
+        cy.get("body").type("{uparrow}ffoo(a,*,b){downarrow}{downarrow}{downarrow}{downarrow} ");
         cy.wait(500);
         // Trigger auto-complete:
         cy.get("body").type("{ctrl} ");
@@ -217,7 +217,7 @@ describe("User-defined items", () => {
         focusEditorAC();
         // Make a class frame with "foo" and the params for the init function "bar, vaz",
         // then make a function call frame inside:
-        cy.get("body").type("{uparrow}cfoo{downarrow}{downarrow}{leftarrow}{leftarrow}bar,vaz{rightarrow}{rightarrow}");
+        cy.get("body").type("{uparrow}cfoo{downarrow}{downarrow}{downarrow}{leftarrow}{leftarrow}bar,vaz{rightarrow}{rightarrow}");
         // Trigger auto-completion:
         cy.get("body").type("{ctrl} ");
         withAC((acIDSel) => {
@@ -246,7 +246,7 @@ describe("User-defined items", () => {
         focusEditorAC();
         // Make a class frame with "foo" and the params for the init function "bar",
         // then add function definition "myF" frame with parameters "vaz, param2" and go inside:
-        cy.get("body").type("{uparrow}cfoo{downarrow}{downarrow}{leftarrow}{leftarrow}bar{rightarrow}{rightarrow}{downarrow}fmyF{rightarrow}vaz,param2{rightarrow}{rightarrow}");
+        cy.get("body").type("{uparrow}cfoo{downarrow}{downarrow}{downarrow}{leftarrow}{leftarrow}bar{rightarrow}{rightarrow}{downarrow}fmyF{rightarrow}vaz,param2{rightarrow}{rightarrow}");
         // Trigger auto-completion:
         cy.get("body").type("{ctrl} ");
         withAC((acIDSel) => {
@@ -294,7 +294,7 @@ describe("User-defined items", () => {
         // Add the right import to get Actor or NeoPixel
         cy.get("body").type(`{uparrow}{uparrow}f${parentImport[0]}{rightarrow}${parentImport[1]}{downarrow}{downarrow}`);
         // Make a class frame with "foo(<parent class>)" and delete the init function, add a function "myF", then go to my code
-        cy.get("body").type(`cfoo(${parentClassName}{downarrow}{del}fmyF{downarrow}{downarrow}{downarrow}{downarrow}`);
+        cy.get("body").type(`cfoo(${parentClassName}{downarrow}{downarrow}{del}fmyF{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}`);
         // Trigger auto-completion on a function call frame:
         cy.get("body").type(" {ctrl} ");
         withAC((acIDSel) => {

--- a/tests/cypress/e2e/basics.cy.ts
+++ b/tests/cypress/e2e/basics.cy.ts
@@ -343,8 +343,8 @@ describe("Classes", () => {
         // Attribute:
         cy.get("body").type("{rightarrow}{downarrow}=myattr=5");
         // Methods:
-        cy.get("body").type("{rightarrow}ffoo{downarrow}r6");
-        cy.get("body").type("{rightarrow}{downarrow}fbar(x,y{downarrow}r7");
+        cy.get("body").type("{rightarrow}ffoo{downarrow}{downArrow}r6");
+        cy.get("body").type("{rightarrow}{downarrow}fbar(x,y{downarrow}{downArrow}r7");
         checkCodeEquals(defaultImports.concat([
             {h: /class\s+Foo\s*:/, b: [
                 {h: /def\s+__init__\s*\((self,?)?\s*\)\s*:/, b: [
@@ -473,7 +473,7 @@ describe("Copying key combination", () => {
         cy.get("body").trigger("keydown", {keycode: 67, key: "c", code: "c"});
         cy.get("body").trigger("keyup", {keycode: 67, key: "c", code: "c"});
         // Empty body messes up test so make a body in constructor:
-        cy.get("body").type("Hello{downArrow}{downArrow}r42");
+        cy.get("body").type("Hello{downArrow}{downArrow}{downArrow}r42");
         checkCodeEquals(defaultImports.concat([{
             h:/class +Hello *:/,
             b:[{h:/def *__init__ *\((self,?)? *\) *:/, b:[/return *42/]}]}]).concat(defaultMyCode));
@@ -481,7 +481,7 @@ describe("Copying key combination", () => {
     it("Does not insert a class frame on Ctrl+C, when C is released first", () => {
         checkCodeEquals(defaultImports.concat(defaultMyCode));
         // Make a function frame and select it:
-        cy.get("body").type("{upArrow}{f}foo{downArrow}r42{downArrow}{downArrow}{shift}{upArrow}");
+        cy.get("body").type("{upArrow}{f}foo{downArrow}{downArrow}r42{downArrow}{downArrow}{downArrow}{shift}{upArrow}");
         cy.get("body").trigger("keydown", {keycode: 17, key: "Control", code: "ControlLeft"});
         cy.get("body").trigger("keydown", {keycode: 67, key: "c", code: "c", ctrlKey: true});
         cy.get("body").trigger("keyup", {keycode: 67, key: "c", code: "c", ctrlKey: true});
@@ -491,7 +491,7 @@ describe("Copying key combination", () => {
     it("Does not insert a class frame on Ctrl+C, when C is released second", () => {
         checkCodeEquals(defaultImports.concat(defaultMyCode));
         // Make a function frame and select it:
-        cy.get("body").type("{upArrow}{f}foo{downArrow}r42{downArrow}{downArrow}{shift}{upArrow}");
+        cy.get("body").type("{upArrow}{f}foo{downArrow}{downArrow}r42{downArrow}{downArrow}{downArrow}{shift}{upArrow}");
         cy.get("body").trigger("keydown", {keycode: 17, key: "Control", code: "ControlLeft"});
         cy.get("body").trigger("keydown", {keycode: 67, key: "c", code: "c", ctrlKey: true});
         cy.get("body").trigger("keyup", {keycode: 17, key: "Control", code: "ControlLeft"}); // Release Ctrl

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -180,7 +180,7 @@ describe("Tests blanks", () => {
         // ___strype_blank = 1 + ___strype_blank * ___strype_blank / () - __strype_blank
         testEntryDisableAndSave("{uparrow}{uparrow}" +
             "ix {rightarrow}f{downarrow}{downarrow}" +
-            "f{downarrow}i{rightarrow} {downarrow}{downarrow}r{rightarrow}{downarrow}{downarrow}" +
+            "f{downarrow}{downarrow}i{rightarrow} {downarrow}{downarrow}r{rightarrow}{downarrow}{downarrow}" +
             "a{rightarrow}={rightarrow}1+*/()-", [], "tests/cypress/fixtures/project-blanks.spy");
     });
     it("Loads and saves with lots of blanks", () => {
@@ -193,7 +193,7 @@ describe("Tests invalid characters", () => {
     it("Outputs a file with invalid chars", () => {
         testEntryDisableAndSave("{uparrow}{uparrow}" +
             "i100{rightarrow}ffoo{rightarrow}£1000{downarrow}i50{downarrow}ifoo（）{downarrow}{downarrow}" +
-            "f#include{rightarrow}100,abc,#35{downarrow}r$50{downarrow}{downarrow}{downarrow}" +
+            "f#include{rightarrow}100,abc,#35{downarrow}{downarrow}r$50{downarrow}{downarrow}{downarrow}" +
             " 100($50, 24.24a)", [], "tests/cypress/fixtures/project-invalid-chars.spy");
     });
     it("Loads and saves a file with invalid chars", () => {

--- a/tests/cypress/support/param-prompt-support.ts
+++ b/tests/cypress/support/param-prompt-support.ts
@@ -143,7 +143,7 @@ export function testRawFuncs(rawFuncs: [string | [string, string] | {class?: str
                     ? `c${(rawFunc[0] as any)?.class}{rightarrow}{rightarrow}`
                     : "";            
                 funcs.push({
-                    keyboardTypingToImport: "{uparrow}" + classTypePreamble + "f" + (rawFunc[0] as any)?.udf + "{downarrow}",
+                    keyboardTypingToImport: "{uparrow}" + classTypePreamble + "f" + (rawFunc[0] as any)?.udf + "{downarrow}{downarrow}",
                     funcName: rawFunc[1],
                     params: params,
                     acSection: (isTestingFunctionInClass) ? "self" : "My functions",


### PR DESCRIPTION
Do you know the tale about the engineer who charged 1000 pounds for hitting a machine with a hammer to get it going again?  1 pound for the hammer tap, 999 for knowing where to tap it... https://quoteinvestigator.com/2017/03/06/tap/ 😀 

We just use all the spans from the whole frame header when deciding where to up/down, rather than just the ones from the current label slot.  This won't matter for most frames -- the way we wrap now, one label slot in a frame is never beneath another, except in class and function frame headers, where it will do what we want.

Fixes #657