### PR TITLE
Fix Safari frame paste

### DIFF
--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -48,13 +48,13 @@ import { cloneDeep } from "lodash";
 import { getAboveFrameCaretPosition, getFrameSectionIdFromFrameId } from "@/helpers/storeMethods";
 import { pasteMixedPython } from "@/helpers/pythonToFrames";
 import scssVars  from "@/assets/style/_export.module.scss";
+import {detectBrowser} from "@/helpers/browser";
 /* IFTRUE_isPython */
 import { getFrameDefType, SlotType, SlotCursorInfos, MediaDataAndDim} from "@/types/types";
 import { setDocumentSelection, getFrameLabelSlotsStructureUID, getLabelSlotUID } from "@/helpers/editor";
 import { preparePasteMediaData } from "@/helpers/media";
 import LabelSlotsStructureComponent from "@/components/LabelSlotsStructure.vue";
 import { getParentOrJointParent } from "@/helpers/storeMethods";
-import {detectBrowser} from "@/helpers/browser";
 /* FITRUE_isPython */
 
 //////////////////////

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -213,6 +213,10 @@ export default Vue.extend({
                 navigator.clipboard.readText().then((text) => {
                     this.pasteIfFocused(event, text);
                 });
+                
+                event.stopPropagation();
+                event.preventDefault();
+                event.stopImmediatePropagation();
             }
         },
 

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -210,7 +210,11 @@ export default Vue.extend({
                     event.preventDefault();
                 }
                 
-                navigator.clipboard.readText().then((text) => {
+                navigator.clipboard.readText().catch((err) => {
+                    // This can happen during Playwright testing:
+                    console.error("Failed to read clipboard during frame paste", err);
+                    return "";
+                }).then((text) => {
                     this.pasteIfFocused(event, text);
                 });
                 

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -198,18 +198,6 @@ export default Vue.extend({
             // Note: Safari also won't paste if the clipboard is empty, which it is when frames are on the clipboard
             // So this solves both issues.
             if (this.isFocusedForPaste && detectBrowser() === "safari" && event.metaKey && event.key.toLowerCase() === "v") {
-                const el = document.activeElement;
-                const safariWouldPaste = el && (
-                    (el as any).isContentEditable ||
-                    el.tagName === "INPUT" ||
-                    el.tagName === "TEXTAREA"
-                );
-
-                if (safariWouldPaste) {
-                    // Block Safari's native paste
-                    event.preventDefault();
-                }
-                
                 navigator.clipboard.readText().catch((err) => {
                     // This can happen during Playwright testing:
                     console.error("Failed to read clipboard during frame paste", err);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3000,7 +3000,10 @@ export const useStore = defineStore("app", {
                 return;
             }
             // We do not use the system's clipboard for frames, so we clear any potential text to avoid interference
-            navigator.clipboard.writeText("");
+            navigator.clipboard.writeText("")
+                .catch((err) => {
+                    console.error("Failed to write frame placeholder to clipboard", err);
+                });
             this.flushCopiedFrames();
             this.doCopySelection();
             this.updateNextAvailableId();


### PR DESCRIPTION
Safari won't paste if it doesn't think the destination element can receive a text paste (e.g. a contenteditable item) and has focus and a text cursor.  So with frame cursors, it's hit and miss as to whether it works.  So we manually handle Cmd-V on Safari to do the paste ourselves.  It seems to make paste more reliable on Safari.