### PR TITLE
Various small improvements

### DIFF
--- a/docs-sphinx/source/_static/custom.css
+++ b/docs-sphinx/source/_static/custom.css
@@ -58,6 +58,7 @@ h2 {
     position: relative;
     padding-bottom: 1rem;
     border-bottom: 1px solid rgba(0,0,0,0.05);
+    margin-bottom: 150px; /* Good to have space anyway, and stops the scrolling indicators overlapping */ 
 }
 
 /* The indicator itself */
@@ -70,6 +71,8 @@ h2 {
     width: 3rem;        /* same as column width */
 
     overflow: visible;  /* allow rotated text to extend outward */
+
+    font-family: 'Trebuchet MS', sans-serif;
 
     display: flex;
     justify-content: center;
@@ -85,7 +88,7 @@ h2 {
 
     white-space: nowrap;     /* prevent wrapping after rotation */
     font-weight: bold;
-    background: rgba(240, 246, 252, 0.9);
+    background: #f2f2f2;
     padding: 0.3rem 0.5rem;
     border: 1px solid rgba(0,0,0,0.1);
     border-radius: 4px;

--- a/docs-sphinx/source/_static/custom.css
+++ b/docs-sphinx/source/_static/custom.css
@@ -47,3 +47,46 @@ dt.sig {
 h2 {
     font-size: 3em;
 }
+
+/* Each module section becomes a two-column grid: narrow left, wide right */
+.module-wrapper {
+    display: grid;
+    grid-template-columns: 1fr 3rem;   /* ← only 3rem reserved for indicator */
+    gap: 1rem;
+    margin-bottom: 2rem;
+    align-items: start;
+    position: relative;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid rgba(0,0,0,0.05);
+}
+
+/* The indicator itself */
+.module-indicator {
+    position: sticky;
+    top: 1rem;
+
+    /* Make it fill the narrow column vertically for sticky behavior */
+    height: 0;          /* avoid affecting layout */
+    width: 3rem;        /* same as column width */
+
+    overflow: visible;  /* allow rotated text to extend outward */
+
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+/* Inner text rotated 90 degrees */
+.module-indicator > * {
+    display: inline-block;
+
+    transform: rotate(90deg) translateX(+40%);
+    transform-origin: center top;
+
+    white-space: nowrap;     /* prevent wrapping after rotation */
+    font-weight: bold;
+    background: rgba(240, 246, 252, 0.9);
+    padding: 0.3rem 0.5rem;
+    border: 1px solid rgba(0,0,0,0.1);
+    border-radius: 4px;
+}

--- a/docs-sphinx/source/conf.py
+++ b/docs-sphinx/source/conf.py
@@ -23,5 +23,8 @@ author = 'K-PET Group, King\'s College London'
 
 templates_path = ['_templates']
 exclude_patterns = []
+# Turn off having package/module names at the start of every identifier, which is quite distracting
+# and potentially confusing for novices:
+add_module_names = False
 
 strype_sphinx_conf_defaults.set_defaults(globals())

--- a/docs-sphinx/source/index.rst
+++ b/docs-sphinx/source/index.rst
@@ -11,18 +11,34 @@ You can see more documentation for Strype on the `main documentation page <https
 strype.graphics module
 ----------------------
 
-.. automodule:: strype.graphics
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. container:: module-wrapper
 
+  .. container:: module-content
+
+    .. automodule:: strype.graphics
+       :members:
+       :undoc-members:
+       :show-inheritance:
+
+  .. container:: module-indicator
+
+    Module strype.graphics
+    
 strype.sound module
 -------------------
 
-.. automodule:: strype.sound
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. container:: module-wrapper
+
+  .. container:: module-content
+
+    .. automodule:: strype.sound
+       :members:
+       :undoc-members:
+       :show-inheritance:
+
+  .. container:: module-indicator
+
+    Module strype.sound
 
 
 .. toctree::

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -358,6 +358,9 @@ export default Vue.extend({
                 }
                 this.appStore.deleteFrames("backspace", true);
             }   
+            
+            // To find all new frames added (including at lower levels), we record all frame ids before the paste:
+            const frameIdsBeforePaste = new Set(Object.keys(this.appStore.frameObjects).map((key) => Number(key)));
 
             if(this.appStore.isSelectionCopied){
                 this.appStore.pasteSelection(
@@ -378,11 +381,19 @@ export default Vue.extend({
                 );
             }
 
+            const frameIdsAfterPaste = Object.keys(this.appStore.frameObjects).map((key) => Number(key));
+            
             if (restoreCaretTo != null && (this.appStore.currentFrame?.id != restoreCaretTo.id || this.appStore.currentFrame?.caretPosition != restoreCaretTo.caretPosition)) {
                 this.appStore.setCurrentFrame(restoreCaretTo);
             }
 
             this.appStore.saveStateChanges(stateBeforeChanges);
+
+            const framesAdded = frameIdsAfterPaste.filter((frameId) => !frameIdsBeforePaste.has(frameId));
+            // Then after nextTick tell all the new frames to update their prompts:
+            Vue.nextTick(() => {
+                this.$root.$emit(CustomEventTypes.updateParamPrompts, framesAdded);
+            });
         },
     
         prepareInsertFrameSubMenu(): void {

--- a/src/components/FrameHeader.vue
+++ b/src/components/FrameHeader.vue
@@ -284,6 +284,7 @@ export default Vue.extend({
     margin-right: 7px;
     margin-top: 0px;
     align-items: center;
+    height: 1.5rem;
 }
 
 .folding-control, .frozen-control {

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -93,6 +93,7 @@ export default Vue.extend({
         this.$nextTick(() => {
             this.updatePrependText();
         });
+        this.$root.$on(CustomEventTypes.updateParamPrompts, this.updateParamPromptsIfInList);
     },
 
     computed:{
@@ -160,6 +161,15 @@ export default Vue.extend({
             // On Firefox there are problems typing into completely blank slots,
             // so we use a zero-width space if there is no code:
             return slot.code ? slot.code : "\u200B";
+        },
+
+        updateParamPromptsIfInList(frameIds: number[]) {
+            if (frameIds.includes(this.frameId)) {
+                // The refactor doesn't actually update the state (we're only updating param prompts)
+                // so this param shouldn't matter but supply valid one just in case:
+                const stateBeforeChanges = cloneDeep(this.appStore.$state);
+                this.checkSlotRefactoring("", stateBeforeChanges, {useFlatMediaDataCode: true, skipCursorSetAndStateSave: true});
+            }
         },
         
         onCompositionEnd(event: CompositionEvent) {
@@ -331,7 +341,7 @@ export default Vue.extend({
             return true;
         },
 
-        checkSlotRefactoring(slotUID: string, stateBeforeChanges: any, options?: {doAfterCursorSet?: VoidFunction, useFlatMediaDataCode?: boolean}) {
+        checkSlotRefactoring(slotUID: string, stateBeforeChanges: any, options?: {skipCursorSetAndStateSave?: boolean, doAfterCursorSet?: VoidFunction, useFlatMediaDataCode?: boolean}) {
             // Slot errors will be check later again. We clear off the notification on the parent (frame header) for slot errors so it can reset the triangle error indicator
             (this.$parent as InstanceType<typeof FrameHeaderComponent>).$data.hasErroneousSlot = false;
             // Comments do not need to be checked, so we do nothing special for them, but just enforce the caret to be placed at the right place and the code value to be updated
@@ -340,9 +350,11 @@ export default Vue.extend({
             if (allowed !== undefined && [AllowedSlotContent.FREE_TEXT_DOCUMENTATION, AllowedSlotContent.LIBRARY_ADDRESS].includes(allowed) && currentFocusSlotCursorInfos) {
                 (this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures.fields[0] as BaseSlot).code = (document.getElementById(getLabelSlotUID(currentFocusSlotCursorInfos.slotInfos))?.textContent??"").replace(/\u200B/g, "");
                 this.$nextTick(() => {
-                    setDocumentSelection(currentFocusSlotCursorInfos, currentFocusSlotCursorInfos);
-                    options?.doAfterCursorSet?.();                    
-                    this.appStore.saveStateChanges(stateBeforeChanges);
+                    if (!options?.skipCursorSetAndStateSave) {
+                        setDocumentSelection(currentFocusSlotCursorInfos, currentFocusSlotCursorInfos);
+                        options?.doAfterCursorSet?.();
+                        this.appStore.saveStateChanges(stateBeforeChanges);
+                    }
                 });
                 return;
             }
@@ -392,7 +404,9 @@ export default Vue.extend({
                                 }
                                 else{
                                     foundPos = true;
-                                    (spanElement as HTMLSpanElement).dispatchEvent(new Event(CustomEventTypes.editableSlotGotCaret));
+                                    if (!options?.skipCursorSetAndStateSave) {
+                                        (spanElement as HTMLSpanElement).dispatchEvent(new Event(CustomEventTypes.editableSlotGotCaret));
+                                    }
                                     const pos = (setInsideNextSlot) ? 0 : focusCursorAbsPos - newUICodeLiteralLength;
                                     const cursorInfos = {slotInfos: parseLabelSlotUID(spanElement.id), cursorPos: pos};
 
@@ -404,7 +418,9 @@ export default Vue.extend({
                                     if(isVarAssignSlotStructure && this.labelIndex == 0 && !((currentFocusSlotCursorInfos?.slotInfos.slotId??",").includes(",")) && this.appStore.frameObjects[this.frameId].frameType.type == AllFrameTypesIdentifier.funccall && uiLiteralCode.match(/(?<!=)=(?!=)/) != null){
                                         // We need to break at the slot preceding the first "=" operator.
                                         const breakAtSlotIndex = parsedCodeRes.slots.operators.findIndex((opSlot) => opSlot.code == "=");
-                                        this.appStore.setSlotTextCursors(undefined, undefined);
+                                        if (!options?.skipCursorSetAndStateSave) {
+                                            this.appStore.setSlotTextCursors(undefined, undefined);
+                                        }
 
                                         setTimeout(() => {
                                             // Remove the focus
@@ -443,20 +459,24 @@ export default Vue.extend({
                                                 cursorPos: cursorInfos.cursorPos,
                                             };                                        
                                             this.$nextTick(() => this.$nextTick(() => {
-                                                setDocumentSelection(newCursorSlotInfos, newCursorSlotInfos);
-                                                this.appStore.setSlotTextCursors(newCursorSlotInfos, newCursorSlotInfos);
-                                                options?.doAfterCursorSet?.();
-                                                // Save changes only when arrived here (for undo/redo)
-                                                this.appStore.saveStateChanges(stateBeforeChanges);
+                                                if (!options?.skipCursorSetAndStateSave) {
+                                                    setDocumentSelection(newCursorSlotInfos, newCursorSlotInfos);
+                                                    this.appStore.setSlotTextCursors(newCursorSlotInfos, newCursorSlotInfos);
+                                                    options?.doAfterCursorSet?.();
+                                                    // Save changes only when arrived here (for undo/redo)
+                                                    this.appStore.saveStateChanges(stateBeforeChanges);
+                                                }
                                             }));
                                         }, 300);                                         
                                     }
                                     else{
-                                        setDocumentSelection(cursorInfos, cursorInfos);
-                                        this.appStore.setSlotTextCursors(cursorInfos, cursorInfos);
-                                        options?.doAfterCursorSet?.();
-                                        // Save changes only when arrived here (for undo/redo)
-                                        this.appStore.saveStateChanges(stateBeforeChanges);
+                                        if (!options?.skipCursorSetAndStateSave) {
+                                            setDocumentSelection(cursorInfos, cursorInfos);
+                                            this.appStore.setSlotTextCursors(cursorInfos, cursorInfos);
+                                            options?.doAfterCursorSet?.();
+                                            // Save changes only when arrived here (for undo/redo)
+                                            this.appStore.saveStateChanges(stateBeforeChanges);
+                                        }
                                     }
                                 }                            
                             }

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -612,11 +612,14 @@ export default Vue.extend({
                 // First we need to check if it's a media item on the clipboard, because that needs
                 // to become a media literal rather than plain text:
                 /* IFTRUE_isPython */
-                preparePasteMediaData(event, (code: string, dataAndDim : MediaDataAndDim) => {
+                if (preparePasteMediaData(event, (code: string, dataAndDim : MediaDataAndDim) => {
                     // The code is the code to load the literal from its base64 string representation:                    
                     document.getElementById(getLabelSlotUID(focusSlotCursorInfos.slotInfos))
                         ?.dispatchEvent(new CustomEvent(CustomEventTypes.editorContentPastedInSlot, {detail: {type: dataAndDim.itemType, content: code, width: dataAndDim.width, height: dataAndDim.height}}));
-                });
+                })) {
+                    // If pasting image, don't also paste text:
+                    return;
+                }
                 /* FITRUE_isPython */
 
                 interface PastedItem {

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -347,15 +347,17 @@ export default Vue.extend({
             // Comments do not need to be checked, so we do nothing special for them, but just enforce the caret to be placed at the right place and the code value to be updated
             const currentFocusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
             const allowed = this.appStore.frameObjects[this.frameId].frameType.labels[this.labelIndex].allowedSlotContent;
-            if (allowed !== undefined && [AllowedSlotContent.FREE_TEXT_DOCUMENTATION, AllowedSlotContent.LIBRARY_ADDRESS].includes(allowed) && currentFocusSlotCursorInfos) {
-                (this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures.fields[0] as BaseSlot).code = (document.getElementById(getLabelSlotUID(currentFocusSlotCursorInfos.slotInfos))?.textContent??"").replace(/\u200B/g, "");
-                this.$nextTick(() => {
-                    if (!options?.skipCursorSetAndStateSave) {
-                        setDocumentSelection(currentFocusSlotCursorInfos, currentFocusSlotCursorInfos);
-                        options?.doAfterCursorSet?.();
-                        this.appStore.saveStateChanges(stateBeforeChanges);
-                    }
-                });
+            if (allowed !== undefined && [AllowedSlotContent.FREE_TEXT_DOCUMENTATION, AllowedSlotContent.LIBRARY_ADDRESS].includes(allowed) && (currentFocusSlotCursorInfos || options?.skipCursorSetAndStateSave)) {
+                if (currentFocusSlotCursorInfos) {
+                    (this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures.fields[0] as BaseSlot).code = (document.getElementById(getLabelSlotUID(currentFocusSlotCursorInfos.slotInfos))?.textContent ?? "").replace(/\u200B/g, "");
+                    this.$nextTick(() => {
+                        if (!options?.skipCursorSetAndStateSave) {
+                            setDocumentSelection(currentFocusSlotCursorInfos, currentFocusSlotCursorInfos);
+                            options?.doAfterCursorSet?.();
+                            this.appStore.saveStateChanges(stateBeforeChanges);
+                        }
+                    });
+                }
                 return;
             }
 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -411,7 +411,8 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
                 // and if we parse the string quotes, we need to set the position value as if the quotes were still here (because they are in the UI)
                 let spacesOffset = 0;
                 const spanElementContentLength = (spanElement.textContent?.replace(/\u200B/g, "")?.length??0);
-                const ignoreAsKW = (spanElement.textContent == "as" && useStore().frameObjects[parseLabelSlotUID(spanElement.id).frameId].frameType.type != AllFrameTypesIdentifier.import);
+                const frameType = useStore().frameObjects[parseLabelSlotUID(spanElement.id).frameId].frameType.type;
+                const ignoreAsKW = (spanElement.textContent == "as" && frameType != AllFrameTypesIdentifier.import && frameType != AllFrameTypesIdentifier.except);
                 if(!ignoreAsKW && !isSlotStringLiteralType(labelSlotCoreInfos.slotType) && (trimmedKeywordOperators.includes(spanElement.textContent??""))){
                     spacesOffset = 2;
                     // Reinsert the spaces in the literal code

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -411,7 +411,8 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
                 // and if we parse the string quotes, we need to set the position value as if the quotes were still here (because they are in the UI)
                 let spacesOffset = 0;
                 const spanElementContentLength = (spanElement.textContent?.replace(/\u200B/g, "")?.length??0);
-                const frameType = useStore().frameObjects[parseLabelSlotUID(spanElement.id).frameId].frameType.type;
+                // Note that sometimes the frameId is unavailable (-100) so the frame object may not be available, hence we need ?. when accessing it:
+                const frameType : string | undefined = useStore().frameObjects[parseLabelSlotUID(spanElement.id).frameId]?.frameType?.type;
                 const ignoreAsKW = (spanElement.textContent == "as" && frameType != AllFrameTypesIdentifier.import && frameType != AllFrameTypesIdentifier.except);
                 if(!ignoreAsKW && !isSlotStringLiteralType(labelSlotCoreInfos.slotType) && (trimmedKeywordOperators.includes(spanElement.textContent??""))){
                     spacesOffset = 2;

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -67,6 +67,7 @@ export enum CustomEventTypes {
     requestedCloudDrivePickerRefresh = "requestedCloudDrivePickerRefresh",
     cutFrameSelection = "cutFrameSelection",
     copyFrameSelection = "copyFrameSelection",
+    updateParamPrompts = "updateParamPrompts",
     /* IFTRUE_isPython */
     pythonExecAreaMounted = "peaMounted",
     pythonExecAreaExpandCollapseChanged = "peaExpandCollapsChanged",

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -406,7 +406,7 @@ export default class Parser {
                 }
                 else {
                     // For varassign frames, the symbolic assignment on the UI should be replaced by the Python "=" symbol
-                    output += ((label.label.length > 0 && statement.frameType.type === AllFrameTypesIdentifier.varassign) ? " = " : label.label);
+                    output += ((label.label.length > 0 && statement.frameType.type === AllFrameTypesIdentifier.varassign) ? " = " : label.label.replaceAll("&nbsp;", " "));
                     if (label.appendSelfWhenInClass && insideAClass) {
                         // In Python it's okay to have a trailing comma on the params, so we don't need to check
                         // whether any actual params follow:

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -711,7 +711,7 @@ export function generateAllFrameDefinitionTypes(regenerateExistingFrames?: boole
         labels: [
             { label: "def ", defaultText: i18n.t("frame.defaultText.name") as string, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_NAMES },
             { label: "(", defaultText: i18n.t("frame.defaultText.parameters") as string, optionalSlot: OptionalSlotType.HIDDEN_WHEN_UNFOCUSED_AND_BLANK, acceptAC: false, allowedSlotContent: AllowedSlotContent.ONLY_FORMAL_PARAMS, appendSelfWhenInClass: true },
-            { label: ") :", showSlots: false, defaultText: "" },
+            { label: ")&nbsp;:", showSlots: false, defaultText: "" },
             { label: `<img src='${quoteCircleFuncdef}'>`, newLine: true, showSlots: true, acceptAC: false, optionalSlot: OptionalSlotType.PROMPT_WHEN_UNFOCUSED_AND_BLANK, defaultText: i18n.t("frame.defaultText.funcDescription") as string, allowedSlotContent: AllowedSlotContent.FREE_TEXT_DOCUMENTATION},
         ],
         allowedCollapsedStates: [CollapsedState.FULLY_VISIBLE, CollapsedState.HEADER_AND_DOC_VISIBLE, CollapsedState.ONLY_HEADER_VISIBLE],

--- a/tests/cypress/support/test-support.ts
+++ b/tests/cypress/support/test-support.ts
@@ -1,6 +1,6 @@
 export function cleanFromHTML(html: string) : string {
     // Get rid of the zero-width spaces which occur in the HTML:
-    return html.replace("\u200B", "");
+    return html.replace("\u200B", "").replaceAll("\u00A0", " ");
 }
 
 export function getDefaultStrypeProjectDocumentationFullLine(mode: string): string {


### PR DESCRIPTION
This fixes various small things, several requested by Michael:
 - Changed the docs generation to remove the package prefix in each name (so set_background, instead of strype.graphics.set_background), and to compensate, added a "sticky" item on the right showing the package.
 - Prevented line break in functions between the bracket and colon, and fixed problems that introduced.  (Now that I write this I wonder if I should have just removed that space instead!?  What do you think?)
 - Made the folding/freezing controls be top-aligned.  Previously, if the function header was too long and wrapped, the folding control was vertically centred against the multiple lines of the function header, which looked odd.
 - If image and text on clipboard, only paste image
 - When we paste Python text at frame cursor, go through and update the parameter prompts.  Since this is calculated in the refactoring check, I actually issue a refactoring check on all slots in all newly added frames.
 - Fix one issue that turned up which is that if you had "try... except Exception as e:" then the refactoring was turning it into "Exceptionase" (Sounded French or Italian when I first saw it!) because it didn't know that as is valid operator in except.  (Previously it was only valid in import).

The PR is not as long as that sounds!  Each one is only a few lines of code change.