### PR TITLE
Several small fixes

### DIFF
--- a/docs-sphinx/source/_static/custom.css
+++ b/docs-sphinx/source/_static/custom.css
@@ -93,3 +93,12 @@ h2 {
     border: 1px solid rgba(0,0,0,0.1);
     border-radius: 4px;
 }
+
+/* Little bit fragile, but add space before all modules after first */
+.sphinxsidebarwrapper > div > ul > li> ul > li:not(:first-child) {
+    padding-top: 3em;
+}
+/* And a bit before first, but less: */
+.sphinxsidebarwrapper > div > ul > li> ul > li:first-child {
+    padding-top: 1em;
+}

--- a/docs-sphinx/source/index.rst
+++ b/docs-sphinx/source/index.rst
@@ -6,9 +6,10 @@
 Strype API documentation
 ========================
 
-You can see more documentation for Strype on the `main documentation page <https://strype.org/doc/>`
+.. Note: the double underscore after the link is necessary syntax:
+You can see more documentation for Strype on the `main documentation page <https://strype.org/doc/>`__
 
-strype.graphics module
+Module strype.graphics
 ----------------------
 
 .. container:: module-wrapper
@@ -24,7 +25,7 @@ strype.graphics module
 
     Module strype.graphics
     
-strype.sound module
+Module strype.sound
 -------------------
 
 .. container:: module-wrapper

--- a/public/public_libraries/strype/graphics.py
+++ b/public/public_libraries/strype/graphics.py
@@ -738,7 +738,7 @@ class Actor:
         # type: (str, float, float, float, str | None) -> None
         """
         Show a speech bubble next to the actor with the given text.  The only required parameter is the
-        text, all others are optional.  \\n can be used to start a new line.
+        text, all others are optional.  \\\\n can be used to start a new line.
         
         If a maximum width is specified, the text will be wrapped to fit the given width.  
         If a maximum height is specified as well, the font size will be reduced if necessary to fit within 

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -147,6 +147,7 @@ export default Vue.extend({
 
     data: function () {
         return {
+            CustomEventTypes, // just for using in template
             scssVars, // just to be able to use in template
             showPasteMenuItem: false,
             insertFrameMenuItems: [] as {name: string, method: VoidFunction, actionName ?: FrameContextMenuActionName}[],
@@ -159,6 +160,7 @@ export default Vue.extend({
     mounted() {
         window.addEventListener("paste", this.pasteIfFocused);
         window.addEventListener("keydown", this.keydownForSafariPaste);
+        document.addEventListener(CustomEventTypes.scrollCaretIntoView, this.putCaretContainerInView);
         // When a frame is added, we need to make sure it will be visible in the view port. This is particularly true
         // when a paste or duplicate action is performed.
         this.putCaretContainerInView();
@@ -167,12 +169,10 @@ export default Vue.extend({
     destroyed() {
         window.removeEventListener("paste", this.pasteIfFocused);
         window.removeEventListener("keydown", this.keydownForSafariPaste);
+        document.removeEventListener(CustomEventTypes.scrollCaretIntoView, this.putCaretContainerInView);
     },
 
     updated() {
-        // Ensure the caret (during navigation) is visible in the page viewport
-        this.putCaretContainerInView();
-        
         // Close the context menu if there is edition or loss of blue caret (for when a frame context menu is present, see Frame.vue)
         if(this.isEditing || this.caretAssignedPosition == CaretPosition.none){
             ((this.$refs.menu as unknown) as VueContextConstructor).close();

--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -446,6 +446,8 @@ export default Vue.extend({
 .#{$strype-classname-caret-container} {
     padding-top: 0px;
     padding-bottom: 0px;
+    scroll-margin-top: 50px;
+    scroll-margin-bottom: 50px;
 }
 
 .static-caret-container{

--- a/src/components/Frame.vue
+++ b/src/components/Frame.vue
@@ -791,10 +791,10 @@ export default Vue.extend({
                     const newFramePos = (isJointFrameLast || nextEnabledJointSiblingFrameId == -1)
                         ? {id: jointRootFrame.id, caretPosition: CaretPosition.below}
                         : {id: jointRootFrame.jointFrameIds[nextEnabledJointSiblingFrameId], caretPosition: CaretPosition.body};
-                    this.appStore.setCurrentFrame(newFramePos);
+                    this.appStore.setCurrentFrame(newFramePos, false);
                 }
                 else{
-                    this.appStore.setCurrentFrame({id: this.frameId, caretPosition: CaretPosition.below});
+                    this.appStore.setCurrentFrame({id: this.frameId, caretPosition: CaretPosition.below}, false);
                 }
             }
             // We add a hover event on the delete menu entries to show cue in the UI on what the entry will act upon

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -824,6 +824,7 @@ export default Vue.extend({
                 else {
                     // Restore the caret visibility
                     Vue.set(this.appStore.frameObjects[this.appStore.currentFrame.id], "caretVisibility", this.appStore.currentFrame.caretPosition);
+                    Vue.nextTick(() => document.dispatchEvent(new CustomEvent(CustomEventTypes.scrollCaretIntoView, {})));
                 }
             }
         },

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -368,7 +368,7 @@ export default Vue.extend({
                 // As we will need to reposition the cursor, we keep a reference to the "absolute" position in this label's slots,
                 // so we find that out while getting through all the slots to get the literal code.
                 let {uiLiteralCode, focusSpanPos: focusCursorAbsPos, hasStringSlots, mediaLiterals} = getFrameLabelSlotLiteralCodeAndFocus(labelDiv, slotUID, {useFlatMediaDataCode: options?.useFlatMediaDataCode});
-                const parsedCodeRes = parseCodeLiteral(uiLiteralCode, {frameType: this.appStore.frameObjects[this.frameId].frameType.type, isInsideString: false, cursorPos: focusCursorAbsPos, skipStringEscape: hasStringSlots, imageLiterals: mediaLiterals});
+                const parsedCodeRes = parseCodeLiteral(uiLiteralCode, {frameType: this.appStore.frameObjects[this.frameId].frameType.type, isInsideString: false, cursorPos: options?.skipCursorSetAndStateSave ? undefined : focusCursorAbsPos, skipStringEscape: hasStringSlots, imageLiterals: mediaLiterals});
                 const majorChange = this.majorChange(this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures, parsedCodeRes.slots);
                 Vue.set(this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex], "slotStructures", parsedCodeRes.slots);
                 // The parser can be return a different size "code" of the slots than the code literal

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1875,7 +1875,7 @@ const getFirstOperatorPos = (codeLiteral: string, blankedStringCodeLiteral: stri
                 });
                 const fieldContent = codeLiteral.substring(lookOffset, firstOperator.pos);
                 if (cursorPos && cursorPos >= lookOffset && cursorPos < firstOperator.pos) {
-                    resStructSlot.fields.push({code: fieldContent.substring(0, cursorPos - lookOffset) + fieldContent.substring(cursorPos - lookOffset).trimEnd()});
+                    resStructSlot.fields.push({code: fieldContent.substring(0, cursorPos - lookOffset) + fieldContent.substring(cursorPos - lookOffset).trimEnd(), focused: true});
                 }
                 else {
                     resStructSlot.fields.push({code: fieldContent.trim()});
@@ -1902,7 +1902,7 @@ const getFirstOperatorPos = (codeLiteral: string, blankedStringCodeLiteral: stri
     closeBracketCharacters.forEach((closingBracket) => {
         code = code.replaceAll(closingBracket, "");
     });
-    resStructSlot.fields.push({code: code});
+    resStructSlot.fields.push({code: code, focused: cursorPos !== undefined && cursorPos >= lookOffset && cursorPos <= codeLiteral.length});
     return {slots: resStructSlot, cursorOffset: cursorOffset};
 };
 

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -51,6 +51,7 @@ export enum CustomEventTypes {
     editableSlotGotCaret= "slotGotCaret",
     editableSlotLostCaret = "slotLostCaret",
     editorContentPastedInSlot = "contentPastedInSlot",
+    scrollCaretIntoView = "scrollCaretIntoView",
     addFunctionToEditorProjectSave = "addToProjectSaveFunction",
     removeFunctionToEditorProjectSave = "rmToProjectSaveFunction",
     requestEditorProjectSaveNow = "requestProjectSaveNow",

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -213,7 +213,7 @@
     "needSaveShareProj":"Save your project in the Cloud before sharing it",
     "lang": "Language: ",
     "homepage": "Strype Homepage", 
-    "apiDocumentation": "Library Documentation...",
+    "apiDocumentation": "Library documentation...",
     "version": "Version",
     "policy": "Privacy policy"
   },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -920,13 +920,16 @@ export const useStore = defineStore("app", {
                 nextCaret.caretPosition
             );
 
+            // Scroll caret into view when navigating with keyboard:
+            Vue.nextTick(() => document.dispatchEvent(new CustomEvent(CustomEventTypes.scrollCaretIntoView, {})));
+
             // Only frame containers (sections) are collapsable, so we don't need to check if a destination frame itself is collapsed,
             // but we do need to check if the target container is - and expand it if needed.
             const containerId = getFrameSectionIdFromFrameId(nextCaret.id);
             this.frameObjects[containerId].collapsedState = CollapsedState.FULLY_VISIBLE;
         },
 
-        setCurrentFrame(newCurrentFrame: CurrentFrame) {
+        setCurrentFrame(newCurrentFrame: CurrentFrame, scrollIntoView = true) {
             Vue.set(
                 this.frameObjects[this.currentFrame.id],
                 "caretVisibility",
@@ -941,6 +944,11 @@ export const useStore = defineStore("app", {
                 "caretVisibility",
                 newCurrentFrame.caretPosition
             );
+
+            // By default, scroll the new caret into view:
+            if (scrollIntoView) {
+                Vue.nextTick(() => document.dispatchEvent(new CustomEvent(CustomEventTypes.scrollCaretIntoView, {})));
+            }
         },
 
         setCurrentInitCodeValue(frameSlotInfos: SlotCoreInfos){
@@ -1586,6 +1594,7 @@ export const useStore = defineStore("app", {
                             "caretVisibility",
                             this.lastCriticalActionPositioning.lastCriticalCaretPosition.caretPosition
                         );
+                        Vue.nextTick(() => document.dispatchEvent(new CustomEvent(CustomEventTypes.scrollCaretIntoView, {})));
                     }
                     if(this.focusSlotCursorInfos && this.anchorSlotCursorInfos){
                         this.setSlotTextCursors(this.focusSlotCursorInfos, this.focusSlotCursorInfos);
@@ -2475,6 +2484,9 @@ export const useStore = defineStore("app", {
                     "caretVisibility",
                     nextPosition.caretPosition
                 );
+
+                // Scroll it into view:
+                Vue.nextTick(() => document.dispatchEvent(new CustomEvent(CustomEventTypes.scrollCaretIntoView, {})));
 
                 this.setSlotTextCursors(undefined, undefined);
        


### PR DESCRIPTION
The fixes are small in that the code is short, but two of them in particular are quite wide-reaching and may need some testing:
 - A fix for a flickering focus issue (see #716) by trying to keep the focused flag set while refactoring slots.  It seems to work from my testing but if we get it wrong it could lead to slots having a different colour until focused/unfocused again.
 - A fix for an issue Michael reported where the caret would be scrolled to when we didn't want to.  One example was right-clicking the top of a very long frame (e.g. a class); we would select and scroll all the way to the bottom of the class to see the frame cursor.  Another was if your frame cursor was in a long list of frames and you used the multi-fold toggle to toggle them all out, you would scroll down to see the frame cursor, and have to scroll back up to toggle again.  The scroll-into-view was happening whenever the frame cursor changed; I've changed it to scroll only on an explicit event which is omitted in the (relatively few) places in the code where we change the frame cursor.