### PR TITLE
Fix up/down in description fields (especially project comments)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -50,6 +50,7 @@
                                     @mousedown="handleWholeEditorMouseDown"
                                 >
                                     <FrameHeader
+                                        :id="getFrameHeaderUID(-10)"
                                         :labels="projectDocLabels"
                                         :frameId="-10"
                                         :frameType="projectDocFrameType"
@@ -120,7 +121,7 @@ import {Splitpanes, Pane, PaneData} from "splitpanes";
 import { useStore, settingsStore } from "@/store/store";
 import { AppEvent, ProjectSaveFunction, BaseSlot, CaretPosition, FrameObject, FrozenState, MessageTypes, ModifierKeyCode, Position, PythonExecRunningState, SaveRequestReason, SlotCursorInfos, SlotsStructure, SlotType, StringSlot, StrypeSyncTarget, StrypePEALayoutMode, defaultEmptyStrypeLayoutDividerSettings, EditImageInDialogFunction, EditSoundInDialogFunction, areSlotCoreInfosEqual, SlotCoreInfos, ProjectDocumentationDefinition, CollapsedState } from "@/types/types";
 import { CloudDriveAPIState, isSyncTargetCloudDrive } from "@/types/cloud-drive-types";
-import { getFrameContainerUID, getCloudDriveHandlerComponentRefId, getMenuLeftPaneUID, getEditorMiddleUID, getCommandsRightPaneContainerId, isElementLabelSlotInput, CustomEventTypes, getFrameUID, parseLabelSlotUID, getLabelSlotUID, getFrameLabelSlotsStructureUID, getSelectionCursorsComparisonValue, setDocumentSelection, getSameLevelAncestorIndex, autoSaveFreqMins, getImportDiffVersionModalDlgId, getAppSimpleMsgDlgId, getFrameContextMenuUID, getActiveContextMenu, actOnTurtleImport, setPythonExecutionAreaTabsContentMaxHeight, setManuallyResizedEditorHeightFlag, setPythonExecAreaLayoutButtonPos, isContextMenuItemSelected, getStrypeCommandComponentRefId, frameContextMenuShortcuts, getCompanionDndCanvasId, addDuplicateActionOnFramesDnD, removeDuplicateActionOnFramesDnD, getFrameComponent, getCaretContainerComponent, sharedStrypeProjectTargetKey, sharedStrypeProjectIdKey, getCaretContainerUID, getEditorID, getLoadProjectLinkId, AutoSaveKeyNames } from "./helpers/editor";
+import {getFrameContainerUID, getCloudDriveHandlerComponentRefId, getMenuLeftPaneUID, getEditorMiddleUID, getCommandsRightPaneContainerId, isElementLabelSlotInput, CustomEventTypes, getFrameUID, parseLabelSlotUID, getLabelSlotUID, getFrameLabelSlotsStructureUID, getSelectionCursorsComparisonValue, setDocumentSelection, getSameLevelAncestorIndex, autoSaveFreqMins, getImportDiffVersionModalDlgId, getAppSimpleMsgDlgId, getFrameContextMenuUID, getActiveContextMenu, actOnTurtleImport, setPythonExecutionAreaTabsContentMaxHeight, setManuallyResizedEditorHeightFlag, setPythonExecAreaLayoutButtonPos, isContextMenuItemSelected, getStrypeCommandComponentRefId, frameContextMenuShortcuts, getCompanionDndCanvasId, addDuplicateActionOnFramesDnD, removeDuplicateActionOnFramesDnD, getFrameComponent, getCaretContainerComponent, sharedStrypeProjectTargetKey, sharedStrypeProjectIdKey, getCaretContainerUID, getEditorID, getLoadProjectLinkId, AutoSaveKeyNames, getFrameHeaderUID} from "./helpers/editor";
 import { AllFrameTypesIdentifier} from "@/types/types";
 /* IFTRUE_isPython */
 import { debounceComputeAddFrameCommandContainerSize, getPEATabContentContainerDivId, getPEAComponentRefId } from "@/helpers/editor";
@@ -817,6 +818,7 @@ export default Vue.extend({
     },
 
     methods: {
+        getFrameHeaderUID,
         setAutoSaveState() {
             // The autosave is only performed on the webstore
             autoSaveTimerId = window.setInterval(() => {

--- a/tests/playwright/e2e/description-fields.spec.ts
+++ b/tests/playwright/e2e/description-fields.spec.ts
@@ -272,4 +272,29 @@ print(myString)
         const expected = multilineExample.replace("seven", "aseven");
         expect(readFileSync(await save(page, false), "utf-8")).toEqual(expected);
     });
+
+    test("Navigates up/down in project documentation slots then edits", async ({page}) => {
+        await loadContent(page, multilineExample);
+        // Cursor all the way to top (but should only be top frame cursor)
+        for (let i = 0; i < 30; i++) {
+            await page.keyboard.press("ArrowUp");
+            await page.waitForTimeout(300);
+        }
+        await page.keyboard.press("ArrowLeft");
+        await page.waitForTimeout(300);
+        await page.keyboard.press("ArrowUp");
+        await page.waitForTimeout(300);
+        await page.keyboard.type("a");
+        await page.waitForTimeout(200);
+        for (let i = 0; i < 5; i++) {
+            await page.keyboard.press("ArrowLeft");
+            await page.waitForTimeout(200);
+        }
+        await page.keyboard.press("ArrowUp");
+        await page.waitForTimeout(200);
+        await page.keyboard.type("b");
+        await page.waitForTimeout(200);
+        const expected = multilineExample.replace("two", "btwo").replace("three", "threae");
+        expect(readFileSync(await save(page, false), "utf-8")).toEqual(expected);
+    });
 });

--- a/tests/playwright/e2e/description-fields.spec.ts
+++ b/tests/playwright/e2e/description-fields.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from "@playwright/test";
 import {checkFrameXorTextCursor, doTextHomeEndKeyPress} from "../support/editor";
 import {readFileSync} from "node:fs";
-import {save, testPlaywrightRoundTripImportAndDownload} from "../support/loading-saving";
+import {loadContent, save, testPlaywrightRoundTripImportAndDownload} from "../support/loading-saving";
 
 const defaultStandardStrypeProjectDocLiteralWithDotSpace = "This is the default Strype starter project. ";
 
@@ -190,5 +190,86 @@ print(myString)
 
     test("Round trip awkward quotes #3", async ({page}, testInfo) => {
         await testPlaywrightRoundTripImportAndDownload(page, "tests/cypress/fixtures/project-documented-quotes-3.spy");
+    });
+});
+
+test.describe("Up/down in description slots", () => {
+    const multilineExample = `
+#(=> Strype:1:std
+'''One
+two
+three
+four'''
+#(=> Section:Imports
+#(=> Section:Definitions
+def foo ( ) :
+    '''Five
+    six
+    seven
+    eight'''
+    return -4 
+#(=> Section:Main
+myString  = "Hello from Strype" 
+print(myString) 
+#(=> Section:End
+`.trimStart();
+    
+    
+    test("Navigates up/down in funcdoc slots then edits #1", async ({page}) => {
+        await loadContent(page, multilineExample);
+        // Cursor all the way to end, then back up to function:
+        for (let i = 0; i < 30; i++) {
+            await page.keyboard.press("ArrowDown");
+            await page.waitForTimeout(300);
+        }
+        await page.keyboard.press("ArrowUp");
+        await page.waitForTimeout(300);
+        await page.keyboard.press("ArrowUp");
+        await page.waitForTimeout(300);
+        await page.keyboard.press("ArrowUp");
+        await page.waitForTimeout(300);
+        await page.keyboard.press(process.platform == "darwin" ? "Alt+ArrowUp" : "Control+ArrowUp");
+        await page.waitForTimeout(300);
+        // Then go into function, type "a" before header, down three times which should take us to before seven, and type "b"
+        await page.keyboard.press("ArrowRight");
+        await page.waitForTimeout(200);
+        await page.keyboard.type("a");
+        await page.waitForTimeout(200);
+        await page.keyboard.press("ArrowDown");
+        await page.waitForTimeout(200);
+        await page.keyboard.press("ArrowDown");
+        await page.waitForTimeout(200);
+        await page.keyboard.press("ArrowDown");
+        await page.waitForTimeout(200);
+        await page.keyboard.type("b");
+        await page.waitForTimeout(200);
+        const expected = multilineExample.replace("foo", "afoo").replace("seven", "bseven");
+        expect(readFileSync(await save(page, false), "utf-8")).toEqual(expected);
+    });
+    test("Navigates up/down in funcdoc slots then edits #2", async ({page}) => {
+        test.setTimeout(90_000);
+        await loadContent(page, multilineExample);
+        // Cursor all the way to end, then back up to function:
+        for (let i = 0; i < 30; i++) {
+            await page.keyboard.press("ArrowDown");
+            await page.waitForTimeout(300);
+        }
+        // Get us beneath function header:
+        for (let i = 0; i < 5; i++) {
+            await page.keyboard.press("ArrowUp");
+            await page.waitForTimeout(300);
+        }
+        // Go left into header, then five times past "Eight":
+        for (let i = 0; i < 1 + 5; i++) {
+            await page.keyboard.press("ArrowLeft");
+            await page.waitForTimeout(300);
+        }
+        // Then up one:
+        await page.keyboard.press("ArrowUp");
+        await page.waitForTimeout(300);
+        await page.keyboard.type("a");
+        await page.waitForTimeout(200);
+        const expected = multilineExample.replace("seven", "aseven");
+        expect(readFileSync(await save(page, false), "utf-8")).toEqual(expected);
     });
 });


### PR DESCRIPTION
Project comments weren't working because their frame header lacked an ID so that was a simple fix.  But it turns out up/down wasn't working right at the start of lines because of the way browsers do bounds for zero-sized selections (like a cursor usually is).  Essentially if you have this:
```
one
two
three
```
which as a string in a <span> is "one\ntwo\nthree" then if you have the cursor position after a \n, like "one\n|two\nthree" then all the browsers will tell you that cursor position is at the end of the first line, not the beginning of the second.  The work-around is to ask for the width of the character "t" at the start of two and then it works.