### PR TITLE
Fix main.ts circular references preventing Vite to do HMR

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -144,7 +144,7 @@ import axios from "axios";
 import scssVars from "@/assets/style/_export.module.scss";
 import {loadDivider} from "@/helpers/load-save";
 import FrameHeader from "@/components/FrameHeader.vue";
-import { projectDocumentationFrameId } from "./main";
+import { projectDocumentationFrameId } from "./helpers/appContext";
 import {inflateRaw} from "pako";
 import { Base64 } from "js-base64";
 

--- a/src/components/CloudDriveHandler.vue
+++ b/src/components/CloudDriveHandler.vue
@@ -33,7 +33,7 @@ import { CloudDriveAPIState, CloudDriveComponent, CloudDriveFile, CloudFileShari
 import GoogleDriveComponent from "@/components/GoogleDriveComponent.vue";
 import OneDriveComponent from "@/components/OneDriveComponent.vue";
 import { generateSPYFileContent } from "@/helpers/load-save";
-import { AppSPYFullPrefix } from "@/main";
+import { AppSPYFullPrefix } from "@/helpers/appContext";
 
 // This enum is used for flaging the action taken when a request to save a file on a Cloud Drive
 // has been done, and a file of the same name already exists on the Drive

--- a/src/components/GoogleDriveComponent.vue
+++ b/src/components/GoogleDriveComponent.vue
@@ -20,7 +20,7 @@ import CloudDriveHandlerComponent from "@/components/CloudDriveHandler.vue";
 import { MessageDefinitions, StrypeSyncTarget } from "@/types/types";
 import GoogleDriveFilePicker from "@/components/GoogleDriveFilePicker.vue";
 import { pythonFileExtension, strypeFileExtension } from "@/helpers/common";
-import { AppSPYFullPrefix } from "@/main";
+import { AppSPYFullPrefix } from "@/helpers/appContext";
 import { getCloudLoginErrorModalDlgId } from "@/helpers/editor";
 
 //////////////////////

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -88,7 +88,7 @@ import scssVars from "@/assets/style/_export.module.scss";
 import MediaPreviewPopup from "@/components/MediaPreviewPopup.vue";
 import {drawSoundOnCanvas} from "@/helpers/media";
 import { isMacOSPlatform } from "@/helpers/common";
-import { projectDocumentationFrameId } from "@/main";
+import { projectDocumentationFrameId } from "@/helpers/appContext";
 
 // Default time to keep in cache: 5 minutes.
 const soundPreviewImages = new Cache<LoadedMedia>({ defaultTtl: 5 * 60 * 1000 });

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -239,7 +239,7 @@ import { cloneDeep } from "lodash";
 import App from "@/App.vue";
 import appPackageJson from "@/../package.json";
 import { getAboveFrameCaretPosition, getFrameSectionIdFromFrameId } from "@/helpers/storeMethods";
-import { getLocaleBuildDate } from "@/main";
+import { getLocaleBuildDate } from "@/helpers/appContext";
 import scssVars from "@/assets/style/_export.module.scss";
 import OpenDemoDlg from "@/components/OpenDemoDlg.vue";
 import { CloudFileSharingStatus, isSyncTargetCloudDrive } from "@/types/cloud-drive-types";

--- a/src/components/OpenDemoDlg.vue
+++ b/src/components/OpenDemoDlg.vue
@@ -58,7 +58,7 @@ import MenuComponent from "@/components/Menu.vue";
 import ModalDlg from "@/components/ModalDlg.vue";
 import {Demo, DemoGroup, getBuiltinDemos, getThirdPartyLibraryDemos} from "@/helpers/demos";
 import Parser from "@/parser/parser";
-import {AppSPYPrefix} from "@/main";
+import {AppSPYPrefix} from "@/helpers/appContext";
 import {escapeRegExp} from "lodash";
 import { BvModalEvent } from "bootstrap-vue";
 import { getMenuLeftPaneUID } from "@/helpers/editor";

--- a/src/helpers/appContext.ts
+++ b/src/helpers/appContext.ts
@@ -1,0 +1,56 @@
+/**
+ * This helper contains all application wide elements we need widely.
+ * The point is to get rid of exported things of main.ts that created circular references.
+ */
+
+import { StrypePlatform } from "@/types/types";
+
+// Version of the application to check code's import compatibility in the editor
+// note: that is not an offical software version of Strype, just a way to help us dealing with compatibility issues.
+// it MUST be kept as an integer matching value
+export const AppVersion = "6";
+// The version used in the new .spy file format.  We may increment this in future
+// if we introduce a breaking change to that file format.
+export const AppSPYSaveVersion = "1";
+export const AppName = "Strype";
+// The prefix to use in comments directly after the "#" to indicate a Strype
+// special directive or metadata:
+export const AppSPYPrefix = "(=>";
+export const AppSPYFullPrefix = "#" + AppSPYPrefix;
+let appPlatform = StrypePlatform.standard;
+// #v-ifdef MODE == VITE_MICROBIT_MODE
+appPlatform = StrypePlatform.microbit;
+// #v-endif
+export const AppPlatform = appPlatform;
+
+// The project defintion slot isn't attached to a "real" frame.
+// We declare the fake frame ID we used for it here.
+export const projectDocumentationFrameId = -10;
+
+let localeBuildDate = "";
+export function getLocaleBuildDate(): string {
+    // This method returns the build date, set in vite.config.js.
+    // To avoid calling the formatter every time, we keep a local
+    // variable with the formatted date value for the web session.
+    if(localeBuildDate.length > 0) {
+        return localeBuildDate;
+    }
+    else{
+        try{
+            const buildDateTicks = new Date(__BUILD_DATE_TICKS__);
+            localeBuildDate = new Date(buildDateTicks).toLocaleDateString(navigator.language);
+            return localeBuildDate;
+        }
+        catch{
+            // Just in case something was wrong in our config file!
+            return "N/A";
+        }
+    }
+}
+
+// This will disappear with Vue 3, only added now for making the current version working
+export let vm = null as any;
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const setVM  = (theVM: any) => {
+    vm = theVM;
+};

--- a/src/helpers/compile.ts
+++ b/src/helpers/compile.ts
@@ -1,6 +1,6 @@
 import Compiler from "@/compiler/compiler";
 import { getAppSimpleMsgDlgId } from "./editor";
-import { vm } from "@/main";
+import { vm } from "@/helpers/appContext";
 import i18n from "@/i18n";
 import { useStore } from "@/store/store"; 
 

--- a/src/helpers/download.ts
+++ b/src/helpers/download.ts
@@ -1,7 +1,7 @@
 import { saveAs } from "file-saver";
 import { compileBlob } from "./compile";
 import { parseCodeAndGetParseElements } from "@/parser/parser";
-import {vm} from "@/main";
+import {vm} from "@/helpers/appContext";
 import { useStore } from "@/store/store";
 import { MessageDefinitions } from "@/types/types";
 import { getAppSimpleMsgDlgId } from "./editor";

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -7,7 +7,7 @@ import {getContentForACPrefix} from "@/autocompletion/acManager";
 import scssVars  from "@/assets/style/_export.module.scss";
 import html2canvas, { Options } from "html2canvas";
 import CaretContainer from "@/components/CaretContainer.vue";
-import { vm } from "@/main";
+import { vm } from "@/helpers/appContext";
 import Vue from "vue";
 import Frame from "@/components/Frame.vue";
 import FrameContainer from "@/components/FrameContainer.vue";

--- a/src/helpers/load-save.ts
+++ b/src/helpers/load-save.ts
@@ -1,4 +1,4 @@
-import { AppName, AppPlatform, AppSPYFullPrefix, AppSPYSaveVersion } from "@/main";
+import { AppName, AppPlatform, AppSPYFullPrefix, AppSPYSaveVersion } from "@/helpers/appContext";
 import { parseCodeAndGetParseElements } from "@/parser/parser";
 import { useStore } from "@/store/store";
 import {StrypeLayoutDividerSettings, StrypePEALayoutMode} from "@/types/types";

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -3,7 +3,7 @@ import {useStore} from "@/store/store";
 import {getCaretContainerComponent, getFrameComponent, operators, trimmedKeywordOperators} from "@/helpers/editor";
 import i18n from "@/i18n";
 import {cloneDeep, escapeRegExp} from "lodash";
-import {AppName, AppSPYFullPrefix, projectDocumentationFrameId} from "@/main";
+import {AppName, AppSPYFullPrefix, projectDocumentationFrameId} from "@/helpers/appContext";
 import {toUnicodeEscapes, stringToCollapsed, stringToFrozen} from "@/parser/parser";
 import FrameContainer from "@/components/FrameContainer.vue";
 

--- a/src/helpers/skulptFileIO.ts
+++ b/src/helpers/skulptFileIO.ts
@@ -4,7 +4,7 @@
  * At the moment, we only support file IO in the cloud (due to restrictions on 
  * the browser's access to the host file system).
  */
-import { vm } from "@/main";
+import { vm } from "@/helpers/appContext";
 import path from "path-browserify";
 import { getCloudDriveHandlerComponentRefId, getMenuLeftPaneUID } from "./editor";
 import CloudDriveHandlerComponent from "@/components/CloudDriveHandler.vue";

--- a/src/helpers/webUSB.ts
+++ b/src/helpers/webUSB.ts
@@ -6,7 +6,7 @@ import { useStore } from "@/store/store";
 import Compiler from "@/compiler/compiler";
 import { parseCodeAndGetParseElements } from "@/parser/parser";
 import { getAppSimpleMsgDlgId } from "./editor";
-import { vm } from "@/main";
+import { vm } from "@/helpers/appContext";
 import i18n from "@/i18n";
 import { cloneDeep } from "lodash";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,56 +7,13 @@ import "bootstrap/dist/css/bootstrap.css";
 import "bootstrap-vue/dist/bootstrap-vue.css";
 import vBlur from "v-blur";
 import AsyncComputed from "vue-async-computed";
-import { StrypePlatform } from "./types/types";
 import scssVars  from "@/assets/style/_export.module.scss";
 import { WINDOW_STRYPE_HTMLIDS_PROPNAME, WINDOW_STRYPE_SCSSVARS_PROPNAME } from "./helpers/sharedIdCssWithTests";
 import {getAppLangSelectId, getEditorID, getEditorMenuUID, getFrameBodyUID, getFrameContainerUID, getFrameHeaderUID, getFrameLabelSlotsStructureUID, getFrameUID, getImportFileInputId, getLabelSlotUID, getLoadFromFSStrypeButtonId, getLoadProjectLinkId, getNewProjectLinkId, getSaveProjectLinkId, getSaveStrypeProjectToFSButtonId, getStrypeSaveProjectNameInputId, getShareProjectLinkId} from "./helpers/editor";
+import { setVM } from "./helpers/appContext";
 // #v-ifdef MODE == VITE_STANDARD_PYTHON_MODE
 import {getPEATabContentContainerDivId} from "./helpers/editor";
 // #v-endif
-
-// Version of the application to check code's import compatibility in the editor
-// note: that is not an offical software version of Strype, just a way to help us dealing with compatibility issues.
-// it MUST be kept as an integer matching value
-export const AppVersion = "6";
-// The version used in the new .spy file format.  We may increment this in future
-// if we introduce a breaking change to that file format.
-export const AppSPYSaveVersion = "1";
-export const AppName = "Strype";
-// The prefix to use in comments directly after the "#" to indicate a Strype
-// special directive or metadata:
-export const AppSPYPrefix = "(=>";
-export const AppSPYFullPrefix = "#" + AppSPYPrefix;
-let appPlatform = StrypePlatform.standard;
-// #v-ifdef MODE == VITE_MICROBIT_MODE
-appPlatform = StrypePlatform.microbit;
-// #v-endif
-export const AppPlatform = appPlatform;
-
-// The project defintion slot isn't attached to a "real" frame.
-// We declare the fake frame ID we used for it here.
-export const projectDocumentationFrameId = -10;
-
-let localeBuildDate = "";
-export function getLocaleBuildDate(): string {
-    // This method returns the build date, set in vite.config.js.
-    // To avoid calling the formatter every time, we keep a local
-    // variable with the formatted date value for the web session.
-    if(localeBuildDate.length > 0) {
-        return localeBuildDate;
-    }
-    else{
-        try{
-            const buildDateTicks = new Date(__BUILD_DATE_TICKS__);
-            localeBuildDate = new Date(buildDateTicks).toLocaleDateString(navigator.language);
-            return localeBuildDate;
-        }
-        catch{
-            // Just in case something was wrong in our config file!
-            return "N/A";
-        }
-    }
-}
 
 // Set the SCSS variables for the tests here
 (window as any)[WINDOW_STRYPE_SCSSVARS_PROPNAME] = scssVars;
@@ -95,9 +52,10 @@ Vue.use(vBlur);
 Vue.use(PiniaVuePlugin);
 const pinia = createPinia();
 
-export const vm = new Vue({
+const vm = new Vue({
     pinia,
     i18n,
     render: (h) => h(App),
 });
+setVM(vm);
 vm.$mount("#app");

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -5,7 +5,7 @@ import i18n from "@/i18n";
 import { useStore } from "@/store/store";
 import {AllFrameTypesIdentifier, AllowedSlotContent, BaseSlot, CollapsedState, ContainerTypesIdentifiers, FieldSlot, FlatSlotBase, FrameContainersDefinitions, FrameObject, FrozenState, getLoopFramesTypeIdentifiers, isFieldBaseSlot, isFieldBracketedSlot, isFieldStringSlot, isSlotBracketType, isSlotQuoteType, isSlotStringLiteralType, LabelSlotPositionsAndCode, LabelSlotsPositions, LineAndSlotPositions, MediaSlot, OptionalSlotType, ParserElements, SlotsStructure, SlotType, StringSlot} from "@/types/types";
 import { ErrorInfo, TPyParser } from "tigerpython-parser";
-import {AppSPYFullPrefix} from "@/main";
+import {AppSPYFullPrefix} from "@/helpers/appContext";
 // #v-ifdef MODE == VITE_STANDARD_PYTHON_MODE
 import { actOnTurtleImport } from "@/helpers/editor";
 // #v-endif

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,7 +3,7 @@ import { FrameObject, CollapsedState, CurrentFrame, CaretPosition, FrozenState, 
 import { getObjectPropertiesDifferences, getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
 import {calculateNextCollapseState, checkCodeErrors, checkStateDataIntegrity, cloneFrameAndChildren, evaluateSlotType, generateFlatSlotBases, getAllChildrenAndJointFramesIds, getAvailableNavigationPositions, getFlatNeighbourFieldSlotInfos, getFrameSectionIdFromFrameId, getParentOrJointParent, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isContainedInFrame, isFramePartOfJointStructure, removeFrameInFrameList, restoreSavedStateFrameTypes, retrieveSlotByPredicate, retrieveSlotFromSlotInfos} from "@/helpers/storeMethods";
-import { AppPlatform, AppVersion, projectDocumentationFrameId, vm } from "@/main";
+import { AppPlatform, AppVersion, projectDocumentationFrameId, vm } from "@/helpers/appContext";
 import initialStates from "@/store/initial-states";
 import { defineStore } from "pinia";
 import { CustomEventTypes, generateAllFrameCommandsDefs, getAddCommandsDefs, getFocusedEditableSlotTextSelectionStartEnd, getLabelSlotUID, isLabelSlotEditable, setDocumentSelection, parseCodeLiteral, undoMaxSteps, getSelectionCursorsComparisonValue, getEditorMiddleUID, getFrameHeaderUID, getImportDiffVersionModalDlgId, checkEditorCodeErrors, countEditorCodeErrors, getCaretUID, getStrypeCommandComponentRefId, getCaretContainerUID, isCaretContainerElement, AutoSaveKeyNames } from "@/helpers/editor";


### PR DESCRIPTION
This is a single commit PR to fix the problem of Hot Module Replacement HMR in Vite.
Because there was _circular references to main.ts_ in some files of our code, HMR didn't work (so the served website couldn't update when a change in the code was made).

The content of the new helper file is mainly meant to stay in the future PR regarding the Vue 3 migration.
The "vm" exported variable **will** be removed later, it's only a temporary fix for the code to work.
