### PR TITLE
Fix service worker

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1051,7 +1051,7 @@ export default defineComponent({
                         showMessage: false,
                         readCompressed: true,
                     }
-                ).then(() => {
+                ).then(async () => {
                     // When a file had been reloaded and it was previously synced with a Cloud Drive, we want to ask the user
                     // about reloading the project from that Cloud Drive again (only if we were not attempting to open a shared project via the URL)
                     if(this.appStore.currentCloudSaveFileId) {
@@ -1079,6 +1079,49 @@ export default defineComponent({
                     else if(this.appStore.syncTarget == StrypeSyncTarget.fs){
                         vueComponentsAPIHandler.menuComponentAPI?.saveTargetChoice(StrypeSyncTarget.none);
                     }
+
+
+                    // If the user does a hard reload (Ctrl/Cmd-Shift-R on most browsers) then according to
+                    // browser security policy, the service worker will not take control of the page because
+                    // it's trying to give a "fresh" version of the page.  But for us that means if the user
+                    // does a hard reload of the page, Pyodide communication won't work when they hit Run!
+                    // The solution is a bit horrible; in this case we need to perform an additional "soft"
+                    // reload of the page to get the service worker to take control again.  To avoid getting
+                    // stuck in a reload loop if there is a constant service worker failure (for some other
+                    // reason?) we use an item in the session storage to not do it repeatedly if we refreshed
+                    // recently:
+                    const RELOAD_KEY = "sw-reload-attempted";
+
+                    await navigator.serviceWorker.ready;
+
+                    // If the service worker hasn't taken control of us, controller will be null (but ready
+                    // just above will still succeed):
+                    if (!navigator.serviceWorker.controller) {
+                        console.error("No service worker controller; considering reloading");
+
+                        const reloadTime = sessionStorage.getItem(RELOAD_KEY);
+                        // Don't reload again if we did this soft-reload in the last 30 seconds:
+                        const reloadRecently = reloadTime && (Date.now() - parseInt(reloadTime)) < 30000;
+
+                        if (reloadRecently) {
+                            console.error("Service worker unavailable even after reload attempt");
+                        }
+                        else {
+                            sessionStorage.setItem(RELOAD_KEY, Date.now().toString());
+                            // Vue/Vite's dev mode intercepts the reload, so we have to circumvent that in dev mode:
+                            if (import.meta.env.DEV) {
+                                window.location.replace(window.location.href);
+                            }
+                            else {
+                                window.location.reload();
+                            }
+                            console.error("Reload did not work"); // this should NOT appear if reload worked
+                            // Block forever to avoid anything else happening — we're about to reload anyway
+                            await new Promise(() => {});
+                        }
+                    }
+                    sessionStorage.removeItem(RELOAD_KEY);
+
                 }, () => {});
             }, () => {});
         },

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -81,7 +81,7 @@ import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
 import { BTab, BTabs } from "bootstrap-vue-next";
 import * as Comlink from "comlink";
 import {handleErrorTrace, setSInputConsole, sInput} from "@/helpers/execPythonCode";
-import {ErrorDetails} from "@/workers/python-execution";
+import {ErrorDetails, serviceWorkerReadyAndInControl} from "@/workers/python-execution";
 import {SpriteHandle, SyncOrAsyncStrypePyodideWorkerRequest} from "@/stryperuntime/worker_bridge_type";
 import {SoundManager} from "@/stryperuntime/sound_manager";
 import {handleAsyncRequests, handleSyncRequests} from "@/stryperuntime/main_bridge_handler";
@@ -653,7 +653,7 @@ export default defineComponent({
                     Comlink.proxy((prompt: string) => {
                         sInput(prompt).then(async (s : string) => {
                             // We send the output back via writeMessage rather than a direct return:
-                            await navigator.serviceWorker.ready;
+                            await serviceWorkerReadyAndInControl();
                             try {
                                 await client.writeMessage(s);
                             }
@@ -673,7 +673,7 @@ export default defineComponent({
                                 console.error(`Internal error: request ${req.request} did not match the response ${resp.request}`);
                             }
                             resp.response.then(async (r: any) => {
-                                await navigator.serviceWorker.ready;
+                                await serviceWorkerReadyAndInControl();
                                 try {
                                     await client.writeMessage({request: resp.request, response: r});
                                 }
@@ -681,7 +681,7 @@ export default defineComponent({
                                     console.error(e);
                                 }
                             }).catch(async (err) => {
-                                await navigator.serviceWorker.ready;
+                                await serviceWorkerReadyAndInControl();
                                 try {
                                     await client.writeMessage({request: resp.request, error: err.toString()});
                                 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,6 @@ import {getPEATabContentContainerDivId} from "./helpers/editor";
 // (If we used the Vite PWA auto-register it would only work in production.)
 if ("serviceWorker" in navigator) {
     window.addEventListener("load", async () => {
-        // Note: service-worker.js is our desired name, the dev-sw.js is the one PWA always uses in dev mode.
         const swUrl = import.meta.env.BASE_URL + "compiled-service-worker.js";
         try {
             const registration = await navigator.serviceWorker.register(swUrl, {type: "module", scope: import.meta.env.BASE_URL});

--- a/src/workers/python-execution.ts
+++ b/src/workers/python-execution.ts
@@ -85,6 +85,20 @@ import {createLazyFetchAssetsFS} from "@/stryperuntime/pyodide-emscripten-assets
 // We only specify updatePort here as we don't want other files using it directly:
 declare const self: PyodideWorkerGlobalScope & { updatePort: MessagePort };
 
+export async function serviceWorkerReadyAndInControl() : Promise<void> {
+    await navigator.serviceWorker.ready;
+
+    // If already controlled, all is fine:
+    if (navigator.serviceWorker.controller) {
+        return;
+    }
+    // Wait until the service worker takes control:
+    await new Promise((resolve) => {
+        navigator.serviceWorker.addEventListener("controllerchange", resolve, { once: true });
+    });
+}
+
+
 async function loadOnly() : Promise<PyodideInterface> {
     const pyodide = await loadPyodideAndPackage({url: `${import.meta.env.BASE_URL}pysrc.zip`, format: "zip"}, loadPyodide);
     

--- a/src/workers/service-worker.ts
+++ b/src/workers/service-worker.ts
@@ -6,6 +6,10 @@ import { serviceWorkerFetchListener } from "sync-message";
 
 declare let self: ServiceWorkerGlobalScope;
 
+self.addEventListener("install", () => {
+    self.skipWaiting(); // activate immediately
+});
+
 self.addEventListener("activate", (event) => {
     // Claim clients immediately so pages are controlled without reload
     event.waitUntil(self.clients.claim());


### PR DESCRIPTION
Sending this as its own PR as actually I had started a new branch to decouple it from the graphics changes.

As we discussed, this hopefully fixes the service worker issue which seemed to be that sometimes the service worker wasn't taking control of the page.  I now think this may be connected to doing a hard refresh, as the browser prevents service worker connection after this by design (see e.g. https://stackoverflow.com/questions/51597231/register-service-worker-after-hard-refresh ).  This should be a relatively rare problem for us in production (not sure many users hard refresh) but it's nice to have a work-around so we trigger a soft refresh if the page loads after a hard refresh.

We will see if this clears up all the issues with the service worker when we test.