### PR TITLE
Various simple menu-related fixes

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -79,7 +79,7 @@
                     </div>
                 </div>
             </ModalDlg>
-            <ModalDlg :dlgId="saveOnLoadModalDlgId" :okCustomTitle="$t('buttonLabel.saveChanges')" :cancelCustomTitle="$t('buttonLabel.discardChanges')">
+            <ModalDlg :dlgId="saveOnLoadModalDlgId" :okCustomTitle="$t('buttonLabel.saveChanges')" :cancelCustomTitle="$t('buttonLabel.discardChanges')" showCloseBtn>
                 <div>
                     <span class="load-project-lost-span">{{ $t("appMessage.editorAskSaveChangedCode") }}</span>
                     <br/>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1578,6 +1578,7 @@ export default defineComponent({
     display: block;
     margin: auto;
     font-size: 14px;
+    background-color: transparent; // this is required for FF (at last from v150) to not apply some custom background
 }
 
 .menu-icon-centered-entry {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1195,24 +1195,27 @@ export default defineComponent({
                             const emitPayload: AppEvent = {requestAttention: true};
                             emitPayload.message = this.$t("appMessage.editorFileUpload");
                             this.$emit(CustomEventTypes.appShowProgressOverlay, emitPayload);
-                            const reader = new FileReader();
-                            reader.addEventListener("load", () => {
-                                // name is not always available so we also check if content starts with a {,
-                                // which it will do for old-style spy files:
-                                if (file.name.endsWith(".py") || !(reader.result as string).trimStart().startsWith("{")) {
-                                    vueComponentsAPIHandler.appComponentAPI?.setStateFromPythonFile(reader.result as string, fileHandles[0].name, file.lastModified, true, fileHandles[0]);
-                                }
-                                else {
-                                    this.appStore.setStateFromJSONStr(
-                                        {
-                                            stateJSONStr: reader.result as string,
-                                        }
-                                    ).then(() => fileHandles[0].getFile().then((file)=> this.onFileLoaded(fileHandles[0].name, file.lastModified, fileHandles[0])), () => {});
-                                }
-                                emitPayload.requestAttention=false;
-                                this.$emit(CustomEventTypes.appShowProgressOverlay, emitPayload);  
-                            });
-                            reader.readAsText(file);
+                            // Make sure we have a delay for the main event loop to let us display the progress bar triggered above
+                            setTimeout(() => {
+                                const reader = new FileReader();
+                                reader.addEventListener("load", () => {
+                                    // name is not always available so we also check if content starts with a {,
+                                    // which it will do for old-style spy files:
+                                    if (file.name.endsWith(".py") || !(reader.result as string).trimStart().startsWith("{")) {
+                                        vueComponentsAPIHandler.appComponentAPI?.setStateFromPythonFile(reader.result as string, fileHandles[0].name, file.lastModified, true, fileHandles[0]);
+                                    }
+                                    else {
+                                        this.appStore.setStateFromJSONStr(
+                                            {
+                                                stateJSONStr: reader.result as string,
+                                            }
+                                        ).then(() => fileHandles[0].getFile().then((file)=> this.onFileLoaded(fileHandles[0].name, file.lastModified, fileHandles[0])), () => {});
+                                    }
+                                    emitPayload.requestAttention=false;
+                                    this.$emit(CustomEventTypes.appShowProgressOverlay, emitPayload);  
+                                });
+                                reader.readAsText(file); 
+                            }, 100);                            
                         });
                     });                        
                 }


### PR DESCRIPTION
This PR fixes 3 menu related issues:
- the progress bar wasn't showing when loading a project from the file system (and when we could use the file browser tool) - the code was in place but not always working due to the UI thread being blocked by the file reading. Fixes #817 
- added a close (hide) button in the "save on load" modal dialog - the code is straightforward because the modal library simply handle this button already for us by simply closing the modal, so no further callback (or tweak of the existing callbacks) are required. Fixes #791 
- the disabled undo and redo images became oddly rendered with latest versions of Firefox. Fixes #832 