### PR TITLE
Handle Google dropouts

### DIFF
--- a/src/components/CloudDriveHandler.vue
+++ b/src/components/CloudDriveHandler.vue
@@ -485,17 +485,18 @@ export default defineComponent({
                         continueSavingProcess();
                     })
                     .catch((responseStatusCode) => {
+                        const errorCode = responseStatusCode.status ?? responseStatusCode;
                         // The following error status codes were relevant for Google Drive. 
                         // We keep them for the general cases, but add a catch up case for other error codes
                         // that may be sent by other Cloud Drives.
                         // Connection issue?
-                        if(responseStatusCode == 401 || responseStatusCode == 403){
+                        if(errorCode){
                             this.proceedFailedConnectionCheckOnSave(cloudTarget);
                             return;
                         }
                         
                         // Folder not found and any other error (400+).
-                        if(responseStatusCode - 400 >= 0){
+                        if(errorCode - 400 >= 0){
                             this.appStore.strypeProjectLocation = undefined;
                             this.appStore.strypeProjectLocationAlias = "";
                             this.appStore.strypeProjectLocationPath = "";

--- a/src/components/CloudDriveHandler.vue
+++ b/src/components/CloudDriveHandler.vue
@@ -485,6 +485,9 @@ export default defineComponent({
                         continueSavingProcess();
                     })
                     .catch((responseStatusCode) => {
+                        // In this generic Cloud Drive handler, we are not sure what the nature of responseStatusCode is: it can be number, a number as string, or
+                        // a proper response object that contains the status property. So we evaluate if the status property exists on responseStatusCode first and 
+                        // if it doesn't exist, we assume responseStatusCode is a number-like variable.
                         const errorCode = responseStatusCode.status ?? responseStatusCode;
                         // The following error status codes were relevant for Google Drive. 
                         // We keep them for the general cases, but add a catch up case for other error codes

--- a/src/components/GoogleDriveComponent.vue
+++ b/src/components/GoogleDriveComponent.vue
@@ -28,6 +28,11 @@ import { AppSPYFullPrefix, eventBus } from "@/helpers/appContext";
 //////////////////////
 //     Component    //
 //////////////////////
+
+// The Google Identity client variable cannot be reactive as calling requestAccessToken on from it
+// would result in a error otherise.
+let gap_client = null as google.accounts.oauth2.TokenClient | null;
+
 export default defineComponent({
     name: "GoogleDriveComponent",
 
@@ -50,10 +55,10 @@ export default defineComponent({
             previousCloudFileSharingStatus: CloudFileSharingStatus.UNKNOWN,
             // Specific to Google Drive:
             gapiLoadedState: CloudDriveAPIState.UNLOADED,
-            client: null as google.accounts.oauth2.TokenClient | null, // The Google Identity client
             oauthToken : null as string | null,
             devKey: import.meta.env.VITE_GOOGLE_DEVKEY,
             signInCallBack: (cloudTarget: StrypeSyncTarget) => {},
+            GAPI_keepAliveHandle: -1, // The handle for the keep alive GIS session (see onGISLoad())
         };
     },
 
@@ -116,7 +121,7 @@ export default defineComponent({
          * Implements CloudDriveComponent
          **/ 
         signIn(callback: (cloudTarget: StrypeSyncTarget) => void) {
-            this.client?.requestAccessToken();
+            gap_client?.requestAccessToken();
             this.signInCallBack = callback;
         },   
 
@@ -616,7 +621,7 @@ export default defineComponent({
 
         // Load Google Identity services API:
         onGSILoad() {
-            this.client = google.accounts.oauth2.initTokenClient({
+            gap_client = google.accounts.oauth2.initTokenClient({
                 client_id: "802295052786-h65netp8r9961pekqnhnt3oapcb9o8ji.apps.googleusercontent.com",
                 scope: this.googleDriveScope,
                 // Note: this callback is after *sign-in* (happens on button press), NOT on simply loading the client:
@@ -631,6 +636,28 @@ export default defineComponent({
                     if (response && response.error == undefined) {
                         this.oauthToken = response.access_token;
                         vueComponentsAPIHandler.cloudDriveHandlerComponentAPI?.updateSignInStatus(StrypeSyncTarget.gd, true);
+                        // We also set a basic Google Drive related activity "keep alive" mechanism to avoid GIS disconnecting after,
+                        // based on observation, about 20 minutes of inactivty. We do so every 15 mins.
+                        // If the OAuth token is null (that is, we're no longer working with Google Drive) we stop the keep alive mechanism.
+                        if(this.GAPI_keepAliveHandle == -1 ){
+                            this.GAPI_keepAliveHandle = window.setInterval(() => {
+                                if(this.oauthToken != null){
+                                    this.testCloudConnection(() => {}, () => {
+                                        // When the connection test failed, that means most likely the access token expired (or some sort of network issue occurred),
+                                        // so we trigger a token refresh.
+                                        // The callback for requestAccessToken() is defined in initToken(), we need to defined our own callback when signin succeeds as well.
+                                        this.signInCallBack = (_) => {
+                                            // Do nothing: in this situation we only wanted to refresh the token, there is no action to follow.                                            
+                                        };
+                                        gap_client?.requestAccessToken({prompt: ""});
+                                    });
+                                }
+                                else{
+                                    window.clearInterval(this.GAPI_keepAliveHandle);
+                                    this.GAPI_keepAliveHandle = -1;
+                                }
+                            }, 15 * 60 * 1000);
+                        }
                     }
 
                     // In any case, continue the action requested by the user (need to do it in a next tick to make sure the oauthToken is updated in all Vue components)


### PR DESCRIPTION
This PR handles 2 problems that were not handled regarding the use of the Google APIs (fixes #731)

First, we could observe a session dropout pretty soon when no Google related requests were made (~20 minutes). Now having a keep-alive mechanism helps with getting the Google Identity Service session extended longer: until when the access token received from Google expires. When the keep-alive request fails, we try to request a new token.

Second, as mentioned just above, upon authentication to Google, we receive an authentication token that is valid for 1 hour. After that we need to request a new token. This mechanism is therefore intertwined with the keep-alive session.
It seems that Google doesn't provide a way for silently getting this new authentication token: when we need to refresh it, an authentication popup will show (unless the API deems no necessary, but I haven't encounter that).
Note that the popup won't keep showing if the keep-alive interval is reached several time: the Google API knows it's already showing.