### PR TITLE
Fix missing case where SPY's "blank space" placeholder should be used

### DIFF
--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -100,11 +100,12 @@ export const generateFlatSlotBases = (slot: { allowedSlotContent?: AllowedSlotCo
             // we have a simple slot, we check if we can infer the detailed type (i.e. number or boolean literals)
             // otherwise we consider it is just a code slot
             
-            // We pass true if we're beside an operator and the other side is the end or a non-blank operator
+            // We pass true if we're beside an operator and the other side is the end or a non-blank operator,
+            // or if we are in between a bracket structure (operator is empty) and a dot.
             
             const opBefore = slotStructure.operators[index - 1]?.code;
             const adjacentOp =
-                operatorSlot.code !== "" &&
+                (operatorSlot.code !== "" || (operatorSlot.code === "" && opBefore === ".")) &&
                 (index == 0 || opBefore !== "") &&
                 !["not", "~"].includes(operatorSlot.code.trim());
             addFlatSlot({...(fieldSlot as BaseSlot), id: slotId, type: evaluateSlotType(slot, fieldSlot)}, adjacentOp, opBefore, operatorSlot.code);

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -190,12 +190,26 @@ describe("Tests blanks", () => {
         //     return
         // raise ___strype_blank
         // ___strype_blank = 1 + ___strype_blank * ___strype_blank / () - __strype_blank
+        // test.___strype_blank() 
+        // test.a+() 
+        // test.___strype_blank 
+        // test.___strype_blank.___strype_blank() 
+        // test.___strype_blank()+1 
+        // test+()+1 
+        // ___strype_blank.___strype_blank() 
 
         //(function and if are followed by a pause, because it can take a bit longer to add their body/joint section)
         testEntryDisableAndSave(["{uparrow}{uparrow}" +
             "ix {rightarrow}f{downarrow}{downarrow}" +
             "f","{downarrow}{downarrow}i","{rightarrow} {downarrow}{downarrow}r{rightarrow}{downarrow}{downarrow}" +
-            "a{rightarrow}={rightarrow}1+*/()-"], [], "tests/cypress/fixtures/project-blanks.spy");
+            "a{rightarrow}={rightarrow}1+*/()-{downarrow}" +
+            " test.{downarrow}" +
+            " test.a+{downarrow}" +
+            " test.{del}{downarrow}" +
+            " test..{downarrow}" +
+            " test.()+1{downarrow}" +
+            " test+()+1{downarrow}" +
+            " ."], [], "tests/cypress/fixtures/project-blanks.spy");
     });
     it("Loads and saves with lots of blanks", () => {
         testRoundTripImportAndDownload("tests/cypress/fixtures/project-blanks.spy");

--- a/tests/cypress/fixtures/project-blanks.spy
+++ b/tests/cypress/fixtures/project-blanks.spy
@@ -10,4 +10,11 @@ def ___strype_blank ( ) :
 #(=> Section:Main
 raise  
 ___strype_blank  = 1+___strype_blank*___strype_blank/()-___strype_blank 
+test.___strype_blank() 
+test.a+() 
+test.___strype_blank 
+test.___strype_blank.___strype_blank() 
+test.___strype_blank()+1 
+test+()+1 
+___strype_blank.___strype_blank() 
 #(=> Section:End


### PR DESCRIPTION
This is a single fix PR because we can make an intermediate test version.
It fixes an issue with expressions that contains `<dot operator><blank space><bracket structure>` which were not parsed properly (the blank spaces needed to be translated to the SPY placeholder so that Skulpt can parse that expression without an error.
Fixes #812 