### PR TITLE
Fix the Google loss of focus when adding operators in slots

### DIFF
--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1184,7 +1184,8 @@ export default defineComponent({
             // The logic is as such, we handle the insertion in the slot (with adequate adaptation if needed, see above)
             // let the parsing and slot factorisation do the checkup later
             // (we handle the insertion even if there is specific adapation because in the call to emit, the DOM has not updated)
-            return () => this.$emit(CustomEventTypes.requestSlotsRefactoring, refactorFocusSpanUID, stateBeforeChanges, {useFlatMediaDataCode: true});
+            // The blur event might be ignore, we set a flag and let the refactoring method evaluate the need for acknowledge this flat.
+            return () => this.$emit(CustomEventTypes.requestSlotsRefactoring, refactorFocusSpanUID, stateBeforeChanges, {useFlatMediaDataCode: true, ignoreBlurEditableSlot: true});
         },
 
         handleFastUDNavKeys(event: KeyboardEvent){

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -44,7 +44,7 @@ import { useStore } from "@/store/store";
 import { mapStores } from "pinia";
 import LabelSlot from "@/components/LabelSlot.vue";
 import { CustomEventTypes, getEditableSelectionText, getFrameLabelSlotLiteralCodeAndFocus, getFrameLabelSlotsStructureUID, getFunctionCallDefaultText, getLabelSlotUID, getMatchingBracket, getSelectionCursorsComparisonValue, getUIQuote, isElementEditableLabelSlotInput, isLabelSlotEditable, openBracketCharacters, parseCodeLiteral, parseLabelSlotUID, setDocumentSelection, STRING_DOUBLEQUOTE_PLACERHOLDER, STRING_SINGLEQUOTE_PLACERHOLDER, stringQuoteCharacters, UIDoubleQuotesCharacters, UISingleQuotesCharacters, getGraphemeLength, getFrameHeaderUID } from "@/helpers/editor";
-import { checkCodeErrors, evaluateSlotType, generateFlatSlotBases, getFlatNeighbourFieldSlotInfos, getFrameParentSlotsLength, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, retrieveSlotByPredicate, retrieveSlotFromSlotInfos, getParentId} from "@/helpers/storeMethods";
+import { checkCodeErrors, evaluateSlotType, generateFlatSlotBases, getFlatNeighbourFieldSlotInfos, getFrameParentSlotsLength, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, retrieveSlotByPredicate, retrieveSlotFromSlotInfos, getParentId, areSlotStructuresIsomorphic} from "@/helpers/storeMethods";
 import { cloneDeep } from "lodash";
 import { calculateParamPrompt } from "@/autocompletion/acManager";
 import scssVars from "@/assets/style/_export.module.scss";
@@ -370,7 +370,7 @@ export default defineComponent({
             return true;
         },
 
-        checkSlotRefactoring(slotUID: string, stateBeforeChanges: any, options?: {skipCursorSetAndStateSave?: boolean, skipStateSaveOnly?: boolean, doAfterCursorSet?: VoidFunction, useFlatMediaDataCode?: boolean}) {
+        checkSlotRefactoring(slotUID: string, stateBeforeChanges: any, options?: {skipCursorSetAndStateSave?: boolean, skipStateSaveOnly?: boolean, doAfterCursorSet?: VoidFunction, useFlatMediaDataCode?: boolean, ignoreBlurEditableSlot?: boolean}) {
             // Slot errors will be check later again. We clear off the notification on the parent (frame header) for slot errors so it can reset the triangle error indicator
             vueComponentsAPIHandler.frameHeaderComponentAPI?.forInstance[this.frameId].setHasErroneousSlot(false);
             // Comments do not need to be checked, so we do nothing special for them, but just enforce the caret to be placed at the right place and the code value to be updated
@@ -399,6 +399,11 @@ export default defineComponent({
                 let {uiLiteralCode, focusSpanPos: focusCursorAbsPos, hasStringSlots, mediaLiterals} = getFrameLabelSlotLiteralCodeAndFocus(labelDiv, slotUID, {useFlatMediaDataCode: options?.useFlatMediaDataCode});
                 const parsedCodeRes = parseCodeLiteral(uiLiteralCode, {frameType: this.appStore.frameObjects[this.frameId].frameType.type, isInsideString: false, cursorPos: options?.skipCursorSetAndStateSave ? undefined : focusCursorAbsPos, skipStringEscape: hasStringSlots, imageLiterals: mediaLiterals});
                 const majorChange = this.majorChange(this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures, parsedCodeRes.slots);
+                // Chrome triggers a loss of focus when the slots structure (and only structurally speaking) are changed in the store, typically when inserting operators
+                // so might want to ignore the event in this situation.
+                if(detectBrowser() == "chrome" && !areSlotStructuresIsomorphic(this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures, parsedCodeRes.slots)){
+                    this.appStore.ignoreBlurEditableSlot = options?.ignoreBlurEditableSlot??false;
+                }
                 this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures = parsedCodeRes.slots;
                 // The parser can be return a different size "code" of the slots than the code literal
                 // (that is for example the case with textual operators which requires spacing in typing, not in the UI)

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -253,6 +253,32 @@ export const evaluateSlotType = (def: { allowedSlotContent?: AllowedSlotContent 
     }
 };
 
+// This helper function compares 2 label slots structure in an isomorphic way: that is we check the internal structure
+// is equivalent, without paying attention to the slot's code values.
+// We assume the structures are well formed so we can only care about the fields, and not look at operators.
+export const areSlotStructuresIsomorphic = (struct1: SlotsStructure, struct2: SlotsStructure): boolean => {
+    if(struct1.fields.length != struct2.fields.length){
+        return false;
+    }
+    else{
+        // We need to compare each slots inner content, to be sure their inner structure doesn't differ too.
+        return !struct1.fields.map((fieldSlot, index) =>  {
+            const fieldSlot1Type = evaluateSlotType({}, fieldSlot);
+            const fieldSlot2Type = evaluateSlotType({}, struct2.fields[index]);
+            if(fieldSlot1Type != fieldSlot2Type){
+                return false;
+            }
+            else if(isFieldBracketedSlot(fieldSlot)){
+                return areSlotStructuresIsomorphic(fieldSlot, struct2.fields[index] as SlotsStructure);
+            }
+            else{
+                // Any other type of slots, when they are of the same type, will be isomorphic
+                return true;
+            }
+        }).some((_)=> !_);
+    }
+};
+
 export const removeFrameInFrameList = (frameId: number): void => {
     // When removing a frame in the list, we remove all its sub levels,
     // then update its parent and then delete the frame itself

--- a/tests/cypress/support/load-save-support.ts
+++ b/tests/cypress/support/load-save-support.ts
@@ -6,21 +6,22 @@ import path from "path";
 export function checkDownloadedFileEquals(strypeElIds: {[varName: string]: (...args: any[]) => string}, fullContent: string, filename: string, firstSave?: boolean) : void {
     const downloadsFolder = Cypress.config("downloadsFolder");
     const destFile = path.join(downloadsFolder, filename);
-    cy.task("deleteFile", destFile);
-    // Save is located in the menu, so we need to open it first, then find the link and click on it
-    // Force these because sometimes cypress gives false alarm about webpack overlay being on top:
-    cy.get("button#" + strypeElIds.getEditorMenuUID()).click({force: true});
-    // Note we use the ID because cy.contains is awkward when "Save" and "Save as" begin the same.
-    cy.get("#saveStrypeProjLink").click({force: true});
-    if (firstSave) {
-        // For testing, we always want to save to this device:
-        cy.contains(en.appMessage.targetFS).click({force: true});
-        cy.contains("button:visible", en.buttonLabel.save).click();
-    }
+    cy.task("deleteFile", destFile).then(() => {
+        // Save is located in the menu, so we need to open it first, then find the link and click on it
+        // Force these because sometimes cypress gives false alarm about webpack overlay being on top:
+        cy.get("button#" + strypeElIds.getEditorMenuUID()).click({force: true});
+        // Note we use the ID because cy.contains is awkward when "Save" and "Save as" begin the same.
+        cy.get("#saveStrypeProjLink").click({force: true});
+        if (firstSave) {
+            // For testing, we always want to save to this device:
+            cy.contains(en.appMessage.targetFS).click({force: true});
+            cy.contains("button:visible", en.buttonLabel.save).click();
+        }
 
-    cy.readFile(destFile).then((p : string) => {
-        // Print out full version in message (without escaped \n), to make it easier to diff:
-        expect(p, "Actual unescaped:\n" + p).to.equal(fullContent.replaceAll("\r\n", "\n"));
+        cy.readFile(destFile).then((p : string) => {
+            // Print out full version in message (without escaped \n), to make it easier to diff:
+            expect(p, "Actual unescaped:\n" + p).to.equal(fullContent.replaceAll("\r\n", "\n"));
+        });
     });
 }
 


### PR DESCRIPTION
This PR fixes #837 : the issue stemmed from Google Chrome triggering a blur event on the slots when the _structure_ changed (which is the case when operators are added in expressions). So the workaround is to 1) detect we are on Chrome and 2) if the label slots refactoring results in a difference of structure, ignore the blur event (when we come from standard text input activities in the slots).

The PR also includes a fix for the Cypress tests. I can't really explain why one particular test failed before but others doing exactly the same mechanism didn't. For this one, it clearly seemed that the file we needed to read was deleted after the reading was requested, instead of before.