### PR TITLE
Autocompletion for built-in file names in string literals

### DIFF
--- a/src/autocompletion/acManager.ts
+++ b/src/autocompletion/acManager.ts
@@ -99,24 +99,29 @@ export function getContentForACPrefix(item : FieldSlot, excludeLast? : boolean) 
 // the full AC content isn't recreated every time, but only do so when we detect a change of context.
 // The return is a token (or null if code completion is invalid here)
 // and context (prefix) which is the part before a dot before the token.
-export function getCandidatesForAC(slotCode: SlotsStructure, location: number[]): {tokenAC: string | null; contextAC: string} {
+export function getCandidatesForAC(slotCode: SlotsStructure, location: number[]): {tokenAC: string | null; contextAC: string, kindAC: "code" | "string"} {
     // If anything goes wrong we make sure not to throw an exception; just show the AC with "No completion available":
     try {
         if (location.length == 1) {
             let fieldIndex = location[0];
             const ourField = slotCode.fields[fieldIndex];
             // We only offer completions for basic slots that are not string literals:
-            if (ourField != undefined && ("code" in ourField && !("quote" in ourField))) {
-                let prefix = "";
-                // Glue together any previous slots that are joined by dots (or blank operators):
-                if (fieldIndex > 0 && slotCode.operators[fieldIndex - 1].code === ".") {
-                    while (fieldIndex > 0 && (slotCode.operators[fieldIndex - 1].code === "." || slotCode.operators[fieldIndex - 1].code === "")) {
-                        fieldIndex -= 1;
-                        prefix = getContentForACPrefix(slotCode.fields[fieldIndex]) + (prefix ? slotCode.operators[fieldIndex].code : "") + prefix;
+            if (ourField != undefined && "code" in ourField) {
+                if (!("quote" in ourField)) {
+                    let prefix = "";
+                    // Glue together any previous slots that are joined by dots (or blank operators):
+                    if (fieldIndex > 0 && slotCode.operators[fieldIndex - 1].code === ".") {
+                        while (fieldIndex > 0 && (slotCode.operators[fieldIndex - 1].code === "." || slotCode.operators[fieldIndex - 1].code === "")) {
+                            fieldIndex -= 1;
+                            prefix = getContentForACPrefix(slotCode.fields[fieldIndex]) + (prefix ? slotCode.operators[fieldIndex].code : "") + prefix;
+                        }
                     }
+
+                    return {tokenAC: ourField.code, contextAC: prefix, kindAC: "code"};
                 }
-                
-                return {tokenAC: ourField.code, contextAC: prefix};
+                else {
+                    return {tokenAC: ourField.code, contextAC: "", kindAC: "string"};
+                }
             }
         }
         else {
@@ -130,7 +135,7 @@ export function getCandidatesForAC(slotCode: SlotsStructure, location: number[])
     catch (e) {
         console.warn("Exception while constructing code for autocompletion:" + e);
     }
-    return {tokenAC: null, contextAC: ""};
+    return {tokenAC: null, contextAC: "", kindAC: "code"};
 }
 
 // Given a slot, find all identifiers that are between two commas (or between a comma

--- a/src/components/AutoCompletion.vue
+++ b/src/components/AutoCompletion.vue
@@ -92,6 +92,21 @@ import microbitDescriptions from "@/autocompletion/microbit.json";
 import microbitAPI from "@/autocompletion/microbit-api.json";
 // #v-endif
 
+const assetFileList : string[] = Object.keys(import.meta.glob(
+    "/src/assetsFilesystem/**/*",
+    {
+        eager: true,
+        query: "?url",
+        import: "default",
+    }
+)).map((path) => path.replace(/^\/src\/assetsFilesystem/, "/strype"))
+    // Leave out cat-test.jpg etc:
+    .filter((path) => !path.includes("-test"));
+
+const assetFileCompletions : AcResultType[] = assetFileList.map((path) => {
+    return {acResult: path, documentation: "A file built in to Strype.", type: [], version: 0};
+});
+
 //////////////////////
 export default defineComponent({
     name: "AutoCompletion",
@@ -282,7 +297,7 @@ export default defineComponent({
         // frameId is which frame we're in.
         // token is the string token being edited, or null if it's invalid to show code completion here
         // context is the part before any preceding dot before us 
-        async updateAC(frameId: number, token : string | null, context: string): Promise<void> {
+        async updateAC(frameId: number, token : string | null, context: string, kind: "code" | "string"): Promise<void> {
             const tokenStartsWithUnderscore = (token ?? "").startsWith("_");
             const parser = new Parser(false, "py", true);
             const inFuncDef = getFrameContainer(frameId) == useStore().getDefsFrameContainerId;
@@ -310,7 +325,11 @@ export default defineComponent({
             this.showFunctionBrackets = true;
             const imported = await getAllExplicitlyImportedItems(context);
             this.acResults = {};
-            if (token === null) {
+            if (token != null && kind == "string") {
+                this.acResults["Files"] = assetFileCompletions;
+                this.showSuggestionsAC(token);
+            }
+            else if (token === null) {
                 this.showSuggestionsAC("");
             }
             else if (context !== "" && imported[context as keyof typeof imported]) {

--- a/src/components/AutoCompletion.vue
+++ b/src/components/AutoCompletion.vue
@@ -326,7 +326,7 @@ export default defineComponent({
             const imported = await getAllExplicitlyImportedItems(context);
             this.acResults = {};
             if (token != null && kind == "string") {
-                this.acResults["Files"] = assetFileCompletions;
+                this.acResults[this.$t("autoCompletion.builtinFiles")] = assetFileCompletions;
                 this.showSuggestionsAC(token);
             }
             else if (token === null) {

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -179,6 +179,7 @@ export default defineComponent({
             contextAC: "",
             // tokenAC can be null if code completion is invalid here
             tokenAC: "" as string | null,
+            kindAC: "code" as "code" | "string",
             //used to force a text cursor position, for example after inserting an AC candidate
             textCursorPos: 0,    
             //flags to indicate whether the user has explicitly marked a pause when deleting text with backspace
@@ -467,7 +468,7 @@ export default defineComponent({
 
         // Event callback equivalent to what would happen for a focus event callback 
         // (the spans don't get focus anymore because the containg editable div grab it)
-        onGetCaret(event: MouseEvent, fromNaturalClick?: boolean): void {
+        onGetCaret(event: MouseEvent | Event | null, fromNaturalClick?: boolean): void {
             this.$nextTick(() => vueComponentsAPIHandler.labelSlotsStructureComponentAPI?.forInstance[getFrameLabelSlotsStructureUID(this.frameId, this.labelSlotsIndex)].updatePrependText());
 
             // When this method is triggered by a natural click on the text slot, we delay the chain of actions a bit,
@@ -476,9 +477,9 @@ export default defineComponent({
             setTimeout(() => {
                 // If the user's code is being executed, or if the frame is disabled, we don't focus any slot, but we make sure we show the adequate frame cursor instead.
                 if(this.isPythonExecuting || this.isDisabled || this.isFrozen){
-                    event.stopImmediatePropagation();
-                    event.stopPropagation();
-                    event.preventDefault();
+                    event?.stopImmediatePropagation();
+                    event?.stopPropagation();
+                    event?.preventDefault();
                     // Call the method which handles a click on the frame instead, we need to find the associated frame object:
                     // the corresponding frame div under that click in the general case, or the outmost disabled ancester frame if the frame is disabled.
                     const outmostDisabledFrameAncestorId = getOutmostDisabledAncestorFrameId(this.frameId);
@@ -486,7 +487,7 @@ export default defineComponent({
                     if(frameDiv){
                         const frameComponentId = (this.isDisabled) ? outmostDisabledFrameAncestorId: this.frameId;
                         // The frame component can only be a frame (and not a frame container) since we've clicked on a slot...
-                        vueComponentsAPIHandler.frameComponentAPI?.forInstance[frameComponentId].changeToggledCaretPosition(event.clientY, frameDiv);
+                        vueComponentsAPIHandler.frameComponentAPI?.forInstance[frameComponentId].changeToggledCaretPosition(event instanceof MouseEvent ? event.clientY : 0, frameDiv);
                         // Even if visually and logically in the app the slot doesn't have focus, the browser will see differently
                         // (a click happened on the span...) - to make sure no undesirable effect occur, we set the focus on the frame div
                         (document.getElementById(getFrameUID(frameComponentId)))?.focus();                        
@@ -499,7 +500,7 @@ export default defineComponent({
                 // If we arrive here by a click, and the slot is a bracket, a quote or an operator, we should get the focus to the nearest editable frame.
                 // We should have neigbours because brackets, quotes and operators are always surronded by fields, but keep TS happy
                 if(this.slotType != SlotType.code && this.slotType != SlotType.string && this.slotType != SlotType.comment){
-                    const clickXValue = event.x;
+                    const clickXValue = event instanceof MouseEvent ? event.x : 0;
                     const slotWidth = document.getElementById(getLabelSlotUID(this.coreSlotInfo))?.offsetWidth??0;
                     const slotXPos = document.getElementById(getLabelSlotUID(this.coreSlotInfo))?.getBoundingClientRect().x??0; 
 
@@ -525,7 +526,7 @@ export default defineComponent({
                         }
                     
                         // Focus on the nearest neighbour to the click
-                        event.preventDefault();
+                        event?.preventDefault();
                         this.$nextTick(() => {
                             const neighbourCursorSlotInfos: SlotCursorInfos = {slotInfos: neighbourSlotInfos, cursorPos: cursorPos};
                             document.getElementById(getLabelSlotUID(neighbourSlotInfos))?.dispatchEvent(new Event(CustomEventTypes.editableSlotGotCaret));
@@ -641,9 +642,10 @@ export default defineComponent({
                     const resultsAC = getCandidatesForAC(frame.labelSlotsDict[this.labelSlotsIndex].slotStructures, new RegExp("[0-9,]+$").exec(this.slotId)?.[0]?.trim()?.split(",")?.map((x) => parseInt(x)) ?? []);
                     this.contextAC = resultsAC.contextAC;
                     this.tokenAC = resultsAC.tokenAC;
+                    this.kindAC = resultsAC.kindAC;
   
                     this.$nextTick(() => {
-                        vueComponentsAPIHandler.autoCompletionComponentAPI?.forInstance[this.AC_UID].updateAC(this.frameId, this.tokenAC, this.contextAC);                        
+                        vueComponentsAPIHandler.autoCompletionComponentAPI?.forInstance[this.AC_UID].updateAC(this.frameId, this.tokenAC, this.contextAC, this.kindAC);                        
                     });
                 }
             }
@@ -1100,6 +1102,8 @@ export default defineComponent({
                     if((currentSlot as StringSlot).quote == inputString){
                         this.removeLastInput(inputString);
                     }
+                    // Must call onGetCaret to make sure AC is updated:
+                    this.onGetCaret(null);
                     return;
                 }
                 else{

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -597,9 +597,6 @@ export default defineComponent({
         },
         
         updateAC() : void {
-            // Note: code in created() debounces this function to stop it running too often
-            // You cannot assume it has run just after you called it.
-            
             const frame: FrameObject = this.appStore.frameObjects[this.frameId];
             const selectionStart = getFocusedEditableSlotTextSelectionStartEnd(this.UID).selectionStart;
 

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -230,6 +230,7 @@
     "myVariables": "My variables",
     "myClasses": "My classes",
     "importedModules": "Imported modules",
+    "builtinFiles": "Built-in files",
     "invalidState": "No completion available",
     "noDocumentation": "No documentation available"
   },

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -228,6 +228,7 @@
     "myVariables": "Mes variables",
     "myClasses": "Mes classes",
     "importedModules": "Modules importés",
+    "builtinFiles": "Fichiers intégrés",
     "invalidState": "Aucune complétion disponible",
     "noDocumentation": "Aucune documentation disponible"
   },

--- a/src/types/vue-component-api-types.ts
+++ b/src/types/vue-component-api-types.ts
@@ -147,7 +147,7 @@ export type AutoCompletionComponentAPI = {
     [componentInstanceKey: string]: {
       updateACForModuleImport: (token: string) => Promise<void>,
       updateACForImportFrom: (token: string, module: string) => void,
-      updateAC: (frameId: number, token : string | null, context: string) => Promise<void>
+      updateAC: (frameId: number, token : string | null, context: string, kind: "code" | "string") => Promise<void>
     },
   },
 }


### PR DESCRIPTION
We now have files available in Strype in the /strype directory, but there's no way to see a list of them.  This adds that ability via the autocomplete mechanism, as already suggested in #315.  Looks like this when you hit ctrl-space in a string literal:

<img width="706" height="131" alt="image" src="https://github.com/user-attachments/assets/6d170a9b-4246-4332-abcd-9bbf571cb50f" />

