### PR TITLE
Change get_key to block and wait for next key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18385,23 +18385,6 @@
             "license": "ISC",
             "peer": true
         },
-        "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
-            }
-        },
         "node_modules/yargs": {
             "version": "15.4.1",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",

--- a/pysrc/strype/graphics.py
+++ b/pysrc/strype/graphics.py
@@ -958,23 +958,6 @@ def key_pressed(keyname):
         keyname = "space"
     return _cached_pressed_keys[keyname.lower()]
 
-def get_key():
-    """
-    Gets the last key that was pressed.
-    
-    If no key was pressed since the last call to this function, None is returned.  Be careful that you should not
-    call this function twice in quick succession as the result will change.  So if you want to check against multiple
-    possibilities, call it once and save it to a variable, then compare the variable.
-    
-    Sometimes you may want to wait for a key (for example, a "press any key to continue" or "press a key to choose")
-    and you want to avoid receiving old (or "stale") key presses, then call get_key() once and ignore the result,
-    then show your prompt, then loop with a pace() call waiting for get_key() to be non-None. 
-    
-    :return: The key that was most recently pressed, or None if no key has been pressed since the last call to this function.
-    """
-    # Note that this is not cached, unlike key_pressed: 
-    return _strype_input_internal.getAndResetLastKey()
-
 def set_background(image_or_color, scale_to_fit = False):
     # type: (Image | str, bool) -> None
     """

--- a/pysrc/strype/graphics.py
+++ b/pysrc/strype/graphics.py
@@ -958,6 +958,17 @@ def key_pressed(keyname):
         keyname = "space"
     return _cached_pressed_keys[keyname.lower()]
 
+def get_key():
+    # type: () -> str 
+    """
+    Waits for a key to be pressed and returns it.
+    
+    This function will wait until a key is pressed, and your program will be paused until the key is pressed. 
+    
+    :return: The key that was pressed.
+    """
+    return _strype_input_internal.waitForNextKey()
+
 def set_background(image_or_color, scale_to_fit = False):
     # type: (Image | str, bool) -> None
     """

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -100,6 +100,7 @@ let mostRecentClickedItems : SpriteHandle[] = []; // All the items under the mou
 let mostRecentClickDetails : { x: number, y: number, button: number, clickCount: number } | null = null; // x, y, button, click_count
 let mostRecentMouseDetails : {x: number, y: number, buttonsPressed: boolean[]} = {x:0, y:0, buttonsPressed: [false, false, false]}; // X, Y, three button states
 let pressedKeys : {[key: string]: boolean} = {};
+let sendNextKey : ((s: string) => void) = () => {}; 
 const keyMapping = new Map<string, string>([["ArrowUp", "up"], ["ArrowDown", "down"], ["ArrowLeft", "left"], ["ArrowRight", "right"], [" ", "space"]]);
 let switchedToGraphicsTabAlreadyThisExecute = false;
 let switchedToConsoleTabAlreadyThisExecute = false;
@@ -573,6 +574,7 @@ export default defineComponent({
                 mostRecentClickDetails = null;
                 mostRecentMouseDetails = {x: 0, y: 0, buttonsPressed: [false, false, false]};
                 pressedKeys = {};
+                sendNextKey = () => {};
                 window.addEventListener("keydown", this.graphicsCanvasKeyDown);
                 window.addEventListener("keyup", this.graphicsCanvasKeyUp);
                 // Start the redraw loop:
@@ -616,6 +618,11 @@ export default defineComponent({
                 
                 const syncBridgePromise = handleSyncRequests(renderer, soundManager as SoundManager, turtlePixiHandler, {
                     getPressedKeys: () => pressedKeys,
+                    waitForNextKey: () => {
+                        return new Promise<string>((resolve) => {
+                            sendNextKey = resolve;
+                        });
+                    },
                     loadLibraryAsset: this.loadLibraryAsset,
                     switchToGraphicsTab: this.switchToGraphicsTab,
                     markTurtleDirty: () => {
@@ -834,6 +841,7 @@ export default defineComponent({
             mostRecentClickDetails = null;
             mostRecentClickedItems = [];
             mostRecentMouseDetails = {x:0, y:0, buttonsPressed: [false, false, false]};
+            sendNextKey = () => {};
             renderer.clear();
             this.redrawCanvas();
         },
@@ -1041,6 +1049,7 @@ export default defineComponent({
         graphicsCanvasKeyUp(event: KeyboardEvent) {
             const keyname = keyMapping.get(event.key) ?? event.key.toLowerCase();
             pressedKeys[keyname] = false; 
+            sendNextKey(keyname);
         },
 
         handleContextMenuOpened() {

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -100,7 +100,6 @@ let mostRecentClickedItems : SpriteHandle[] = []; // All the items under the mou
 let mostRecentClickDetails : { x: number, y: number, button: number, clickCount: number } | null = null; // x, y, button, click_count
 let mostRecentMouseDetails : {x: number, y: number, buttonsPressed: boolean[]} = {x:0, y:0, buttonsPressed: [false, false, false]}; // X, Y, three button states
 let pressedKeys : {[key: string]: boolean} = {};
-let mostRecentKey : string | undefined = undefined;
 const keyMapping = new Map<string, string>([["ArrowUp", "up"], ["ArrowDown", "down"], ["ArrowLeft", "left"], ["ArrowRight", "right"], [" ", "space"]]);
 let switchedToGraphicsTabAlreadyThisExecute = false;
 let switchedToConsoleTabAlreadyThisExecute = false;
@@ -574,7 +573,6 @@ export default defineComponent({
                 mostRecentClickDetails = null;
                 mostRecentMouseDetails = {x: 0, y: 0, buttonsPressed: [false, false, false]};
                 pressedKeys = {};
-                mostRecentKey = undefined;
                 window.addEventListener("keydown", this.graphicsCanvasKeyDown);
                 window.addEventListener("keyup", this.graphicsCanvasKeyUp);
                 // Start the redraw loop:
@@ -618,11 +616,6 @@ export default defineComponent({
                 
                 const syncBridgePromise = handleSyncRequests(renderer, soundManager as SoundManager, turtlePixiHandler, {
                     getPressedKeys: () => pressedKeys,
-                    getAndResetLastKey: () => {
-                        const k = mostRecentKey;
-                        mostRecentKey = undefined;
-                        return k;
-                    },
                     loadLibraryAsset: this.loadLibraryAsset,
                     switchToGraphicsTab: this.switchToGraphicsTab,
                     markTurtleDirty: () => {
@@ -841,7 +834,6 @@ export default defineComponent({
             mostRecentClickDetails = null;
             mostRecentClickedItems = [];
             mostRecentMouseDetails = {x:0, y:0, buttonsPressed: [false, false, false]};
-            mostRecentKey = undefined;
             renderer.clear();
             this.redrawCanvas();
         },
@@ -1048,8 +1040,7 @@ export default defineComponent({
         },
         graphicsCanvasKeyUp(event: KeyboardEvent) {
             const keyname = keyMapping.get(event.key) ?? event.key.toLowerCase();
-            pressedKeys[keyname] = false;
-            mostRecentKey = keyname; 
+            pressedKeys[keyname] = false; 
         },
 
         handleContextMenuOpened() {

--- a/src/stryperuntime/main_bridge_handler.ts
+++ b/src/stryperuntime/main_bridge_handler.ts
@@ -17,7 +17,6 @@ import {getRawFileFromLibraries} from "@/helpers/libraryManager";
 // This means we don't have to make reference to the PythonExecutionArea component itself.
 interface SyncRequestCallbacks {
     getPressedKeys : () => {[key: string]: boolean},
-    getAndResetLastKey : () => string | undefined,
     loadLibraryAsset : (libraryShortName: string, fileName: string) => Promise<string | undefined>,
     switchToGraphicsTab: (condition: "always" | "ifFirstCallDuringExecute") => void,
     markTurtleDirty: () => void,
@@ -50,9 +49,6 @@ export const handleSyncRequests : (
     }
     case "getPressedKeys": {
         return {request: req.request, response: Promise.resolve(callbacks.getPressedKeys())};
-    }
-    case "getAndResetLastKey": {
-        return {request: req.request, response: Promise.resolve(callbacks.getAndResetLastKey())};
     }
     case "getMouseDetails": {
         return {request: req.request, response: Promise.resolve(callbacks.getMouseDetails())};

--- a/src/stryperuntime/main_bridge_handler.ts
+++ b/src/stryperuntime/main_bridge_handler.ts
@@ -17,6 +17,7 @@ import {getRawFileFromLibraries} from "@/helpers/libraryManager";
 // This means we don't have to make reference to the PythonExecutionArea component itself.
 interface SyncRequestCallbacks {
     getPressedKeys : () => {[key: string]: boolean},
+    waitForNextKey : () => Promise<string>,
     loadLibraryAsset : (libraryShortName: string, fileName: string) => Promise<string | undefined>,
     switchToGraphicsTab: (condition: "always" | "ifFirstCallDuringExecute") => void,
     markTurtleDirty: () => void,
@@ -49,6 +50,9 @@ export const handleSyncRequests : (
     }
     case "getPressedKeys": {
         return {request: req.request, response: Promise.resolve(callbacks.getPressedKeys())};
+    }
+    case "waitForNextKey": {
+        return {request: req.request, response: callbacks.waitForNextKey()};
     }
     case "getMouseDetails": {
         return {request: req.request, response: Promise.resolve(callbacks.getMouseDetails())};

--- a/src/stryperuntime/strype_graphics_input_internal.ts
+++ b/src/stryperuntime/strype_graphics_input_internal.ts
@@ -28,6 +28,10 @@ export function getPressedKeys() : {[key: string]: boolean} {
     return syncBridge({request: "getPressedKeys"});
 }
 
+export function waitForNextKey() : string | undefined {
+    return syncBridge({request: "waitForNextKey"});
+}
+
 export function checkCollision(idA : number, idB : number) : boolean {
     return globalThis.spriteManager.checkCollision(idA, idB);
 }

--- a/src/stryperuntime/strype_graphics_input_internal.ts
+++ b/src/stryperuntime/strype_graphics_input_internal.ts
@@ -28,10 +28,6 @@ export function getPressedKeys() : {[key: string]: boolean} {
     return syncBridge({request: "getPressedKeys"});
 }
 
-export function getAndResetLastKey() : string | undefined {
-    return syncBridge({request: "getAndResetLastKey"});
-}
-
 export function checkCollision(idA : number, idB : number) : boolean {
     return globalThis.spriteManager.checkCollision(idA, idB);
 }

--- a/src/stryperuntime/worker_bridge_type.ts
+++ b/src/stryperuntime/worker_bridge_type.ts
@@ -53,6 +53,7 @@ export type SyncStrypePyodideWorkerRequest =
     | { request: "canvas_drawText", img: RemoteCanvas, text: string, x: number, y: number, fontSize: number, maxWidth: number, maxHeight: number, fontName: string }
     | { request: "turtle", buffer: [string, string, any][]}    
     | { request: "getPressedKeys" }
+    | { request: "waitForNextKey" }
     | { request: "getMouseDetails" }
     | { request: "consumeLastClickDetails" }
     | { request: "consumeLastClickedItems" }
@@ -89,6 +90,7 @@ export type SyncStrypePyodideWorkerResponse =
     | { request: "canvas_drawText"; response: { width: number; height: number; } }
     | { request: "turtle"; response: boolean; } // We don't need a return value as such, we're just using the response to wait
     | { request: "getPressedKeys"; response: {[key: string]: boolean} }
+    | { request: "waitForNextKey"; response: string }
     | { request: "getMouseDetails", response: {x : number, y: number, buttonsPressed: boolean[] } }
     | { request: "consumeLastClickDetails", response: { x: number, y: number, button: number, clickCount: number } | null }
     | { request: "consumeLastClickedItems", response: SpriteHandle[] }

--- a/src/stryperuntime/worker_bridge_type.ts
+++ b/src/stryperuntime/worker_bridge_type.ts
@@ -53,7 +53,6 @@ export type SyncStrypePyodideWorkerRequest =
     | { request: "canvas_drawText", img: RemoteCanvas, text: string, x: number, y: number, fontSize: number, maxWidth: number, maxHeight: number, fontName: string }
     | { request: "turtle", buffer: [string, string, any][]}    
     | { request: "getPressedKeys" }
-    | { request: "getAndResetLastKey" }
     | { request: "getMouseDetails" }
     | { request: "consumeLastClickDetails" }
     | { request: "consumeLastClickedItems" }
@@ -90,7 +89,6 @@ export type SyncStrypePyodideWorkerResponse =
     | { request: "canvas_drawText"; response: { width: number; height: number; } }
     | { request: "turtle"; response: boolean; } // We don't need a return value as such, we're just using the response to wait
     | { request: "getPressedKeys"; response: {[key: string]: boolean} }
-    | { request: "getAndResetLastKey"; response: string | undefined }
     | { request: "getMouseDetails", response: {x : number, y: number, buttonsPressed: boolean[] } }
     | { request: "consumeLastClickDetails", response: { x: number, y: number, button: number, clickCount: number } | null }
     | { request: "consumeLastClickedItems", response: SpriteHandle[] }

--- a/tests/playwright/e2e/graphics.spec.ts
+++ b/tests/playwright/e2e/graphics.spec.ts
@@ -565,25 +565,3 @@ while True  :
     });
 });
 
-test.describe("Test get_key", () => {
-    test("Test typing with get_key", async ({page}) => {
-        await loadContent(page, `
-from strype.graphics import *
-set_background("blue")
-s = ""
-while True:
-    k = get_key()
-    if k:
-        if k == "space":
-            k = " "
-        s = s + k
-        show_text(s, font_size=120)
-    pace()
-`);
-        await startRunning(page);
-        await page.waitForTimeout(1000);
-        await page.keyboard.type("Hello world", {delay: 500});
-        await page.waitForTimeout(1000);
-        await checkGraphicsAreaContent(page, "type-get-key-show-text");
-    });
-});

--- a/tests/playwright/e2e/graphics.spec.ts
+++ b/tests/playwright/e2e/graphics.spec.ts
@@ -565,3 +565,23 @@ while True  :
     });
 });
 
+test.describe("Test get_key", () => {
+    test("Test typing with get_key", async ({page}) => {
+        await loadContent(page, `
+from strype.graphics import *
+set_background("blue")
+s = ""
+while True:
+    k = get_key()
+    if k == "space":
+        k = " "
+    s = s + k
+    show_text(s, font_size=120)
+`);
+        await startRunning(page);
+        await page.waitForTimeout(1000);
+        await page.keyboard.type("Hello world", {delay: 200});
+        await page.waitForTimeout(1000);
+        await checkGraphicsAreaContent(page, "type-get-key-show-text");
+    });
+});


### PR DESCRIPTION
As discussed in the meeting, removes the "old" (we never released it) get_key and replaces it with a version that blocks to wait for the next key.  I've done it in two commits: a removal and addition, in case we later decide we want both and want to rollback the removal.  But it's probably simplest to just read the overall diff to see the change.