### PR TITLE
Added error handling for when indexedDB is unavailable, and added a test for it

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ export default [
             "temp-scripts/**",
             "scripts/compiled/**",
             "docs-sphinx/**",
+            "tests/playwright/html-report/**",
         ],
     },
     {

--- a/src/App.vue
+++ b/src/App.vue
@@ -139,7 +139,7 @@ import { getAPIItemTextualDescriptions } from "./helpers/microbitAPIDiscovery";
 import { DAPWrapper } from "./helpers/partial-flashing";
 // #v-endif
 import { mapStores } from "pinia";
-import { getFlatNeighbourFieldSlotInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, retrieveParentSlotFromSlotInfos, retrieveSlotFromSlotInfos, getFrameBelowCaretPosition, checkCodeErrors, calculateNextCollapseState } from "./helpers/storeMethods";
+import {getFlatNeighbourFieldSlotInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, retrieveParentSlotFromSlotInfos, retrieveSlotFromSlotInfos, getFrameBelowCaretPosition, checkCodeErrors, calculateNextCollapseState, showIndexDBError} from "./helpers/storeMethods";
 import { cloneDeep } from "lodash";
 import {pasteMixedPython} from "@/helpers/pythonToFrames";
 import MediaPreviewPopup from "@/components/MediaPreviewPopup.vue";
@@ -886,7 +886,8 @@ export default defineComponent({
                     const stateJSONStrWithCheckpoint = this.appStore.generateStateJSONStrWithCheckpoint(true);
                     if (reason !== SaveRequestReason.unloadPage && reason !== SaveRequestReason.reloadBrowser) {
                         // We have time, so we save normally (which is async):
-                        saveSessionState(getEditorTabId(), stateJSONStrWithCheckpoint);
+                        saveSessionState(getEditorTabId(), stateJSONStrWithCheckpoint)
+                            .catch(showIndexDBError);
                     }
                     else {
                         // Async might get killed during the closing process so we save to local storage as an alternative:
@@ -973,7 +974,10 @@ export default defineComponent({
         checkLocalStorageHasProject(): Promise<string> {
             // Check if a local storage project exists.
             // The promise returns the local storage content on fulfillment.
-            return loadSessionState(getEditorTabId()).then((value) => {
+            return loadSessionState(getEditorTabId()).catch((err) => {
+                showIndexDBError(err);
+                return null;
+            }).then((value) => {
                 if (value === null) {
                     throw new Error("Stored session state not found");
                 }

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -2,7 +2,7 @@ import { getSHA1HashForObject } from "@/helpers/common";
 import i18n from "@/i18n";
 import Parser from "@/parser/parser";
 import { useStore } from "@/store/store";
-import { AllFrameTypesIdentifier, AllowedSlotContent, BaseSlot, CaretPosition, CollapsedState, ContainerTypesIdentifiers, CurrentFrame, EditorFrameObjects, FieldSlot, FlatSlotBase, FrameLabel, FrameObject, FrozenState, getFrameDefType, isFieldBracketedSlot, isFieldMediaSlot, isFieldStringSlot, isSlotBracketType, isSlotCodeType, NavigationPosition, OptionalSlotType, SlotCoreInfos, SlotCursorInfos, SlotInfos, SlotsStructure, SlotType, StrypePlatform } from "@/types/types";
+import { AllFrameTypesIdentifier, AllowedSlotContent, BaseSlot, CaretPosition, CollapsedState, ContainerTypesIdentifiers, CurrentFrame, EditorFrameObjects, FieldSlot, FlatSlotBase, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, FrameLabel, FrameObject, FrozenState, getFrameDefType, isFieldBracketedSlot, isFieldMediaSlot, isFieldStringSlot, isSlotBracketType, isSlotCodeType, MessageDefinitions, NavigationPosition, OptionalSlotType, SlotCoreInfos, SlotCursorInfos, SlotInfos, SlotsStructure, SlotType, StrypePlatform } from "@/types/types";
 import { nextTick} from "vue";
 import { checkEditorCodeErrors, countEditorCodeErrors, getCaretContainerUID, getLabelSlotUID, getMatchingBracket, parseLabelSlotUID } from "./editor";
 import { cloneDeep, isEqual } from "lodash";
@@ -1099,4 +1099,12 @@ export function calculateNextCollapseState(frameList: FrameObject[], parentIsFro
         }
         return {overall: nextState, individual: decided};
     }
+}
+
+// Show an error using the ErrorAccessingIndexedDB message
+export function showIndexDBError(errorMsg:string) : void {
+    const msg = cloneDeep(MessageDefinitions.ErrorAccessingIndexedDB);
+    const msgObj = msg.message as FormattedMessage;
+    msgObj.args[FormattedMessageArgKeyValuePlaceholders.error.key] = msgObj.args.errorMsg.replace(FormattedMessageArgKeyValuePlaceholders.error.placeholderName, errorMsg);
+    useStore().showMessage(msg, null);
 }

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -47,7 +47,8 @@
     "invalidPythonParsePaste": "Invalid Python code pasted: {errorMsg}",
     "wrongPythonStructCopied": "cannot paste else/elif/except/finally and further content in one paste",
     "incompatiblePythonStrypeSection": "the Python code cannot be placed in the target Strype section",
-    "invalidMatchStmtContent": "this content is not allowed inside a 'match' statement"
+    "invalidMatchStmtContent": "this content is not allowed inside a 'match' statement",
+    "errorAccessingIndexedDB": "Error accessing browser storage (possibly due to private browsing).  State cannot be loaded and may be irretrievable on reload or close.  (Error: {errorMsg})"
   },
   "buttonLabel": {
     "undo": "Undo",

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,11 +10,10 @@ import {getAppLangSelectId, getEditorID, getEditorMenuUID, getFrameBodyUID, getF
 import "@imengyu/vue3-context-menu/lib/vue3-context-menu.css";
 import ContextMenu from "@imengyu/vue3-context-menu";
 import { openIndexedDBConnection, tidyUpDatabaseState } from "@/store/store-db-storage";
-import { getEditorTabId, useStore } from "@/store/store";
+import { getEditorTabId } from "@/store/store";
+import { showIndexDBError } from "@/helpers/storeMethods";
 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
 import {getPEATabContentContainerDivId} from "./helpers/editor";
-import {MessageDefinitions} from "@/types/types";
-import {showIndexDBError} from "@/helpers/storeMethods";
 // #v-endif
 
 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,9 +10,11 @@ import {getAppLangSelectId, getEditorID, getEditorMenuUID, getFrameBodyUID, getF
 import "@imengyu/vue3-context-menu/lib/vue3-context-menu.css";
 import ContextMenu from "@imengyu/vue3-context-menu";
 import { openIndexedDBConnection, tidyUpDatabaseState } from "@/store/store-db-storage";
-import { getEditorTabId } from "@/store/store";
+import { getEditorTabId, useStore } from "@/store/store";
 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
 import {getPEATabContentContainerDivId} from "./helpers/editor";
+import {MessageDefinitions} from "@/types/types";
+import {showIndexDBError} from "@/helpers/storeMethods";
 // #v-endif
 
 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
@@ -102,8 +104,10 @@ app.directive("blur", {
 app.use(ContextMenu);
 
 // Important to do this tidy up before checking the state:
-const initialDBConnection = await openIndexedDBConnection();
-await tidyUpDatabaseState(getEditorTabId(), initialDBConnection);
+await openIndexedDBConnection()
+    .then((initialDBConnection) => tidyUpDatabaseState(getEditorTabId(), initialDBConnection, showIndexDBError))
+    .catch(showIndexDBError);
+
 
 // Mount the app
 app.mount("#app");

--- a/src/store/store-db-storage.ts
+++ b/src/store/store-db-storage.ts
@@ -158,11 +158,10 @@ async function cleanupOldSessions(db: IDBDatabase) : Promise<void> {
 // moves any old local storage (which can exist from a version before we added indexed DB)
 // into indexed DB, plus any emergency-sync-written state from a page unload into the DB too.
 // That way, all code after this function only has to look at the DB.
-export async function tidyUpDatabaseState(ourTabId : string, db: IDBDatabase) : Promise<void> {
+export async function tidyUpDatabaseState(ourTabId : string, db: IDBDatabase, onError: (err: string) => void) : Promise<void> {
     // We need to find any "emergency" localStorage items which were saved during page unload or refresh,
     // and move them into the database where they belong:
-    const toAddToDatabase: Record<string, string> = {};
-    const keysToDelete: string[] = [];
+    const toAddToDatabase: Record<string, {content: string, keyToDelete: string}> = {};
     let storeKey = AutoSaveKeyNames.pythonEditorState;
     // #v-ifdef STRYPE_PLATFORM == VITE_MICROBIT_MODE
     storeKey = AutoSaveKeyNames.mbEditor;
@@ -172,24 +171,29 @@ export async function tidyUpDatabaseState(ourTabId : string, db: IDBDatabase) : 
     for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
         if (key && key.startsWith(prefix)) {
-            toAddToDatabase[key.slice(prefix.length)] = localStorage.getItem(key) as string;
-            keysToDelete.push(key);
+            toAddToDatabase[key.slice(prefix.length)] = {content: localStorage.getItem(key) as string, keyToDelete: key};
         }
-    }
-
-    for (const key of keysToDelete) {
-        localStorage.removeItem(key);
     }
     
     for (const tabId of Object.keys(toAddToDatabase)) {
-        await saveSessionState(tabId, toAddToDatabase[tabId], db);
+        const item = toAddToDatabase[tabId];
+        await saveSessionState(tabId, item.content, db)
+            .catch(onError)
+            .then((() => {
+                // Only delete key if save was successful:
+                localStorage.removeItem(item.keyToDelete);
+            }));
     }
     
     // We also claim any old storage item and associate it with the current tab:
     const oldSingleItem = localStorage.getItem(storeKey);
     if (oldSingleItem) {
-        localStorage.removeItem(storeKey);
-        await saveSessionState(ourTabId, oldSingleItem, db);
+        await saveSessionState(ourTabId, oldSingleItem, db)
+            .catch(onError)
+            .then(() => {
+                // Only delete key if save was successful:
+                localStorage.removeItem(storeKey);
+            });
     }
     
     await cleanupOldSessions(db);

--- a/src/stryperuntime/main_thread_python_handler.ts
+++ b/src/stryperuntime/main_thread_python_handler.ts
@@ -21,7 +21,7 @@ let pythonWorker : Worker | null = makeNewPyodideWorker();
 let pythonClient : PyodideClient<any> | null = pythonWorker == null ? null: makePyodideClient(pythonWorker);
 
 function makeNewPyodideWorker() : Worker | null {
-    if ((window as any)?.TestingNoPyodide) {
+    if (sessionStorage.getItem("TestingNoPyodide")) {
         console.info("Skipping Pyodide as in testing mode");
         return null;
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -944,6 +944,7 @@ export const MessageTypes = {
     gdriveFileAlreadyExists: "gdriveFileAlreadyExists",
     invalidPythonParseImport: "invalidPythonParseImport",
     invalidPythonParsePaste: "invalidPythonParsePaste",
+    errorAccessingIndexedDB: "errorAccessingIndexedDB",
 };
 
 //empty message
@@ -1065,6 +1066,17 @@ const InvalidPythonParsePaste: MessageDefinition = {
     },
 };
 
+const ErrorAccessingIndexedDB: MessageDefinition = {
+    ...NoMessage,
+    type: MessageTypes.errorAccessingIndexedDB,
+    message: {
+        path: "messageBannerMessage.errorAccessingIndexedDB",
+        args: {
+            [FormattedMessageArgKeyValuePlaceholders.error.key]: FormattedMessageArgKeyValuePlaceholders.error.placeholderName,
+        },
+    },
+};
+
 
 export const MessageDefinitions = {
     NoMessage,
@@ -1081,6 +1093,7 @@ export const MessageDefinitions = {
     GDriveCantCreateStrypeFolder,
     InvalidPythonParseImport,
     InvalidPythonParsePaste,
+    ErrorAccessingIndexedDB,
 };
 
 //WebUSB listener

--- a/tests/playwright/e2e/storage-model.spec.ts
+++ b/tests/playwright/e2e/storage-model.spec.ts
@@ -2,6 +2,7 @@
 // specifically around storing and restoring the state from browser storage.
 
 import { Page, expect, test } from "@playwright/test";
+import { skipPyodideLoading } from "../support/general";
 
 // Note we don't visit a page in the beforeEach; that is left to individual tests.
 
@@ -44,6 +45,7 @@ async function appendContent(page: Page, paramContent: string) {
 }
 
 async function loadAndWaitForEditor(page: Page) {
+    await skipPyodideLoading(page);
     await page.goto("./", {waitUntil: "load"});
     await page.waitForSelector(".frame-container");
 }

--- a/tests/playwright/e2e/storage-model.spec.ts
+++ b/tests/playwright/e2e/storage-model.spec.ts
@@ -52,6 +52,9 @@ test.describe("Test basic operation", () => {
     test("Test initial fresh load", async ({page}) => {
         await loadAndWaitForEditor(page);
         await assertStartingProject(page);
+        const scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
+        // Check no error showing:
+        await expect(page.locator("." + scssVars.messageBannerContainerClassName)).not.toBeVisible();
     });
 
     test("Test reload on fresh page", async ({page}) => {
@@ -169,5 +172,27 @@ test.describe("Test migration from old system", () => {
         const page2 = await context.newPage();
         await loadAndWaitForEditor(page2);
         await assertStartingProject(page2);
+    });
+});
+
+test.describe("Test IndexedDB failure", () => {
+    test("Failure message when IndexedDB won't open", async ({page, browserName}) => {
+        if (browserName === "webkit") {
+            // Webkit doesn't allow stubbing out the indexedDB.open call, so can't test on that:
+            return;
+        }
+        await page.addInitScript(() => {
+            indexedDB.open = () => {
+                throw new DOMException(
+                    "Simulated failure",
+                    "InvalidStateError"
+                );
+            };
+        });
+        await loadAndWaitForEditor(page);
+        // Now should show error:
+        const scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
+        await expect(page.locator("." + scssVars.messageBannerContainerClassName)).toBeVisible();
+        await expect(page.locator("." + scssVars.messageBannerContainerClassName)).toContainText("Simulated failure");
     });
 });

--- a/tests/playwright/support/general.ts
+++ b/tests/playwright/support/general.ts
@@ -4,6 +4,6 @@ import { Disposable, Page } from "@playwright/test";
 // Useful for tests which don't actually execute the code at all.
 export function skipPyodideLoading(page: Page) : Promise<Disposable> {
     return page.addInitScript(() => {
-        (window as any).TestingNoPyodide = true;
+        sessionStorage.setItem("TestingNoPyodide", "true");
     });
 }


### PR DESCRIPTION
As discussed earlier, add error handling for indexedDB issues along with an error message.  The Playwright test confirms that it does show.

I thought I'd separate this off as a small PR rather than lump it in with the next bit of work about loading old orphaned states.