### PR TITLE
Various UI fixes

### DIFF
--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1687,8 +1687,18 @@ export const parseCodeLiteral = (codeLiteral: string, flags?: {isInsideString?: 
             resStructSlot.operators.push(...structBeforeString.operators, {code: ""}, {code: ""}, ...structAfterString.operators);
         }
         else{
-            // 3 - break the code by operatorSlot
-            const {slots: operatorSplitsStruct, cursorOffset: operatorCursorOffset} = getFirstOperatorPos(codeLiteral, blankedStringCodeLiteral, flags?.frameType??"", flags?.cursorPos);
+            // 3 - break the code by operatorSlot, if we have any media here (that is, strype image placeholders) we need to temporary update the cursor position for that
+            const mediaMatchs = blankedStringCodeLiteral.matchAll(new RegExp(IMAGE_PLACERHOLDER.replaceAll("$", "\\$") + "\\d+\\$", "g"));
+            let mediaCursorPos: null|number = null;
+            if(flags?.cursorPos != undefined && mediaMatchs){
+                mediaCursorPos = flags.cursorPos;
+                mediaMatchs.forEach((match) => {
+                    if((mediaCursorPos as number) > match.index){
+                        (mediaCursorPos as number) += match[0].length;
+                    }
+                });
+            }
+            const {slots: operatorSplitsStruct, cursorOffset: operatorCursorOffset} = getFirstOperatorPos(codeLiteral, blankedStringCodeLiteral, flags?.frameType??"",mediaCursorPos??(flags?.cursorPos));
             cursorOffset += operatorCursorOffset;
             resStructSlot.fields = operatorSplitsStruct.fields;
             resStructSlot.operators = operatorSplitsStruct.operators;

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1756,7 +1756,7 @@ const getFirstOperatorPos = (codeLiteral: string, blankedStringCodeLiteral: stri
         .replaceAll(/(^\s+|\b|[+\-*/%<>&|^=!,]\s*)((\d+(\.\d*)?|\.\d+)[eE][-+]\d+j?)($|(\s*[ +\-*/%<>&|^=!,:]))/g,
             (...params) => blankReplacer(2, ["+", "-"], ...params))
         // Replacing a preceding sign operator
-        .replaceAll(/(^\s*|[+\-*/%<>&|^=!,]\s*)([+-]((0b[01]+)|(0x[0-9A-Fa-f]+)|((\d+(\.\d*)?|\.\d+)([eE]\d+)?j?)))(?=$|(\s*[ +\-*/%<>&|^=!,:]))/g,
+        .replaceAll(new RegExp(String.raw`(^\s*|[+\-*/%<>&|^=!,]\s*|(?:${keywordOperatorsWithSurroundSpaces.map((kw) => kw.trim()).join("|")})\s*)([+-]((0b[01]+)|(0x[0-9A-Fa-f]+)|((\d+(\.\d*)?|\.\d+)([eE]\d+)?j?)))(?=$|(\s*[ +\-*/%<>&|^=!,:]))`, "g"),
             (...params) => blankReplacer(2, ["+", "-"], ...params))
         // Replacing the decimal separator (note: \b is a word boundary)
         .replaceAll(/(\s+|\b|[+\-*/%<>&|^=!,:]\s*)(((\d+(\.\d*))([eE][0]?\d+)?j?))($|(\s*[ +\-*/%<>&|^=!,:]))/g,

--- a/tests/cypress/e2e/structured-expressions-floating.cy.ts
+++ b/tests/cypress/e2e/structured-expressions-floating.cy.ts
@@ -92,6 +92,12 @@ describe("Stride TestExpressionSlot.testFloating()", () => {
     //testBackspace("1.\b.0", "{1$.0}", false, true); // delete before
     //testBackspace("a..\bc", "{a}.{$c}", true, false); // backspace after
     //testBackspace("a.\b.c", "{a$}.{c}", false, true); // delete before
+    
+
+    //Testing unary operators in combination with keyword operators
+    testInsert("-1.2 if var < -5.6 else -4.3", "{-1.2}if{var}<{-5.6}else{-4.3$}");
+    testInsert("-1.2 if -5.6 > var else -4.3", "{-1.2}if{-5.6}>{var}else{-4.3$}");
+    testInsert("-1.2 and -5.6", "{-1.2}and{-5.6$}");
 });
 
 

--- a/tests/playwright/e2e/structured-expressions-media.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-media.spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from "@playwright/test";
-import { typeIndividually, doPagePaste, doTextHomeEndKeyPress, assertStateOfIfFrame, checkFrameXorTextCursor } from "../support/editor";
+import { typeIndividually, doPagePaste, doTextHomeEndKeyPress, assertStateOfIfFrame, checkFrameXorTextCursor, MEDIA_SLOT_PARSED_PLACEHOLDER } from "../support/editor";
 import fs from "fs";
 import {addFakeClipboard} from "../support/clipboard";
 import { skipPyodideLoading } from "../support/general";
@@ -226,5 +226,49 @@ test.describe("Media literal manipulation", () => {
         // Check that the image is still an image (in bug #661, it turned into the text of the load_sound call):
         await expect(page.getByText("load_sound")).not.toBeVisible();
         await expect(page.locator("img[data-code^='load_sound']")).toBeVisible();
+    });
+});
+
+test.describe("Edition in expressions with media",() => {
+    test("With keyword operators (basic)", async ({page}) => {
+        // Write the expression (inside if): <media> or 5
+        await page.keyboard.press("i"),
+        await page.waitForTimeout(200);
+        const image = fs.readFileSync("src/assetsFilesystem/images/cat-test.jpg").toString("base64");
+        const last10B64ImgChars = image.slice(-10);
+        await doPagePaste(page, image, "image/jpeg");
+        await page.waitForTimeout(200);
+        await page.keyboard.type(" and 5");
+        await assertStateOfIfFrame(page, `{}${MEDIA_SLOT_PARSED_PLACEHOLDER.image}{}and{5$}`, [{mediaType: "img", endOfB64: last10B64ImgChars}]);
+    });
+
+    test("With keyword operators (a bit more complex)", async ({page}) => {
+        // Write the expression (inside if): test(<media>, 5 and 6)
+        await page.keyboard.type("itest("),
+        await page.waitForTimeout(200);
+        const image = fs.readFileSync("src/assetsFilesystem/images/cat-test.jpg").toString("base64");
+        const last10B64ImgChars = image.slice(-10);
+        await doPagePaste(page, image, "image/jpeg");
+        await page.waitForTimeout(200);
+        await page.keyboard.type(",5 and 6");
+        await assertStateOfIfFrame(page, `{test}({}${MEDIA_SLOT_PARSED_PLACEHOLDER.image}{},{5}and{6$}){}`, [{mediaType: "img", endOfB64: last10B64ImgChars}]);
+    });
+
+    test("With keyword operators (and 2 media)", async ({page}) => {
+        // Write the expression (inside if): <media1>+<media2> and "abc")
+        await page.keyboard.press("i"),
+        await page.waitForTimeout(200);
+        const mediaInfo: {mediaType: "img" | "snd", endOfB64: string}[] = [];
+        const image = fs.readFileSync("src/assetsFilesystem/images/cat-test.jpg").toString("base64");
+        mediaInfo.push({mediaType: "img", endOfB64: image.slice(-10)});
+        await doPagePaste(page, image, "image/jpeg");
+        await page.waitForTimeout(200);
+        await page.keyboard.type("+");
+        const sound = fs.readFileSync("src/assetsFilesystem/sounds/cat-test-meow.wav").toString("base64");
+        mediaInfo.push({mediaType: "snd", endOfB64: sound.slice(-10)});
+        await doPagePaste(page, sound, "audio/x-wav");
+        await page.waitForTimeout(200);
+        await page.keyboard.type("and \"abc");
+        await assertStateOfIfFrame(page, `{}${MEDIA_SLOT_PARSED_PLACEHOLDER.image}{}+{}${MEDIA_SLOT_PARSED_PLACEHOLDER.sound}{}and{}“abc$”{}`, mediaInfo);
     });
 });

--- a/tests/playwright/support/editor.ts
+++ b/tests/playwright/support/editor.ts
@@ -1,5 +1,13 @@
 import {Page, expect} from "@playwright/test";
 
+// This enumeration is used for the media slots placeholder when parsing slots
+// Don't use "_" in the values as they will be scrapped by the parser later.
+export enum MEDIA_SLOT_PARSED_PLACEHOLDER {
+    unknown="<unknown-media>", // Doesn't match anything of Strype's media, but used for the tests sanity checks
+    image="<media-img>",
+    sound="<media-snd>",
+}
+
 // If the last param is given, we check for frame cursor (true) or text (false)
 // If it's not given, no specific check, just check only one or the other is visible
 export async function checkFrameXorTextCursor(page: Page, specificFrameCursor?: boolean, message?: string) : Promise<void> {
@@ -38,42 +46,83 @@ async function getSelection(page: Page) : Promise<{ id: string, cursorPos : numb
     });
 }
 
-async function assertLabelSlotsContent(page: Page, expectedState: string, isInStatementFrame?: boolean) {
-    const info = await getSelection(page);
+async function assertLabelSlotsContent(page: Page, expectedState: string, options?: {isInStatementFrame?: boolean, mediaInfo?: {mediaType: "img" | "snd", endOfB64: string}[]}) {
+    const info = {...await getSelection(page), mediaClassName: "", media: MEDIA_SLOT_PARSED_PLACEHOLDER};
     const scssVars = await page.evaluate(() => {
         return (window as any)["StrypeSCSSVarsGlobals"];
     });
-    const s = await page.locator("#frameContainer_-3" + " ." + scssVars.frameHeaderClassName).first().locator("." + scssVars.labelSlotInputClassName + ", ." + scssVars.frameColouredLabelClassName).evaluateAll((parts, info: { id: string, cursorPos : number, isInStatementFrame?: boolean }) => {
+
+    // Only parse media if we have indicated any media info (see mediaInfo in options)
+    const s = await page.locator("#frameContainer_-3" + " ." + scssVars.frameHeaderClassName).first().locator(`.${scssVars.labelSlotInputClassName}, .${scssVars.frameColouredLabelClassName}${(options?.mediaInfo) ? (", ." + scssVars.labelSlotMediaClassName) : ""}`).evaluateAll((parts, data) => {
+        const  {info, mediaPlaceHolders, mediaClassName} = data;
         let s = "";
         if (!parts) {
             // Try to debug an occasional seemingly impossible failure:
             console.log("Parts is null which I'm sure shouldn't happen");
         }
         // If we're in a block frame like "if", we ignore the first and last part:
-        const parseOffset = (info.isInStatementFrame) ? 0 : 1;
+        const parseOffset = (info.options?.isInStatementFrame) ? 0 : 1;
+
+        let mediaInfoCounter = 0;
         for (let i = 1; i < parts.length - parseOffset; i++) {
             const p: any = parts[i];
 
             let text = (p.value || p.textContent || "").replace("\u200B", "");
 
+            // Handling of media: we don't make strict comparison for media:
+            // instead, based on mediaInfos, we check the start of the slots based on the media type, 
+            // and the content of the media solely based on a few last characters based on the media info property "endOfB64".
+            // Media appear as <img> in the editor (their representation).
+            let isMediaSlot = false;
+            if(info?.options?.mediaInfo && p.tagName == "IMG" && p.classList.contains(mediaClassName)){
+                isMediaSlot = false;
+                // Fist check the media info array is in line with what we are parsing
+                if(mediaInfoCounter >= info.options.mediaInfo.length){
+                    throw new Error("A media slot has been parsed but it does not match a media info array entry.");
+                }
+                let mediaPlaceHolderText = mediaPlaceHolders.unknown;
+                const {mediaType, endOfB64} = info.options.mediaInfo[mediaInfoCounter];
+                const pDataCode = p.getAttribute("data-code");
+                
+                // Check the media type is in line with the media info
+                const dataCodePreamble = (mediaType == "img") ? "load_image(\"data:image/" : "load_sound(\"data:audio/";
+                if(!pDataCode?.startsWith(dataCodePreamble)){
+                    throw new Error("Did not find the expected media type.");
+                }
+                mediaPlaceHolderText = (mediaType == "img") ? mediaPlaceHolders.image : mediaPlaceHolders.sound;
+                
+                // Check the media content is (loosely) in line with the media info
+                if(!pDataCode.endsWith(endOfB64+"\")")){
+                    throw new Error("Did not find the expected media content ending.");
+                }
+
+                // The checks passed, we can now render the text as expected
+                text += mediaPlaceHolderText;
+                isMediaSlot = true;
+
+                // Increment the counter for the next media we'll parse
+                mediaInfoCounter++;
+            }
+
+
             // If we're the focused slot, put a dollar sign in to indicate the current cursor position:
             if (info.id === p.getAttribute("id") && info.cursorPos >= 0) {
                 text = text.substring(0, info.cursorPos) + "$" + text.substring(info.cursorPos);
             }
-            // Don't put curly brackets around strings, operators or brackets:
-            if (!p.classList.contains((window as any)["StrypeSCSSVarsGlobals"].frameStringSlotClassName) && !p.classList.contains((window as any)["StrypeSCSSVarsGlobals"].frameOperatorSlotClassName) && !/[([)\]$]/.exec(p.textContent)) {
+            // Don't put curly brackets around strings, operators or brackets, or media:
+            if (!p.classList.contains((window as any)["StrypeSCSSVarsGlobals"].frameStringSlotClassName) && !p.classList.contains((window as any)["StrypeSCSSVarsGlobals"].frameOperatorSlotClassName) && !/[([)\]$]/.exec(p.textContent) && !isMediaSlot) {
                 text = "{" + text + "}";
             }
             s += text;
         }
         return s;
-    }, {...info, isInStatementFrame: isInStatementFrame});
+    }, {info: {...info, options: options}, mediaPlaceHolders: MEDIA_SLOT_PARSED_PLACEHOLDER, mediaClassName: scssVars.labelSlotMediaClassName});
     // There is no correspondence for _ (indicating a null operator) in the Strype interface so just ignore that:
     expect(s).toEqual(expectedState.replaceAll("_", ""));
 }
 
-export async function assertStateOfIfFrame(page: Page, expectedState : string) : Promise<void> {
-    await assertLabelSlotsContent(page, expectedState);
+export async function assertStateOfIfFrame(page: Page, expectedState : string, mediaInfo?: {mediaType: "img" | "snd", endOfB64: string}[]) : Promise<void> {
+    await assertLabelSlotsContent(page, expectedState, {mediaInfo});
 }
 
 export async function assertStateOfVarAssignFrame(page: Page, expectedLHSState : string, expectedRHSState: string) : Promise<void> {
@@ -91,7 +140,7 @@ export async function assertStateOfVarAssignFrame(page: Page, expectedLHSState :
     expect(varassignLabelSlotContent).toEqual(" ⇐ ");
     
     // 2 - Check the expected text part:
-    await assertLabelSlotsContent(page, `${expectedLHSState}{ ⇐ }${expectedRHSState}`, true);
+    await assertLabelSlotsContent(page, `${expectedLHSState}{ ⇐ }${expectedRHSState}`, {isInStatementFrame: true});
 }
 
 export async function typeIndividually(page: Page, content: string, timeout = 75) : Promise<void> {


### PR DESCRIPTION
This PR contains 2 fixes (#906 and #907) as mentioned in the commits.
It also adds some feature to include the media slots in our Playwright tests, when we want to check the slots' content.
The idea was to make it as customisable as possible, but avoid a heavy test on the media itself.
So it checks for a valid media slot based on the test's content, and check types and part of the media's base64 matches.