### PR TITLE
Fix prints queueing for long time after execution

### DIFF
--- a/src/stryperuntime/main_bridge_handler.ts
+++ b/src/stryperuntime/main_bridge_handler.ts
@@ -34,6 +34,9 @@ export const handleSyncRequests : (
     callbacks : SyncRequestCallbacks,
 ) => SyncPromiseStrypePyodideHandlerFunction = (renderer, soundManager, turtle, callbacks) => (req) => {
     switch (req.request) {
+    case "dummy": {
+        return {request: req.request, response: Promise.resolve(true)};
+    }
     case "console_input": {
         return {request: req.request, response: sInput()};
     }

--- a/src/stryperuntime/worker_bridge_type.ts
+++ b/src/stryperuntime/worker_bridge_type.ts
@@ -43,6 +43,7 @@ import { Expect, IsSerializable } from "@/stryperuntime/check_serializable";
 export type CloudFileInfo = {fileId: CloudFileId, name: string; isDir: true;} | {fileId: CloudFileId, name: string; isDir: false; fileSize: number};
 
 export type SyncStrypePyodideWorkerRequest =
+    | { request: "dummy" } // No-op request used to make sure we haven't raced too far ahead of main thread
     | { request: "console_input" }    
     | { request: "loadImage"; url: string }
     | { request: "loadLibraryAsset"; libraryShortName: string; fileName: string }
@@ -81,6 +82,7 @@ export type SyncStrypePyodideWorkerRequest =
 // Note that if there is an error, it is sent with an "error" string field; we can't easily specify this in the type without
 // cluttering it up (as the error could be for any request) so we do that part dynamically without telling Typescript.
 export type SyncStrypePyodideWorkerResponse =
+    | { request: "dummy"; response: boolean; }
     | { request: "console_input"; response: string; }
     | { request: "loadImage"; response: RemoteImage;}
     | { request: "loadLibraryAsset"; response: string | undefined; }

--- a/src/workers/python-execution.ts
+++ b/src/workers/python-execution.ts
@@ -137,8 +137,40 @@ const executePython = pyodideExpose(async (
     userLibrariesFileIndexes: { [url: string]: Record<string, string>},
     startInSlashCloud: boolean,
     // Important all requests (sync and async) go through one function to avoid them racing each other:
-    makeRequest: Comlink.Remote<(req: SyncOrAsyncStrypePyodideWorkerRequest) => void>
+    makeRawRequest: Comlink.Remote<(req: SyncOrAsyncStrypePyodideWorkerRequest) => void>
 ) : Promise<PyodideErrorDetails | null> => {
+    // There is a potential issue with async requests that if we have a tight loop
+    // (e.g. while True: print("a")) then we can issue requests faster than the main
+    // thread can service them.  If we send an unlimited number of async requests without ever
+    // waiting for them to complete, they can all queue up, and even if the user clicks Stop,
+    // these requests can keep being serviced for a long time (tens of seconds!) after Stop is clicked.
+    // This is only an issue with consecutive async requests; any sync request where we have to wait
+    // will effectively also synchronise with the main thread because the sync request will only
+    // be answered after the previous async requests have all been processed.
+    //
+    // To avoid problems with many consecutive async requests, we count them, and every 50 requests
+    // we do a dummy sync request just to make sure we haven't gotten too far ahead of the main thread:
+    let numConsecutiveAsyncRequests = 0;
+    const makeRequest = (req: SyncOrAsyncStrypePyodideWorkerRequest) => {
+        if (req.kind === "sync") {
+            numConsecutiveAsyncRequests = 0;
+        }
+        else {
+            numConsecutiveAsyncRequests += 1;
+            if (numConsecutiveAsyncRequests >= 50) {
+                // To avoid racing too far ahead of the main thread, we do a quick catch-up:
+                makeRawRequest({kind: "sync", request: {request: "dummy"}});
+                const reply = extras.readMessage() as (SyncStrypePyodideWorkerResponse | {request: string, error: string});
+                if (reply.request != "dummy") {
+                    throw new Error(`Internal error: Pyodide worker received ${reply.request} but had asked for dummy`);
+                }
+                numConsecutiveAsyncRequests = 0;
+            }
+        }
+        // All requests are ultimately sent on:
+        makeRawRequest(req);
+    };
+    
     return reloader == null ? null : await reloader.withPyodide(async (pyodide : PyodideInterface) => {
         // Load any in-built packages they've used (e.g. numpy, pandas):
         const loaded = await pyodide.loadPackagesFromImports(pythonCode, {messageCallback: console.log, errorCallback: console.error});

--- a/tests/playwright/e2e/console-execution.spec.ts
+++ b/tests/playwright/e2e/console-execution.spec.ts
@@ -258,3 +258,53 @@ TypeError: object of type 'NoneType' has no len()
 `);
     });
 });
+
+test.describe("Check console prints don't queue up after stopping", () => {
+    for (let runTime of [3, 10, 30]) {
+        test(`Check console stops printing time within seconds of stopping after running for ${runTime} seconds`, async ({page}) => {
+            await enterCode(page, ["from time import time", "", `
+i = 0
+while True:
+    print(time())`]);
+            const runButton = await startRunning(page, true);
+            await page.waitForTimeout(runTime * 1000);
+            // We fetch the console content:
+            let consoleValue = await page.locator("#peaConsole").inputValue();
+            // Ignore the last line because there is a chance it was incomplete; look at the one before:
+            const lastNumberWhileRunning = Number(consoleValue.split("\n")?.at(-2)?.trim());
+            // Now we stop:
+            await runButton.click();
+            await runButtonShowsRun(runButton, true);
+            // Wait for slush to print if there was some (shouldn't be, but that's what we're testing...):
+            await page.waitForTimeout(10_000);
+            // Then check the last actual printed line:
+            consoleValue = await page.locator("#peaConsole").inputValue();
+            const lastNumberAfterStopping = Number(consoleValue.split("\n")?.at(-2)?.trim());
+            // Should have stopped printing within 2 seconds:
+            expect(lastNumberAfterStopping).toBeLessThan(lastNumberWhileRunning + 2);
+        });
+
+        test(`Check console stops printing literal within seconds of stopping after running for ${runTime} seconds`, async ({page}) => {
+            await enterCode(page, ["", "", `
+while True:
+    print("Hi")`]);
+            const runButton = await startRunning(page, true);
+            await page.waitForTimeout(runTime * 1000);
+            // We fetch the console content:
+            let consoleValue = await page.locator("#peaConsole").inputValue();
+            // Divide by 3 ("Hi\n".length) to get lines:
+            const lengthWhileRunning = consoleValue.length / 3;
+            const linesPerSecond = lengthWhileRunning / runTime;
+            // Now we stop:
+            await runButton.click();
+            await runButtonShowsRun(runButton, true);
+            // Wait for slush to print if there was some (shouldn't be, but that's what we're testing...):
+            await page.waitForTimeout(10_000);
+            // Then check the last actual printed line:
+            consoleValue = await page.locator("#peaConsole").inputValue();
+            const lengthAfterStopping = consoleValue.length / 3;
+            // Should have stopped printing soon after (within 2 seconds' worth):
+            expect(lengthAfterStopping).toBeLessThan(lengthWhileRunning + linesPerSecond * 2);
+        });
+    }
+});


### PR DESCRIPTION
Previously there was an issue that prints in a tight loop could queue up indefinitely during execution.  This turned out to be a bit more awkward to fix than I'd thought but I think I found a relatively understandable way to do it, as explained in the comments in the code.

Fixes #909 