### PR TITLE
Fix an issue with new project

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1054,6 +1054,9 @@ export default defineComponent({
                     if (typeof(Storage) !== "undefined") {
                         sessionStorage.removeItem(AutoSaveKeyNames.strypeEditorTabId);
                     }
+                    // We need to set this flag so that the browser doesn't then show a "Leave page" dialog because
+                    // the project is modified
+                    this.appStore.isEditorContentModified = false;
                     // ... and reload the page to reload the Strype default project (removing potential query parameters)
                     window.location.href = window.location.pathname + "?" + newStrypeProject;
                 }


### PR DESCRIPTION
Very tiny PR to fix a specific issue.  When you made a new project, the browser would show its confirmation dialog, because it counted the project as modified even though the user had clicked Ok on our own confirmation dialog.