### PR TITLE
Assorted small fixes

### DIFF
--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1360,8 +1360,7 @@ export default defineComponent({
                                 pastedInvalidCode = true;
                             }
                             else{
-                                const isSimpleImport = (this.frameType == AllFrameTypesIdentifier.import);
-                                if(tempSlots.operators.some((operator) => operator.code != "," && operator.code != "." && (!isSimpleImport || (isSimpleImport && operator.code != "as")))){
+                                if(tempSlots.operators.some((operator) => operator.code != "," && operator.code != "." && operator.code != "as")){
                                     pastedInvalidCode = true;
                                 }
                             }

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -8,6 +8,8 @@
             <!-- IMPORTANT: keep this div with "invisible" text for proper layout rendering, it replaces the tabs -->
             <span v-if="!isTabsLayout" :class="scssVars.peaNoTabsPlaceholderSpanClassName">c+g</span>
             <div class="flex-padding"/>            
+            <span v-if="peaDisplayTabIndex == 0 && !isPythonExecuting && mouseCoordsToShow" class="pea-hover-coords">{{mouseCoordsToShow}}</span>
+            <div class="flex-padding"/>
             <button id="runButton" ref="runButton" class="pea-controls-button" @click="runClicked" :title="$t((isPythonExecuting) ? 'PEA.stop' : 'PEA.run') + ' (Ctrl+Enter)'" :class="{highlighted: highlightPythonRunningState}" :disabled="!isPythonWorkerReady">
                 <img v-if="!isPythonExecuting" :src="faviconURL" class="pea-play-img">
                 <span v-else class="python-running">{{runCodeButtonIconText}}</span>
@@ -21,7 +23,7 @@
                 <Splitpanes :horizontal="!isExpandedPEA" @resize="onSplitterPane1Resize">
                     <pane :id="graphicsSplitPaneId" key="1" v-show="isGraphicsAreaShowing" :size="(isTabsLayout) ? 100 : currentSplitterPane1Size" min-size="5">
                         <div :id="graphicsContainerDivId" @wheel.stop :class="{'pea-graphics-container': true, hidden: graphicsTemporaryHidden}" @contextmenu="handleContextMenu">
-                            <canvas id="pythonGraphicsCanvas" ref="pythonGraphicsCanvas" @mousedown.stop="graphicsCanvasMouseDown" @mouseup.stop="graphicsCanvasMouseUp" @mousemove="graphicsCanvasMouseMove"></canvas>
+                            <canvas id="pythonGraphicsCanvas" ref="pythonGraphicsCanvas" @mousedown.stop="graphicsCanvasMouseDown" @mouseup.stop="graphicsCanvasMouseUp" @mousemove="graphicsCanvasMouseMove" @mouseleave="graphicsCanvasMouseExit"></canvas>
                         </div>
                     </pane>
                     <pane key="2" v-show="isConsoleAreaShowing" :size="(isTabsLayout) ? 100 : (100 - currentSplitterPane1Size)" min-size="5">
@@ -216,6 +218,7 @@ export default defineComponent({
             // Prepare an empty version of the menu: it will be updated as required in handleClick()
             frameContextMenuItems: [] as StrypeContextMenuItem[],
             showContextMenuAtCoordPos: {x: 0, y: 0} as CoordPosition,
+            mouseCoordsToShow: undefined as string | undefined,
             graphicsOverride: null as {background: OffscreenCanvas | HTMLImageElement, imageToShowCentered: OffscreenCanvas | HTMLImageElement} | null,
         };
     },
@@ -1049,7 +1052,14 @@ export default defineComponent({
                 adjustedY >= -graphicsCanvasLogicalHeight / 2 && adjustedY <= graphicsCanvasLogicalHeight / 2 - 1) {
                 mostRecentMouseDetails.x = adjustedX;
                 mostRecentMouseDetails.y = adjustedY;
+                this.mouseCoordsToShow = "(" + Math.round(mostRecentMouseDetails.x) + ", " + Math.round(mostRecentMouseDetails.y) + ")";
             }
+            else {
+                this.mouseCoordsToShow = undefined;
+            }
+        },
+        graphicsCanvasMouseExit(event: MouseEvent) {
+            this.mouseCoordsToShow = undefined;
         },
         graphicsCanvasMouseUp(event: MouseEvent) {
             if (event.button < mostRecentMouseDetails.buttonsPressed.length) {
@@ -1340,6 +1350,11 @@ export default defineComponent({
     .pea-graphics-div {
         background-color: white;
         outline: none;
+    }
+    
+    .pea-hover-coords {
+        font-size: 90%;
+        color: #333;
     }
     
     .pea-no-graphics-import-span {

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -421,7 +421,7 @@ export function getFrameLabelSlotLiteralCodeAndFocus(frameLabelStruct: HTMLEleme
                 const spanElementContentLength = (spanElement.textContent?.replace(/\u200B/g, "")?.length??0);
                 // Note that sometimes the frameId is unavailable (-100) so the frame object may not be available, hence we need ?. when accessing it:
                 const frameType : string | undefined = useStore().frameObjects[parseLabelSlotUID(spanElement.id).frameId]?.frameType?.type;
-                const ignoreAsKW = (spanElement.textContent == "as" && frameType != AllFrameTypesIdentifier.import && frameType != AllFrameTypesIdentifier.except);
+                const ignoreAsKW = (spanElement.textContent == "as" && frameType != AllFrameTypesIdentifier.import && frameType != AllFrameTypesIdentifier.fromimport && frameType != AllFrameTypesIdentifier.except);
                 if(!ignoreAsKW && !isSlotStringLiteralType(labelSlotCoreInfos.slotType) && (trimmedKeywordOperators.includes(spanElement.textContent??""))){
                     spacesOffset = 2;
                     // Reinsert the spaces in the literal code
@@ -1778,7 +1778,7 @@ const getFirstOperatorPos = (codeLiteral: string, blankedStringCodeLiteral: stri
         // - "as" is only relevant for import frames, we ignore it otherwise
         const isInFromImportFrame = (frameType == AllFrameTypesIdentifier.fromimport);
         const isInImportFrame = (frameType == AllFrameTypesIdentifier.import);
-        const operatorPosList : OpFound[] = ((isInFromImportFrame) ? allOperators.filter((opDef) => !opDef.match.includes("*") && opDef.match != " as ") : allOperators.filter((opDef) => isInImportFrame || opDef.match != " as "))
+        const operatorPosList : OpFound[] = ((isInFromImportFrame) ? allOperators.filter((opDef) => !opDef.match.includes("*")) : allOperators.filter((opDef) => isInImportFrame || opDef.match != " as "))
             .flatMap((operator : OpDef) => {
                 if (operator.keywordOperator) {
                     // "g" flag is necessary to make it obey the lastIndex item as a place to start:

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -1070,7 +1070,10 @@ function copyFramesFromPython(p: ParsedConcreteTree, s : CopyState) : CopyState 
                     s = addFrame(makeFrame(AllFrameTypesIdentifier.library, {0: {slotStructures: {fields: [{code: library}], operators: []}}}, s.isSPY), p.lineno, s);
                 }
                 else if (slots.fields.length == 1 && (slots.fields[0] as BaseSlot)?.code && (slots.fields[0] as BaseSlot).code === STRYPE_WHOLE_LINE_BLANK) {
-                    s = addFrame(makeFrame(AllFrameTypesIdentifier.blank, {}, s.isSPY), p.lineno, s);
+                    // Blanks are not allowed directly inside class defs:
+                    if (s.parent?.frameType.type != AllFrameTypesIdentifier.classdef) {
+                        s = addFrame(makeFrame(AllFrameTypesIdentifier.blank, {}, s.isSPY), p.lineno, s);
+                    }
                 }
                 else {
                     // Everything else goes in method call:

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -930,12 +930,9 @@ function toSlots(p: ParsedConcreteTree) : SlotsStructure {
             throw new Error("Cannot find operator " + ps.nextIndex + " in:\n" + debugToString(p, ""), {cause: err});
         }
         if (op != null && (operators.includes(op) || trimmedKeywordOperators.includes(op))) {
-            if (op == ":" && ps.nextIndex == ps.seq.length) {
-                // Can be blank on RHS of colon
+            if ((op == ":" || op == ",") && ps.nextIndex == ps.seq.length) {
+                // Can be blank on RHS of colon or comma
                 latest = concatSlots(latest, op, {fields: [{code: ""}], operators: []});
-            }
-            else if (op == "," && ps.nextIndex == ps.seq.length) {
-                // Can have a trailing comma with nothing following; ignore
             }
             else {
                 latest = concatSlots(latest, op, parseNextTerm(ps));

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -697,7 +697,7 @@ function parseNextTerm(ps : ParseState) : SlotsStructure {
         ps.nextIndex += 1;
         return concatSlots({fields: [{code: ""}], operators: []}, nextVal, parseNextTerm(ps));
     }
-    if (nextVal === "not" || nextVal === ":") {
+    if (nextVal === "not" || nextVal === ":" || nextVal === "*") {
         ps.nextIndex += 1;
         return concatSlots({fields: [{code: ""}], operators: []}, nextVal, parseNextTerm(ps));
     }

--- a/src/workers/python-execution.ts
+++ b/src/workers/python-execution.ts
@@ -277,6 +277,9 @@ if ${usingMatplotlib ? "True" : "False"}:
             def show(self):
                 _figure_renderer_pyodide.render_current_figure(self.canvas.figure)
                 
+            @classmethod
+            def start_main_loop():
+                
                 # Now run a main loop:
                 x, y = -1, -1
                 import strype.graphics as g
@@ -442,7 +445,6 @@ runner`);
                 // So no need to scale.
                 
                 // Then add it as a sprite (default 0, 0 position is fine):
-                console.log("Plot size: " + image.width + " x " + image.height);
                 matPlotLibSpriteId = self.spriteManager.addSprite(image, false);
                 return [image.width, image.height];
             }

--- a/src/workers/python-execution.ts
+++ b/src/workers/python-execution.ts
@@ -283,13 +283,20 @@ if ${usingMatplotlib ? "True" : "False"}:
                 from matplotlib.backend_bases import MouseEvent, KeyEvent
                 while True:
                     fig = self.canvas.figure
+                    render_w, render_h = fig.canvas.get_width_height()
+                    scale_x = render_w / 800
+                    scale_y = render_h / 600
                     x2, y2, _, _, _ = g.get_mouse()
                     if x != x2 or y != y2:
                         x, y = x2, y2
-                        render_w, render_h = fig.canvas.get_width_height()
-                        scale_x = render_w / 800
-                        scale_y = render_h / 600
                         self.canvas.callbacks.process("motion_notify_event", MouseEvent("motion_notify_event", self.canvas, (x + 400) * scale_x, (y + 300) * scale_y))
+                    # Strype's API doesn't give us press and release, but it does give clicks so we turn that into press with immediate release:
+                    c = g.get_mouse_click()
+                    if c is not None:
+                        xc, yc, button, clicks = c
+                        # Picking is done automatically when handling these events:
+                        self.canvas.callbacks.process("button_press_event", MouseEvent("button_press_event", self.canvas, (x + 400) * scale_x, (y + 300) * scale_y, button=button + 1, dblclick=clicks==2))
+                        self.canvas.callbacks.process("button_release_event", MouseEvent("button_release_event", self.canvas, (x + 400) * scale_x, (y + 300) * scale_y, button=button + 1))
                     g.pace()
     
         # Tell the canvas which manager class to use. This has to be set

--- a/src/workers/python-execution.ts
+++ b/src/workers/python-execution.ts
@@ -233,33 +233,86 @@ runner = StrypePyodideRunner()
 if ${usingMatplotlib ? "True" : "False"}:
     try:
         import matplotlib
-        # Must set backend before importing pyplot:
-        matplotlib.use("Agg", force=True)
+        matplotlib.use("Agg", force=True)  # placeholder, overridden below
     
-        # workaround from https://github.com/pyodide/pyodide/issues/1518
+        import sys
+        import types
         import base64
         from io import BytesIO
     
-        import matplotlib.pyplot
+        from matplotlib.backend_bases import FigureManagerBase, _Backend
+        from matplotlib.backends.backend_agg import FigureCanvasAgg
     
-        def show():
-            fig = matplotlib.pyplot.gcf()
-            # Current figure size in inches
-            w_in, h_in = fig.get_size_inches()
-            # Compute DPI that fits within bounds:
-            dpi = min(800 / w_in, 600 / h_in)
+        class FigureRendererPyodide:        
+            def render_current_figure(self, fig):            
+                w_in, h_in = fig.get_size_inches()
+                dpi = min(800 / w_in, 600 / h_in)
+    
+                buf = BytesIO()
+                fig.savefig(buf, format="png", dpi=dpi) #, bbox_inches="tight")
+                buf.seek(0)
+                img = "data:image/png;base64," + base64.b64encode(buf.read()).decode("utf-8")
+    
+                self.cur_width, self.cur_height = runner.callback("matplotlib_img", data=img)
+
+        _figure_renderer_pyodide = FigureRendererPyodide()
+    
+        class FigureCanvasPyodide(FigureCanvasAgg):
+            """Canvas class — rendering is inherited from Agg."""
+            def draw(self):
+                # Actually rasterize the figure (this is what FigureCanvasAgg.draw normally does)
+                super().draw()
+                # Now push it out, same as show() does
+                _figure_renderer_pyodide.render_current_figure(self.figure)
         
-            buf = BytesIO()
-            matplotlib.pyplot.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
-            buf.seek(0)
-            # encode to a base64 str
-            img = "data:image/png;base64," + base64.b64encode(buf.read()).decode("utf-8")
-            matplotlib.pyplot.clf()
-            runner.callback("matplotlib_img", data=img)
+            def draw_idle(self):
+                # draw_idle is what most interactive matplotlib code calls
+                # (widgets, event handlers, animations) instead of draw()
+                # directly, so route it through the same path.
+                self.draw()
     
-        matplotlib.pyplot.show = show
+        class FigureManagerPyodide(FigureManagerBase):
+            """Manager class — this is where plt.show() ends up."""
+    
+            def show(self):
+                _figure_renderer_pyodide.render_current_figure(self.canvas.figure)
+                
+                # Now run a main loop:
+                x, y = -1, -1
+                import strype.graphics as g
+                from matplotlib.backend_bases import MouseEvent, KeyEvent
+                while True:
+                    fig = self.canvas.figure
+                    x2, y2, _, _, _ = g.get_mouse()
+                    if x != x2 or y != y2:
+                        x, y = x2, y2
+                        render_w, render_h = fig.canvas.get_width_height()
+                        scale_x = render_w / 800
+                        scale_y = render_h / 600
+                        self.canvas.callbacks.process("motion_notify_event", MouseEvent("motion_notify_event", self.canvas, (x + 400) * scale_x, (y + 300) * scale_y))
+                    g.pace()
+    
+        # Tell the canvas which manager class to use. This has to be set
+        # after both classes are defined, since FigureCanvasPyodide is
+        # declared before FigureManagerPyodide exists.
+        FigureCanvasPyodide.manager_class = FigureManagerPyodide
+    
+        sys.modules["pyodide_mpl_backend"] = types.ModuleType("pyodide_mpl_backend")
+    
+        @_Backend.export
+        class _BackendPyodide(_Backend):
+            __module__ = "pyodide_mpl_backend"
+            FigureCanvas = FigureCanvasPyodide
+            FigureManager = FigureManagerPyodide
+    
+        matplotlib.use("module://pyodide_mpl_backend")
+    
+        import matplotlib.pyplot as plt  # import *after* matplotlib.use()
+    
     except ModuleNotFoundError:
         pass
+    except Exception as e:
+        print(e)
 
 # Now return the runner object:
 runner`);
@@ -382,7 +435,9 @@ runner`);
                 // So no need to scale.
                 
                 // Then add it as a sprite (default 0, 0 position is fine):
+                console.log("Plot size: " + image.width + " x " + image.height);
                 matPlotLibSpriteId = self.spriteManager.addSprite(image, false);
+                return [image.width, image.height];
             }
             else {
                 // We don't currently handle any other callbacks

--- a/tests/cypress/e2e/paste-python.cy.ts
+++ b/tests/cypress/e2e/paste-python.cy.ts
@@ -31,6 +31,10 @@ describe("Python round-trip", () => {
         // ** binds tighter than unary -, hence the space before:
         "raise foo**-6.7**False**True**'bye'\n",
         "try:\n    x = 0\nexcept:\n    x = 1\n",
+        // Expand operator:
+        "f(*a)\n",
+        "x = [*a]\n",
+        "first,*rest = x\n",
     ];
     for (const basic of basics) {
         // Since basics paste code from the default state, we need to include the default project documentation to the code

--- a/tests/cypress/e2e/paste-python.cy.ts
+++ b/tests/cypress/e2e/paste-python.cy.ts
@@ -35,6 +35,9 @@ describe("Python round-trip", () => {
         "f(*a)\n",
         "x = [*a]\n",
         "first,*rest = x\n",
+        // Single element tuples (made using a trailing comma in a bracket):
+        "(x,) = a\n",
+        "print((100,))\n",        
     ];
     for (const basic of basics) {
         // Since basics paste code from the default state, we need to include the default project documentation to the code

--- a/tests/playwright/e2e/graphics.spec.ts
+++ b/tests/playwright/e2e/graphics.spec.ts
@@ -604,7 +604,7 @@ matplotlib.pyplot.ylabel("Y axis")
 matplotlib.pyplot.title("Simple Matplotlib Graph")
 
 # Show the graph
-matplotlib.pyplot.show()
+matplotlib.pyplot.show(block=False)
 `);
 
         await runToFinish(page, true);
@@ -648,7 +648,7 @@ for ax, (title, y) in zip(axes, plots):
 # Overall figure title
 fig.suptitle("Multi-panel Matplotlib Example", fontsize=16)
 
-plt.show()        
+plt.show(block=False)        
 `);
 
         await runToFinish(page, true);


### PR DESCRIPTION
This will make most sense by commit, I think.  It has various small fixes, some of which were bugs I noticed while trying to get matplotlib interactivity working, as I was pasting in example code from their website.

Features added:
 - Added the (x, y) in the PEA header while hovering over the graphics canvas while not executing.
 - Added mouse support to matplotlib, it now responds to mouse move and click events (may need more improvement in future; we don't currently have useful APIs for mouse drags or listening to all keys without blocking, maybe we want new public or private APIs for this)

Parsing/pasting bugs/features:
 - Support for * as unary operator, this is for parameter expanding, e.g. "f(*a)"
 - Fixed trailing commas being discarded, Python uses these for single item tuples, e.g. "(a,)"
 - Don't allow blanks to be pasted in a class def since you're not allowed to insert them there
 - Allow "as" in from import, e.g. "from a import b as c"