### PR TITLE
Cloud pyodide improvements

### DIFF
--- a/docs-sphinx/source/index.rst
+++ b/docs-sphinx/source/index.rst
@@ -59,6 +59,8 @@ Module strype.builtins
   .. container:: module-content
       
     Note that everything from this module is automatically imported so you should not ever need to import it yourself.  For example, if you want to call `clear_console()` you can just call it, without needing to add an import.
+    
+    ⚠️The content of this module is only available on the standard version of Strype.
 
     .. automodule:: strype.builtins
        :members:

--- a/pysrc/strype/builtins.py
+++ b/pysrc/strype/builtins.py
@@ -9,3 +9,13 @@ def clear_console():
     """
     _strype_input_internal.clearConsole()
 
+def get_connected_cloud():
+    # type: () -> str | None
+    """
+    Use this function to check the Cloud provider name where this Strype project lives.
+    (Currently, the Cloud providers Strype supports are `"Google Drive"` and `"Microsoft OneDrive"`.) 
+
+    :return: The name of the Cloud provider where this Strype project lives, `None` if the Strype project does not live on the Cloud.
+    """
+    return _strype_input_internal.getCurrentCloudName()
+

--- a/src/autocompletion/python-api.json
+++ b/src/autocompletion/python-api.json
@@ -15026,6 +15026,14 @@
                 "function"
             ],
             "version": 0
+        },
+        {
+            "acResult": "get_connected_cloud",
+            "documentation": "Use this function to check the Cloud provider name where this Strype project lives.\n(Currently, the Cloud providers Strype supports are `\"Google Drive\"` and `\"Microsoft OneDrive\"`.) \n\n:return: The name of the Cloud provider where this Strype project lives, `None` if the Strype project does not live on the Cloud.",
+            "type": [
+                "function"
+            ],
+            "version": 0
         }
     ],
     "strype.graphics": [

--- a/src/stryperuntime/main_bridge_handler.ts
+++ b/src/stryperuntime/main_bridge_handler.ts
@@ -195,6 +195,8 @@ export const handleSyncRequests : (
     }
     case "getCurrentCloudName":
         let cloudName = undefined;
+        // The following values are directly returned to the user code, so we should NOT modify them in the future
+        // to prevent any incompatibility within the older user programs which may have used them...
         switch (useStore().syncTarget) {
         case StrypeSyncTarget.gd:
             cloudName = "Google Drive";

--- a/src/stryperuntime/main_bridge_handler.ts
+++ b/src/stryperuntime/main_bridge_handler.ts
@@ -12,6 +12,7 @@ import {useStore} from "@/store/store";
 import { handleTurtle, TurtlePixiHandler } from "@/stryperuntime/turtle_pixi_handler";
 import { sInput } from "@/helpers/execPythonCode";
 import {getRawFileFromLibraries} from "@/helpers/libraryManager";
+import { StrypeSyncTarget } from "@/types/types";
 
 // These are callbacks passed from PythonExecutionArea.vue to do things that are tied to the DOM or wider Strype state.
 // This means we don't have to make reference to the PythonExecutionArea component itself.
@@ -192,6 +193,19 @@ export const handleSyncRequests : (
             return {request: req.request, response: Promise.reject("The turtle rendering failed to initialise.  Try refreshing the page or using a different browser.")};
         }
     }
+    case "getCurrentCloudName":
+        let cloudName = undefined;
+        switch (useStore().syncTarget) {
+        case StrypeSyncTarget.gd:
+            cloudName = "Google Drive";
+            break;
+        case StrypeSyncTarget.od:
+            cloudName = "Microsoft OneDrive";
+            break;
+        default:
+            break;
+        }
+        return {request: req.request, response: Promise.resolve(cloudName)};
     default:
         // Trick to give a compile-time error if a case is missing above:
         const _exhaustive: never = req;

--- a/src/stryperuntime/pyodide-emscripten-cloud-fs.ts
+++ b/src/stryperuntime/pyodide-emscripten-cloud-fs.ts
@@ -98,6 +98,11 @@ export function getFSForEmscripten(pyodide: PyodideAPI) : EmscriptenFileSystemPl
             return content.length;
         },
         write(stream: FSStream, buffer: Uint8Array | Int8Array, offset: number, length: number, position: number): number {
+            if (stream.flags & stream.isAppend && stream.node.size) {
+                // Very strangely, stream.isAppend returns the flag value rather than a boolean.
+                // When the file opened in append mode, the position 0 is against the end of file.
+                position = stream.node.size;
+            }
             // It seems Pyodide/Emscripten can give an Int8Array so we must convert to make the bytes in 0-255 range before encoding to string:
             const u8 = new Uint8Array(buffer.buffer, offset, length);
             syncBridge({request: "file_write", id: stream.node.strypeCloudFileId, from: position, encodedContent: encodeUint8ToString(u8), filePath: getFullFilePath(stream.node)});

--- a/src/stryperuntime/pyodide-emscripten-cloud-fs.ts
+++ b/src/stryperuntime/pyodide-emscripten-cloud-fs.ts
@@ -98,7 +98,7 @@ export function getFSForEmscripten(pyodide: PyodideAPI) : EmscriptenFileSystemPl
             return content.length;
         },
         write(stream: FSStream, buffer: Uint8Array | Int8Array, offset: number, length: number, position: number): number {
-            if (stream.flags & stream.isAppend && stream.node.size) {
+            if ((stream.flags & stream.isAppend) != 0 && stream.node.size) {
                 // Very strangely, stream.isAppend returns the flag value rather than a boolean.
                 // When the file opened in append mode, the position 0 is against the end of file.
                 position = stream.node.size;

--- a/src/stryperuntime/strype_graphics_input_internal.ts
+++ b/src/stryperuntime/strype_graphics_input_internal.ts
@@ -1,6 +1,7 @@
 // This file contains the internal mouse+keyboard input API for the Strype graphics world.
 // These functions are not directly exposed to users, but are used by graphics.py to
 // form the actual public API.
+// It also contains (for ease) the Strype builtins internals.
 import { asyncBridge, PyodideWorkerGlobalScope, syncBridge } from "@/workers/python_execution_type";
 import { SpriteHandle } from "@/stryperuntime/worker_bridge_type";
 
@@ -56,6 +57,16 @@ export function setCollidable(id : number, collidable : boolean) : void {
     globalThis.spriteManager.setSpriteCollidable(id, collidable);
 }
 
+/**
+ * Strype builtins related content.
+ * We keep it for now as there are very few elements.
+ */
+
 export function clearConsole() : void {
     asyncBridge({request: "console_clear"});
 }
+
+export function getCurrentCloudName() : string | undefined {
+    return syncBridge({request: "getCurrentCloudName"});
+} 
+// end Strype builtins

--- a/src/stryperuntime/worker_bridge_type.ts
+++ b/src/stryperuntime/worker_bridge_type.ts
@@ -76,6 +76,7 @@ export type SyncStrypePyodideWorkerRequest =
     | { request: "file_getRoot"; }
     | { request: "assetFile_fetch"; url: string }
     | { request: "libraryFile_fetch"; libraryURL: string; filename: string; }    
+    | { request: "getCurrentCloudName"; }
 ;
 
 // All types above should map into this type:
@@ -115,6 +116,7 @@ export type SyncStrypePyodideWorkerResponse =
     | { request: "file_getRoot"; response: CloudFileId }
     | { request: "assetFile_fetch"; response: string }
     | { request: "libraryFile_fetch"; response: string }
+    | { request: "getCurrentCloudName"; response: string | undefined }
 ;
 
 // Wraps the response field of a type in a promise:

--- a/tests/cypress/e2e/autocomplete.cy.ts
+++ b/tests/cypress/e2e/autocomplete.cy.ts
@@ -22,12 +22,14 @@ describe("Built-ins", () => {
             checkExactlyOneItem(acIDSel, BUILTIN, "AssertionError()");
             // We had a previous bug with multiple sum items in microbit:
             checkExactlyOneItem(acIDSel, BUILTIN, "sum(iterable, start)");
-            // Should show our built-in, clear_console, but not in microbit:
+            // Should show our built-in, clear_console and get_connected_cloud, but not in microbit:
             if (Cypress.env("mode") === "microbit") {
                 checkNoItems(acIDSel, "clear_console");
+                checkNoItems(acIDSel, "get_connected_cloud");
             }
             else {
                 checkExactlyOneItem(acIDSel, BUILTIN, "clear_console()");
+                checkExactlyOneItem(acIDSel, BUILTIN, "get_connected_cloud()");
             }
             checkExactlyOneItem(acIDSel, BUILTIN, "ZeroDivisionError()");
             checkExactlyOneItem(acIDSel, BUILTIN, "zip()");

--- a/tests/playwright/e2e/fileIO.spec.ts
+++ b/tests/playwright/e2e/fileIO.spec.ts
@@ -115,12 +115,13 @@ with open("/tmp/test.txt")  as f  :
 
     test("Read+Write an existing file", async ({page}) => {
         await copyAssetInTemp("/books/fairy-tales.txt", "test.txt")(page);
-        // First seek: +3 (BOM) +2 (the first line break) + 2 (position for "A |certain king" where | is the cursor)
+        // First seek: +3 (BOM) +2 or +1 (the first line break on Windows or Linux) + 2 (position for "A |certain king" where | is the cursor)
         // Second seek: same except the last +2
+        const firstLinebreakOSOffset = (process.platform === "win32") ? 1 : 0;
         const writeAndReadCode =`with open("/tmp/test.txt","r+", encoding="utf-8-sig")  as f3  :
-    f3.seek(7) 
+    f3.seek(6+${firstLinebreakOSOffset}) 
     f3.write("great Strype") 
-    f3.seek(5) 
+    f3.seek(4+${firstLinebreakOSOffset}) 
     print(f3.read(250)+"|")
     `;
         await doPagePaste(page, writeAndReadCode);

--- a/tests/playwright/e2e/fileIO.spec.ts
+++ b/tests/playwright/e2e/fileIO.spec.ts
@@ -1,0 +1,153 @@
+import { test, Page } from "@playwright/test";
+import { doPagePaste } from "../support/editor";
+import { checkConsoleContent, runToFinish } from "../support/execution";
+
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    if (browserName === "webkit" && process.platform === "win32") {
+        // On Windows+Webkit it just can't seem to load the page for some reason:
+        testInfo.skip(true, "Skipping on Windows + WebKit due to unknown problems");
+    }
+
+    // These tests can take longer than the default 30 seconds:
+    testInfo.setTimeout(240000); // 240 seconds
+
+    // Make browser's console.log output visible in our logs (useful for debugging):
+    page.on("console", (msg) => {
+        console.log("Browser log:", msg.text());
+    });
+    await page.goto("./", {waitUntil: "load"});
+    await page.waitForSelector("body");
+
+    await page.evaluate(() => {
+        (window as any).Playwright = true;
+    });
+});
+
+function deleteDefaultProject(): ((page: Page) => Promise<void>) {
+    return async (page) => {
+        await page.keyboard.press(process.platform == "darwin" ? "Meta+a" : "Control+a");
+        await page.waitForTimeout(200);
+        await page.keyboard.press("Backspace");
+        await page.waitForTimeout(200);
+    };
+}
+
+function copyAssetInTemp(assetPath: string, copyFileName: string): ((page: Page) => Promise<void>) {
+    const createAssetCopyCode = `text  = "" 
+with open("${assetPath}","r",encoding="utf-8")  as f  :
+    f.seek(5) 
+    text  = f.read() 
+with open("/tmp/${copyFileName}","w")  as f2  :
+    f2.write(text) 
+`;
+    return async (page) => {
+        await deleteDefaultProject()(page);
+        await doPagePaste(page, createAssetCopyCode);        
+    };
+}
+
+test.describe("Internal FileIO checkups", () => {
+    test("Read N lines of an existing file (text)", async ({page}) => {
+        await deleteDefaultProject()(page);
+        // ("utf-8-sig" allows to ignore the BOM (\uFEFF))
+        const readExistingFileCode = `with open("/books/fairy-tales.txt",encoding="utf-8-sig")  as f  :
+    for line_index  in range(0,5)  :
+        print(f"#{line_index+1} -> {f.readline()}") 
+`;
+        await doPagePaste(page, readExistingFileCode);
+        await page.waitForTimeout(200);
+        // Run code and check console output
+        await runToFinish(page, true);
+        await checkConsoleContent(page, `#1 -> 
+
+#2 -> A certain king had a beautiful garden, and in the garden stood a tree
+
+#3 -> which bore golden apples. These apples were always counted, and about
+
+#4 -> the time when they began to grow ripe it was found that every night one
+
+#5 -> of them was gone. The king became very angry at this, and ordered the
+
+`);
+    });
+
+    test("Read N bytes of an existing file (binary)", async ({page}) => {
+        await deleteDefaultProject()(page);
+        const readExistingFileCode = `with open("/images/cat-test.jpg","rb")  as f  :
+    print(f.read(20)) 
+`;
+        await doPagePaste(page, readExistingFileCode);
+        await page.waitForTimeout(200);
+        // Run code and check console output
+        await runToFinish(page, true);
+        await checkConsoleContent(page, "b'\\xff\\xd8\\xff\\xe0\\x00\\x10JFIF\\x00\\x01\\x01\\x01\\x00`\\x00`\\x00\\x00'\n");
+    });
+
+    test("Write bytes in a new file", async ({page}) => {
+        await deleteDefaultProject()(page);
+        const writeThenReadCode = `with open("/tmp/tests.txt","wb")  as f  :
+    bytes_txt  = bytearray([83,116,114,121,112,101]) 
+    f.write(bytes_txt) 
+with open("/tmp/tests.txt")  as f  :
+    print(f.read()) 
+`;
+        await doPagePaste(page, writeThenReadCode);
+        await page.waitForTimeout(200);
+        // Run code and check console output
+        await runToFinish(page, true);
+        await checkConsoleContent(page, "Strype\n");
+    });;
+
+    test("Write text in an existing file", async ({page}) => {
+        await copyAssetInTemp("/books/fairy-tales.txt", "test.txt")(page);
+        const writeThenReadCode = `with open("/tmp/test.txt","w")  as f  :
+    f.write("This is added by Strype!") 
+with open("/tmp/test.txt")  as f  :
+    print(f.read(100)+"|") 
+`;
+        await doPagePaste(page, writeThenReadCode);
+        await page.waitForTimeout(200);
+        // Run code and check console output
+        await runToFinish(page, true);
+        await checkConsoleContent(page, "This is added by Strype!|\n");
+    });;
+
+    test("Read+Write an existing file", async ({page}) => {
+        await copyAssetInTemp("/books/fairy-tales.txt", "test.txt")(page);
+        const writeAndReadCode =`with open("/tmp/test.txt","r+")  as f3  :
+    f3.seek(2) 
+    f3.write("great Strype") 
+    f3.seek(0) 
+    print(f3.read(250)+"|")
+    `;
+        await doPagePaste(page, writeAndReadCode);
+        await page.waitForTimeout(200);
+        // Run code and check console output
+        await runToFinish(page, true);
+        await checkConsoleContent(page, `A great Strype had a beautiful garden, and in the garden stood a tree
+which bore golden apples. These apples were always counted, and about
+the time when they began to grow ripe it was found that every night one
+of them was gone. The king became very|
+`);
+    });
+
+    test("Append text in an existing file", async ({page}) => {
+        await copyAssetInTemp("/books/fairy-tales.txt", "test.txt")(page);
+        const appendThenReadCode = `with open("/tmp/test.txt","a")  as f  :
+    f.write("This is added by Strype!") 
+with open("/tmp/test.txt", encoding="utf-8")  as f  :
+    whole_text = f.read()
+    print(whole_text[-100:]) 
+`;
+        await doPagePaste(page, appendThenReadCode);
+        await page.waitForTimeout(200);
+        // Run code and check console output
+        await runToFinish(page, true);
+        await checkConsoleContent(page, `e her window, and every year bore the most beautiful
+roses, white and red.
+
+This is added by Strype!
+`);
+    });
+});

--- a/tests/playwright/e2e/fileIO.spec.ts
+++ b/tests/playwright/e2e/fileIO.spec.ts
@@ -26,6 +26,7 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
 
 function deleteDefaultProject(): ((page: Page) => Promise<void>) {
     return async (page) => {
+        await page.waitForTimeout(200);
         await page.keyboard.press(process.platform == "darwin" ? "Meta+a" : "Control+a");
         await page.waitForTimeout(200);
         await page.keyboard.press("Backspace");
@@ -35,11 +36,10 @@ function deleteDefaultProject(): ((page: Page) => Promise<void>) {
 
 function copyAssetInTemp(assetPath: string, copyFileName: string): ((page: Page) => Promise<void>) {
     const createAssetCopyCode = `text  = "" 
-with open("${assetPath}","r",encoding="utf-8")  as f  :
-    f.seek(5) 
-    text  = f.read() 
-with open("/tmp/${copyFileName}","w")  as f2  :
-    f2.write(text) 
+with open("${assetPath}","rb")  as f  :
+    content  = f.read() 
+with open("/tmp/${copyFileName}","wb")  as f2  :
+    f2.write(content) 
 `;
     return async (page) => {
         await deleteDefaultProject()(page);
@@ -115,10 +115,12 @@ with open("/tmp/test.txt")  as f  :
 
     test("Read+Write an existing file", async ({page}) => {
         await copyAssetInTemp("/books/fairy-tales.txt", "test.txt")(page);
-        const writeAndReadCode =`with open("/tmp/test.txt","r+")  as f3  :
-    f3.seek(2) 
+        // First seek: +3 (BOM) +2 (the first line break) + 2 (position for "A |certain king" where | is the cursor)
+        // Second seek: same except the last +2
+        const writeAndReadCode =`with open("/tmp/test.txt","r+", encoding="utf-8-sig")  as f3  :
+    f3.seek(7) 
     f3.write("great Strype") 
-    f3.seek(0) 
+    f3.seek(5) 
     print(f3.read(250)+"|")
     `;
         await doPagePaste(page, writeAndReadCode);


### PR DESCRIPTION
This PR addresses two things:
- a fix to handle the Cloud files opened with "append" mode via Pyodide (#928)
- a new helper Strype builtins function, `get_connected_cloud`, that reaturns the name of the Cloud provider the Strype project lives in (or None if not relevant).

The docs and tests have also been updated (included some tests for generic Pyodide file IO operations - which are not completely relevant for Strype as such but might still be handy to have).