### PR TITLE
Various bug fixes

### DIFF
--- a/pysrc/strype/sound.py
+++ b/pysrc/strype/sound.py
@@ -165,7 +165,8 @@ def load_sound(source):
     # If they mistakenly try to load a sound (e.g. a literal) just let it through:
     if isinstance(source, Sound):
         return source
-    if source.startswith("http:") or source.startswith("https:") or source.startswith("data:"):
+    import re
+    if source.startswith("http:") or source.startswith("https:") or source.startswith("data:")  or source.startswith(":") or (":" not in source and re.match(r'^[^./]+\.[^/]+/.+', source)):
         buffer = _strype_sound_internal.loadAndWaitForAudioBuffer(source)
     else:
         # We load it from our virtual file system, either the current dir or /strype/graphics/

--- a/src/components/EditImageDlg.vue
+++ b/src/components/EditImageDlg.vue
@@ -188,8 +188,8 @@ export default defineComponent({
                 return Promise.reject("Loading");
             }
             const scale = this.imageScale / 100.0;
-            let width = this.cropSize.width * scale;
-            let height = this.cropSize.height * scale;
+            let width = Math.ceil(this.cropSize.width * scale);
+            let height = Math.ceil(this.cropSize.height * scale);
 
             const targetCanvas = document.createElement("canvas");
             targetCanvas.width = width;

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1776,9 +1776,9 @@ const getFirstOperatorPos = (codeLiteral: string, blankedStringCodeLiteral: stri
         // When we look for operators, there is 2 exceptions:
         // - we discard "*" (and "**" why not) when are in a from import frame, we will treat it as text
         // - "as" is only relevant for import frames, we ignore it otherwise
-        const isInFromImportFrame = (frameType == AllFrameTypesIdentifier.fromimport);
+        const canHaveAs = (frameType == AllFrameTypesIdentifier.fromimport) || (frameType == AllFrameTypesIdentifier.except);
         const isInImportFrame = (frameType == AllFrameTypesIdentifier.import);
-        const operatorPosList : OpFound[] = ((isInFromImportFrame) ? allOperators.filter((opDef) => !opDef.match.includes("*")) : allOperators.filter((opDef) => isInImportFrame || opDef.match != " as "))
+        const operatorPosList : OpFound[] = ((canHaveAs) ? allOperators.filter((opDef) => !opDef.match.includes("*")) : allOperators.filter((opDef) => isInImportFrame || opDef.match != " as "))
             .flatMap((operator : OpDef) => {
                 if (operator.keywordOperator) {
                     // "g" flag is necessary to make it obey the lastIndex item as a place to start:

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -266,7 +266,7 @@
   },
   "media": {
     "edit": "Edit",
-    "imageChangedSize": "Changed size (approx): ",
+    "imageChangedSize": "Changed size: ",
     "imageCrop": "Image Crop",
     "imageDetails": "Image Details",
     "imageOriginalSize": "Original size: ",

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -242,7 +242,6 @@ export default class Parser {
     private ignoreSpecificFrameId = -100;
     private ignoreCheckErrors = false;
     private saveAsSPY = false;
-    private outputProjectDoc = false;
     private stoppedIndentation = ""; // The indentation level when we encountered the stop frame.
     private libraries : string[] = [];
     private omitMediaLiterals = false;
@@ -250,7 +249,6 @@ export default class Parser {
     constructor(ignoreCheckErrors = false, destination: "spy" | "py-export" | "py" = "py", omitMediaLiterals = false) {
         this.ignoreCheckErrors = ignoreCheckErrors;
         this.saveAsSPY = destination == "spy";
-        this.outputProjectDoc = destination == "spy" || destination == "py-export";
         this.omitMediaLiterals = omitMediaLiterals;
     }
 
@@ -352,8 +350,8 @@ export default class Parser {
         || (!this.saveAsSPY && statement.frameType.type === AllFrameTypesIdentifier.funccall && isFieldBaseSlot(statement.labelSlotsDict[0].slotStructures.fields[0]) && (statement.labelSlotsDict[0].slotStructures.fields[0] as BaseSlot).code.startsWith("#"))){
             const commentContent = (statement.labelSlotsDict[0].slotStructures.fields[0] as BaseSlot).code;
 
-            // The project doc is optional so if it's blank omit it, and we don't mind about line numbers for SPY:
-            if (statement.frameType.type === AllFrameTypesIdentifier.projectDocumentation && (!this.outputProjectDoc || commentContent.trim().length == 0)) {
+            // The project doc is optional so if it's blank omit it:
+            if (statement.frameType.type === AllFrameTypesIdentifier.projectDocumentation && commentContent.length == 0) {
                 return "";
             }
             
@@ -396,10 +394,10 @@ export default class Parser {
             let hasDocContent = false;
             if(label.showLabel??true){
                 if (label.allowedSlotContent == AllowedSlotContent.FREE_TEXT_DOCUMENTATION) {
-                    if (useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields.length > 1 || (useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields[0] as BaseSlot).code.trim().length > 0) {
+                    if (useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields.length > 1 || (useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields[0] as BaseSlot).code != "") {
                         if (label.newLine ?? false) {
                             // If we are in a free text documentation situation (in functions or classes docs), we need to account for all the line breaks this comment can contain.
-                            this.line += ((((useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields[0] as BaseSlot).code.trim().length > 0)) ? ((useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields[0] as BaseSlot).code.split("\n").length) : 1);
+                            this.line += (useStore().frameObjects[statement.id].labelSlotsDict[labelSlotsIndex].slotStructures.fields[0] as BaseSlot).code.split("\n").length;
                             // Newlines indent below, e.g. comments in funcdef frames:
                             output += "\n" + indentation + "    ";
                         }
@@ -437,7 +435,7 @@ export default class Parser {
                     // (if user ends with a single quote, there will be four single quotes in a row at the end, and Python will parse it
                     // as the first three ending the string, and the fourth as left-over outside the string).
                     // We also need to escape backslashes by doubling them.
-                    output += slotStartsLengthsAndCode.code.trimStart().replaceAll("\n", ("\n" + indentation + "    ")).replaceAll("\\", "\\\\").replaceAll("'", "\\'") + "'''";
+                    output += slotStartsLengthsAndCode.code.replaceAll("\n", ("\n" + indentation + "    ")).replaceAll("\\", "\\\\").replaceAll("'", "\\'") + "'''";
                 }
                 else if (label.allowedSlotContent != AllowedSlotContent.FREE_TEXT_DOCUMENTATION) {
                     output += slotStartsLengthsAndCode.code.trimStart() + " ";
@@ -872,8 +870,9 @@ export default class Parser {
             else{        
                 // that's an editable (code) slot, we get the position and length for that slot
                 // we trim the field's code when we are not in a string literal
-                let flatSlotCode = (isSlotStringLiteralType(flatSlot.type) ? flatSlot.code : flatSlot.code.trim());
-                if (flatSlot.type != SlotType.string) {
+                const stringOrComment = isSlotStringLiteralType(flatSlot.type) || flatSlot.type == SlotType.comment;
+                let flatSlotCode = stringOrComment ? flatSlot.code : flatSlot.code.trim();
+                if (!stringOrComment) {
                     // Blanks are allowed before colons in slices:
                     if (opBefore === ":" || opAfter === ":") {
                         // Don't substitute the special blank marker.

--- a/tests/cypress/e2e/load-save-share.cy.ts
+++ b/tests/cypress/e2e/load-save-share.cy.ts
@@ -171,6 +171,9 @@ describe("Tests loading project descriptions", () => {
     it("Loads a project with docs", () => {
         testLoadingFromCalculatedShareLink("tests/cypress/fixtures/project-documented.spy");
     });
+    it("Loads a project with docs and newlines", () => {
+        testLoadingFromCalculatedShareLink("tests/cypress/fixtures/project-documented-newlines.spy");
+    });
     it("Loads a project with docs when there is already a project description", () => {
         focusEditorAndClear();
         cy.get("body").type("{uparrow}{uparrow}{leftarrow}Temporary description.");

--- a/tests/cypress/e2e/load-save.cy.ts
+++ b/tests/cypress/e2e/load-save.cy.ts
@@ -105,6 +105,9 @@ describe("Loads and re-saves fixture files", () => {
     it("Loads a basic trisection project", () => {
         testRoundTripImportAndDownload("tests/cypress/fixtures/project-basic-trisection.spy");
     });
+    it("Loads a project with except as", () => {
+        testRoundTripImportAndDownload("tests/cypress/fixtures/project-except-as.spy");
+    });
     it("Outputs a dummy for solo try", () => {
         // Make an empty try, which should save with a placeholder:
         // (try is followed by a pause, because it can take a bit longer to add its body/join sections)

--- a/tests/cypress/fixtures/project-documented-newlines.spy
+++ b/tests/cypress/fixtures/project-documented-newlines.spy
@@ -56,5 +56,5 @@ print(len(Foo.__doc__.split('\n')))
 print(len(Foo.__init__.__doc__.split('\n'))) 
 print(len(foo.__doc__.split('\n'))) 
 print(len(bar.__doc__.split('\n'))) 
-print("This will cause an error:" + len(None)) 
+print("This will cause an error:"+len(None)) 
 #(=> Section:End

--- a/tests/cypress/fixtures/project-documented-newlines.spy
+++ b/tests/cypress/fixtures/project-documented-newlines.spy
@@ -10,6 +10,19 @@ It has leading newlines, middle newlines and trailing ones.
 '''
 #(=> Section:Imports
 #(=> Section:Definitions
+class Foo  :
+    '''
+    
+    This is the class docs
+    
+    
+    '''
+    def __init__ (self, ) :
+        '''This is the init docs, only trailing newlines
+        
+        
+        '''
+        pass
 def foo ( ) :
     '''
     
@@ -30,6 +43,18 @@ def foo ( ) :
     
     '''
     return 42 
+def bar ( ) :
+    '''
+    
+    
+    
+    '''
+    print("This project doc has only newlines") 
 #(=> Section:Main
+print(len(__doc__.split('\n'))) 
+print(len(Foo.__doc__.split('\n'))) 
+print(len(Foo.__init__.__doc__.split('\n'))) 
+print(len(foo.__doc__.split('\n'))) 
+print(len(bar.__doc__.split('\n'))) 
 print("This will cause an error:" + len(None)) 
 #(=> Section:End

--- a/tests/cypress/fixtures/project-documented-newlines.spy
+++ b/tests/cypress/fixtures/project-documented-newlines.spy
@@ -1,0 +1,35 @@
+#(=> Strype:1:std
+'''
+
+This project has a description attached.
+
+
+It has leading newlines, middle newlines and trailing ones.
+
+
+'''
+#(=> Section:Imports
+#(=> Section:Definitions
+def foo ( ) :
+    '''
+    
+    This is the function foo.
+    
+    
+    
+    It also has a bunch of newlines.
+    
+    
+        
+    '''
+    '''
+    
+    This is a multiline comment which has newlines too
+    Which is allowed
+    
+    
+    '''
+    return 42 
+#(=> Section:Main
+print("This will cause an error:" + len(None)) 
+#(=> Section:End

--- a/tests/cypress/fixtures/project-except-as.spy
+++ b/tests/cypress/fixtures/project-except-as.spy
@@ -1,0 +1,10 @@
+#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+#(=> Section:Main
+try :
+    print(myString) 
+except Exception as e  :
+    print("oh") 
+    print(e) 
+#(=> Section:End

--- a/tests/playwright/e2e/console-execution.spec.ts
+++ b/tests/playwright/e2e/console-execution.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Locator, Page } from "@playwright/test";
 import { enterCode } from "../support/editor";
 import { checkConsoleContent, runButtonShowsRun, runToFinish, startRunning } from "../support/execution";
+import { load } from "../support/loading-saving";
 
 let scssVars: {[varName: string]: string};
 test.beforeEach(async ({ page, browserName }, testInfo) => {
@@ -147,6 +148,15 @@ except Exception:
         await checkConsoleContent(page, /.*TypeError: object of type 'NoneType' has no len\(\).*/);
         // Should not show any error counts because we caught it:
         await checkFrameErrorCount(page, 0);
+    });
+    
+    test("Check error shows at right place when documentation parts have newlines", async ({page}) => {
+        await load(page, "tests/cypress/fixtures/project-documented-newlines.spy");
+        await runToFinish(page);
+        // Two separate checks to keep things clear, one for the expected lengths of each of the docs, one for the error:
+        await checkConsoleContent(page, /9\n6\n4\n11\n5\n.*/);
+        await checkConsoleContent(page, /.*TypeError: object of type 'NoneType' has no len\(\).*/);
+        await expectHasVisibleErrorIcon(page.locator("span", {hasText: "This will cause an error:"}));
     });
 });
 
@@ -295,7 +305,7 @@ except Exception:
         await runToFinish(page);
         // Should be an error, but only one:
         await checkConsoleContent(page, `Traceback (most recent call last):
-  File "/home/pyodide/my_program.py", line 8, in <module>
+  File "/home/pyodide/my_program.py", line 9, in <module>
     print(len(None))
           ~~~^^^^^^
 TypeError: object of type 'NoneType' has no len()
@@ -326,8 +336,8 @@ while True:
             // Then check the last actual printed line:
             consoleValue = await page.locator("#peaConsole").inputValue();
             const lastNumberAfterStopping = Number(consoleValue.split("\n")?.at(-2)?.trim());
-            // Should have stopped printing within 4 seconds (should be less, but CI can be slow...):
-            expect(lastNumberAfterStopping).toBeLessThan(lastNumberWhileRunning + 4);
+            // Should have stopped printing within 10 seconds (should be less, but CI can be slow...):
+            expect(lastNumberAfterStopping).toBeLessThan(lastNumberWhileRunning + 10);
         });
 
         test(`Check console stops printing literal within seconds of stopping after running for ${runTime} seconds`, async ({page}) => {

--- a/tests/playwright/e2e/console-execution.spec.ts
+++ b/tests/playwright/e2e/console-execution.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Locator, Page } from "@playwright/test";
 import { enterCode } from "../support/editor";
 import { checkConsoleContent, runButtonShowsRun, runToFinish, startRunning } from "../support/execution";
 
+let scssVars: {[varName: string]: string};
 test.beforeEach(async ({ page, browserName }, testInfo) => {
     if (browserName === "webkit" && process.platform === "win32") {
         // On Windows+Webkit it just can't seem to load the page for some reason:
@@ -12,7 +13,9 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
     testInfo.setTimeout(90000); // 90 seconds
     
     await page.goto("./", {waitUntil: "load"});
-    await page.waitForSelector("body");
+    // Wait for content to load:
+    await expect(page.locator(".frame-div")).toHaveCount(2);
+    scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
     await page.evaluate(() => {
         (window as any).Playwright = true;
     });
@@ -22,22 +25,43 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
     });
 });
 
+// Given a locator for a slot or frame header, checks if the nearest enclosing frame has an error showing
+export async function expectHasVisibleErrorIcon(locator: Locator): Promise<void> {
+    const parent = locator.locator(
+        `xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' ${scssVars.frameHeaderClassName} ')][1]`
+    );
+
+    await expect(parent).toHaveCount(1);
+
+    const errIcon = parent.locator(".err-icon:visible");
+    await expect(errIcon).toHaveCount(1);
+    // Should only be one error:
+    await checkFrameErrorCount(locator.page(), 1);
+}
+
+export async function checkFrameErrorCount(page: Page, expectedCount: number) : Promise<void> {
+    await expect(page.locator(".err-icon:visible")).toHaveCount(expectedCount);
+}
+
 test.describe("Check console after execution", () => {
     test("Check default code works", async ({page}) => {
         await runToFinish(page);
         await checkConsoleContent(page, "Hello from Strype\n");
+        await checkFrameErrorCount(page, 0);
     });
 
     test("Check two prints work", async ({page}) => {
         await enterCode(page, ["", "", "print('Hello')\nprint('World')\n"]);
         await runToFinish(page);
         await checkConsoleContent(page, "Hello\nWorld\n");
+        await checkFrameErrorCount(page, 0);
     });
 
     test("Check format string works", async ({page}) => {
         await enterCode(page, ["", "", "x=1\ny=2\nprint(f'X is {x}')\nprint(f'Y is {y}')\nprint(f\"Total is {x+y}\")"]);
         await runToFinish(page);
         await checkConsoleContent(page, "X is 1\nY is 2\nTotal is 3\n");
+        await checkFrameErrorCount(page, 0);
     });
 
     test("Check raw string works", async ({page}) => {
@@ -45,6 +69,7 @@ test.describe("Check console after execution", () => {
         await enterCode(page, ["", "", "print('Line 1\\nLine 2')\nprint(r\"Line 3.0\\nLine 3.1\")"]);
         await runToFinish(page);
         await checkConsoleContent(page, "Line 1\nLine 2\nLine 3.0\\nLine 3.1\n");
+        await checkFrameErrorCount(page, 0);
     });
 });
 
@@ -58,6 +83,7 @@ test.describe("Test stdin works", () => {
         // Then it should not be running again, because it has finished:
         await runButtonShowsRun(button);
         await checkConsoleContent(page, "What is your name?\nGeorge\nHello George\n");
+        await checkFrameErrorCount(page, 0);
     });
 
     test("Check multiple input works", async ({page}) => {
@@ -73,6 +99,7 @@ test.describe("Test stdin works", () => {
         await checkConsoleContent(page, "What is your name?\nGeorge\nHello George\nWhat is your species?\ncat\nHello George the cat\n");
         // Then it should not be running again, because it has finished:
         await runButtonShowsRun(button);
+        await checkFrameErrorCount(page, 0);
     });
 });
 
@@ -81,16 +108,19 @@ test.describe("Check errors show", () => {
         await enterCode(page, ["", "", "print(len(None))"]);
         await runToFinish(page);
         await checkConsoleContent(page, "< TypeError: object of type 'NoneType' has no len() >\n  From the highlighted call in your code");
+        await expectHasVisibleErrorIcon(page.locator("span", {hasText: "print"}));
     });
     test("Check error shows #2", async ({page}) => {
         await enterCode(page, ["", "", "print('a'.foo())"]);
         await runToFinish(page);
         await checkConsoleContent(page, "< AttributeError: 'str' object has no attribute 'foo' >\n  From the highlighted call in your code");
+        await expectHasVisibleErrorIcon(page.locator("span", {hasText: "print"}));
     });
     test("Check error shows for file reading", async ({page}) => {
         await enterCode(page, ["", "", "open(\"/does/not/exist.txt\", \"r\", encoding=\"utf-8\")"]);
         await runToFinish(page);
         await checkConsoleContent(page, "< FileNotFoundError: [Errno 44] No such file or directory: '/does/not/exist.txt' >\n  From the highlighted call in your code");
+        await expectHasVisibleErrorIcon(page.locator("span", {hasText: "open"}));
     });
     
     // Check syntax error too, this use of global shows a syntax error:
@@ -102,6 +132,7 @@ def test():
 `.trimStart(), "print(\"Hi!\")\n"]);
         await runToFinish(page);
         await checkConsoleContent(page, "< SyntaxError: name 'a' is assigned to before global declaration >\n  From the highlighted call in your code");
+        await expectHasVisibleErrorIcon(page.locator("div.frame-header-label", {hasText: "global"}));
     });
 
     test("Check error shows after manually printing", async ({page}) => {
@@ -114,6 +145,8 @@ except Exception:
         await runToFinish(page);
         // Should be an error, but only one:
         await checkConsoleContent(page, /.*TypeError: object of type 'NoneType' has no len\(\).*/);
+        // Should not show any error counts because we caught it:
+        await checkFrameErrorCount(page, 0);
     });
 });
 
@@ -127,6 +160,7 @@ count = content.count("Montmorency")
 print(f'Montmorency is mentioned {count} times.')`]);
         await runToFinish(page);
         await checkConsoleContent(page, "Montmorency is mentioned 59 times.\n");
+        await checkFrameErrorCount(page, 0);
     });
 });
 
@@ -146,6 +180,7 @@ print(s.get_samples())`]);
 [-0.5, 0.5]
 [1, -1]
 `.trimStart());
+        await checkFrameErrorCount(page, 0);
     });
 
     test("Check type of sound samples", async ({page}) => {
@@ -156,6 +191,7 @@ print(type(s.get_samples()))`]);
         await checkConsoleContent(page, `
 <class 'list'>
 `.trimStart());
+        await checkFrameErrorCount(page, 0);
     });
 
     test("Create zero length Sound", async ({page}) => {
@@ -179,6 +215,7 @@ print(len(s.get_samples()))`]);
 <class 'list'>
 1
 `.trimStart());
+        await checkFrameErrorCount(page, 0);
     });
 });
 
@@ -193,6 +230,7 @@ test.describe("Test console flushing and ordering", () => {
         await page.click("#runButton");
         // Then it should not be running, because it has been terminated:
         await runButtonShowsRun(button);
+        await checkFrameErrorCount(page, 0);
     });
     test("Check output shows when printing then sleeping", async ({page}) => {
         await enterCode(page, ["import time", "", "print('Began')\ntime.sleep(60)\n"]);
@@ -205,6 +243,7 @@ test.describe("Test console flushing and ordering", () => {
         await page.click("#runButton");
         // Then it should not be running, because it has been terminated:
         await runButtonShowsRun(button);
+        await checkFrameErrorCount(page, 0);
     });
 });
 
@@ -213,16 +252,19 @@ test.describe("Test console clearing", () => {
         await enterCode(page, ["", "", "print('Hello')\nclear_console()\n"]);
         await runToFinish(page);
         await checkConsoleContent(page, "");
+        await checkFrameErrorCount(page, 0);
     });
     test("Check console clears stdout #2", async ({page}) => {
         await enterCode(page, ["", "", "print('Hello')\nclear_console()\nprint('Goodbye')\n"]);
         await runToFinish(page);
         await checkConsoleContent(page, "Goodbye\n");
+        await checkFrameErrorCount(page, 0);
     });
     test("Check console clears stdout #3", async ({page}) => {
         await enterCode(page, ["", "", "print('First')\nclear_console()\nprint('Second')\nclear_console()\nprint('Third')\nprint('Fourth')\n"]);
         await runToFinish(page);
         await checkConsoleContent(page, "Third\nFourth\n");
+        await checkFrameErrorCount(page, 0);
     });
     test("Check console clears stderr #1", async ({page}) => {
         await enterCode(page, ["import traceback", "", `
@@ -235,6 +277,8 @@ print("Hi")
 `]);
         await runToFinish(page);
         await checkConsoleContent(page, "Hi\n");
+        // Should not show error because we caught it:
+        await checkFrameErrorCount(page, 0);
     });
     test("Check console clears stderr #2", async ({page}) => {
         await enterCode(page, ["import traceback", "", `
@@ -256,6 +300,8 @@ except Exception:
           ~~~^^^^^^
 TypeError: object of type 'NoneType' has no len()
 `);
+        // Should not show error because we caught it:
+        await checkFrameErrorCount(page, 0);
     });
 });
 

--- a/tests/playwright/e2e/description-fields.spec.ts
+++ b/tests/playwright/e2e/description-fields.spec.ts
@@ -196,6 +196,10 @@ print(myString)
     test("Round trip awkward quotes #3", async ({page}, testInfo) => {
         await testPlaywrightRoundTripImportAndDownload(page, "tests/cypress/fixtures/project-documented-quotes-3.spy");
     });
+
+    test("Round trip newlines", async ({page}, testInfo) => {
+        await testPlaywrightRoundTripImportAndDownload(page, "tests/cypress/fixtures/project-documented-newlines.spy");
+    });
 });
 
 test.describe("Up/down in description slots", () => {

--- a/tests/playwright/e2e/load-save-share.spec.ts
+++ b/tests/playwright/e2e/load-save-share.spec.ts
@@ -73,6 +73,7 @@ async function testLongRoundTripLoadShareNewLoadSave(page: Page, filepath: strin
 test.describe("Fully round-trip the sharing", () => {
     const filesToCheck = [
         "tests/cypress/fixtures/project-basic.spy",
+        "tests/cypress/fixtures/project-except-as.spy",
         "tests/cypress/fixtures/project-libraries-disable.spy",
         "tests/cypress/fixtures/default-parameter-values.spy",
         "tests/cypress/fixtures/format-strings.spy",

--- a/tests/playwright/e2e/media-literal-edit.spec.ts
+++ b/tests/playwright/e2e/media-literal-edit.spec.ts
@@ -101,7 +101,7 @@ test.describe("Media literal resizing", async () => {
                 // Now check it matches exactly the new size:
                 await page.locator(".btn.btn-primary", {hasText: "OK"}).filter({visible: true}).click();
                 // Give it a moment to update:
-                await page.waitForTimeout(1500);
+                await page.waitForTimeout(4000);
                 
                 await page.locator("img.label-slot-media").hover();
                 const newSizeText = await page.locator(".MediaPreviewPopup-header-text").textContent();

--- a/tests/playwright/e2e/media-literal-edit.spec.ts
+++ b/tests/playwright/e2e/media-literal-edit.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+import { PNG } from "pngjs";
+import { doPagePaste } from "../support/editor";
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    if (browserName === "webkit" && process.platform === "win32") {
+        // On Windows+Webkit it just can't seem to load the page for some reason:
+        testInfo.skip(true, "Skipping on Windows + WebKit due to unknown problems");
+    }
+
+    await page.goto("./", {waitUntil: "load"});
+    await page.waitForSelector("body");
+    await page.evaluate(() => {
+        (window as any).Playwright = true;
+    });
+    // Make browser's console.log output visible in our logs (useful for debugging):
+    page.on("console", (msg) => {
+        console.log("Browser log:", msg.text());
+    });
+});
+
+/**
+ * Generates a data URL for a solid black PNG.
+ *
+ * @param width Image width in pixels
+ * @param height Image height in pixels
+ * @returns A base64 encode of the image
+ */
+export function createBlackPngBase64(width: number, height: number): string {
+    if (width <= 0 || height <= 0) {
+        throw new Error("Width and height must be positive");
+    }
+
+    const png = new PNG({ width, height });
+
+    // Every pixel defaults to 0, so set alpha to 255.
+    for (let i = 0; i < png.data.length; i += 4) {
+        png.data[i + 3] = 255; // A
+    }
+
+    const buffer = PNG.sync.write(png);
+
+    return buffer.toString("base64");
+}
+
+function expectWithin(a: number, b: number, tolerance: number) {
+    expect(a).toBeGreaterThanOrEqual(b - tolerance);
+    expect(a).toBeLessThanOrEqual(b + tolerance);
+}
+
+
+
+test.describe("Media literal resizing", async () => {
+    // We previously had a bug where resizing media literals could be a pixel off after resizing.
+    // We are not super interested in whether the resize is accurate (but we do check it's within a pixel)
+    // but more that the preview size displayed in the dialog is the same as the final size
+    for (const srcSizes of [[100, 100], [600, 600], [800, 600], [237, 526], [23, 41]]) {
+        for (const percentage of [1, 10, 28, 100, 107, 193]) {
+            test("Resizing " + JSON.stringify(srcSizes) + " to " + percentage + "%", async ({page}) => {
+                const srcX = srcSizes[0];
+                const srcY = srcSizes[1];
+                const srcImage = createBlackPngBase64(srcX, srcY);
+                
+                // Make a print and put the image in the params:
+                await page.keyboard.press("p");
+                await doPagePaste(page, srcImage, "image/png");
+                
+                // Now hover over it and bring up the edit dialog:
+                await page.locator("img.label-slot-media").hover();
+                await page.locator(".MediaPreviewPopup-header-edit-button").click();
+                
+                // Have to wait a sec for it to load (check "Loading" is gone):
+                const spans = page.locator("span.EditImageDlg-sizeInfo");
+                const count = await spans.count();
+                for (let i = 0; i < count; i++) {
+                    await expect(spans.nth(i)).not.toContainText("Loading", {timeout: 5000});
+                }
+                
+                // Move the slider to the right percentage:
+                const slider = page.locator("input#EditImageDlg-imageScale");
+
+                await slider.evaluate((el: HTMLInputElement, val: string) => {
+                    el.value = val;
+                    el.dispatchEvent(new Event("input", { bubbles: true }));
+                    el.dispatchEvent(new Event("change", { bubbles: true }));
+                }, "" + percentage);
+                
+                // Check the size in the preview list:
+                const previewSizeRegex = /Changed[^0-9]+([0-9]+)[^0-9]+([0-9]+)/;
+                const span = page.locator("span").filter({ hasText:  previewSizeRegex}).first();
+
+                const text = await span.textContent() as string;
+
+                const [, oldValue, newValue] = text.match(previewSizeRegex) as RegExpMatchArray;
+
+                const resizedX = Number(oldValue), resizedY = Number(newValue);
+                // Check size is reasonable for resize:
+                expectWithin(resizedX, srcX * percentage / 100, 1.5);
+                expectWithin(resizedY, srcY * percentage / 100, 1.5);
+                
+                // Now check it matches exactly the new size:
+                await page.locator(".btn.btn-primary", {hasText: "OK"}).filter({visible: true}).click();
+                // Give it a moment to update:
+                await page.waitForTimeout(1500);
+                
+                await page.locator("img.label-slot-media").hover();
+                const newSizeText = await page.locator(".MediaPreviewPopup-header-text").textContent();
+                expect(newSizeText).toMatch(new RegExp(resizedX + " × " + resizedY));
+            });
+        }
+    }
+});


### PR DESCRIPTION
This fixes a few different bugs:
 - Fix an issue with media literal resizing being off by one pixel (e.g. it says 100x60, you get 99x59).
 - Fix "except Exception as e" not saving and reloading correctly.
 - Fix sounds not accepting a special library syntax, which broke the mediacomp sound examples
 - Fix an issue with newlines in project/class/function documentation fields upsetting the line number calculation, so that if you then got a runtime error it could display in the wrong place, or cause a "silent" exception in the console that made it seem like execution had hung.