### PR TITLE
Fix some interaction issue with the copy shortcuts on the media editing dialogs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -431,6 +431,12 @@ export default defineComponent({
                 return;
             }
 
+            // The media editor dialogs also register an event listener which callback will be called after this one.
+            // So when we detect one of the dialogs is opened, we just ignore this callback method.
+            if(this.appStore.isModalDlgShown && (this.appStore.currentModalDlgId == "editImageDlg" || this.appStore.currentModalDlgId == "editSoundDlg")){
+                return;
+            }
+
             // Close the rename identifiers popup on most keys:
             // to simplify the event registration on when we close the popup, we close it on almost all key hits except navigation keys:
             // they will be handled in watch() via the change of frame and we do allow navigation when the popup is showing.

--- a/src/components/EditImageDlg.vue
+++ b/src/components/EditImageDlg.vue
@@ -245,7 +245,9 @@ export default defineComponent({
         },
         
         onKeyDown(event: KeyboardEvent) {
-            if (this.$refs.cropper && event.key === "c" && ((isMacOSPlatform() && event.metaKey) || (!isMacOSPlatform() && event.ctrlKey))) {
+            // We need to make sure we are actually in the sitation the dialog is opened: this event callback can be called because of interaction elsewhere in the UI,
+            // and here will may trigger the event to be prevented (last part of the method) - even if the conditions to make the copy as expected here were not met.
+            if (this.appStore.isModalDlgShown && this.appStore.currentModalDlgId == this.dlgId && this.$refs.cropper && event.key.toLowerCase() === "c" && ((isMacOSPlatform() && event.metaKey) || (!isMacOSPlatform() && event.ctrlKey))) {
                 if (event.shiftKey) {
                     if (this.cursorColor !== undefined) {
                         navigator.clipboard.writeText(this.cursorColor);

--- a/src/components/EditSoundDlg.vue
+++ b/src/components/EditSoundDlg.vue
@@ -292,7 +292,9 @@ export default defineComponent({
         },
 
         onKeyDown(event: KeyboardEvent) {
-            if (this.$refs.cropper && event.key === "c" && ((isMacOSPlatform() && event.metaKey) || (!isMacOSPlatform() && event.ctrlKey))) {
+            // We need to make sure we are actually in the sitation the dialog is opened: this event callback can be called because of interaction elsewhere in the UI,
+            // and here will may trigger the event to be prevented (last part of the method) - even if the conditions to make the copy as expected here were not met.
+            if (this.appStore.isModalDlgShown && this.appStore.currentModalDlgId == this.dlgId && this.$refs.cropper && event.key.toLowerCase() === "c" && ((isMacOSPlatform() && event.metaKey) || (!isMacOSPlatform() && event.ctrlKey))) {
                 if (event.shiftKey) {
                     if (this.cursorHeight !== undefined) {
                         navigator.clipboard.writeText(this.cursorHeight);


### PR DESCRIPTION
This PR fixes #944: the copy shortcuts for the media (image or sound) editing dialogs didn't work (for Windows at least).
I think this is a consequence of changing the Bootstrap modal library when we upgraded to Vue 3.
