### PR TITLE
Handle two stores in our IndexedDB

### DIFF
--- a/src/store/store-db-storage.ts
+++ b/src/store/store-db-storage.ts
@@ -33,7 +33,7 @@ const MAX_SESSION_AGE_MILLIS_UNSAVED = 8 * 24 * 60 * 60 * 1000;
 const MAX_SESSION_AGE_MILLIS_SAVED = 1 * 24 * 60 * 60 * 1000;
 
 const DB_NAME = AutoSaveKeyNames.strypeIndexDatabaseName;
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 let STORE : string;
 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
 STORE = AutoSaveKeyNames.strypePythonDBStore;
@@ -64,9 +64,21 @@ export function openIndexedDBConnection(): Promise<IDBDatabase> {
 
         request.onupgradeneeded = () => {
             const db = request.result;
+              
+            // We always create both stores together, otherwise we cannot use one db for 2 stores.
+            let otherStore = AutoSaveKeyNames.strypeMicrobitDBStore;
+            // #v-ifdef STRYPE_PLATFORM == VITE_MICROBIT_MODE
+            otherStore = AutoSaveKeyNames.strypePythonDBStore;
+            // #v-endif
 
             if (!db.objectStoreNames.contains(STORE)) {
                 db.createObjectStore(STORE, {
+                    keyPath: DatabaseFieldNames.tabId,
+                });
+            }
+
+            if (!db.objectStoreNames.contains(otherStore)) {
+                db.createObjectStore(otherStore, {
                     keyPath: DatabaseFieldNames.tabId,
                 });
             }


### PR DESCRIPTION
This PR fixes #963 which was a consequence of a problem with IndexedDB.

The code was creating one DB store for a given Strype version. 
When Strype had never been been accessed on the browser (or at least not since the new model), accessing Strype from the browser was detecting that the required store was missing and created it.

That is fine, but then when accessing _the other version of Strype_, the store _of this other version of Strype_ didn't exist and couldn't be created, because the DB version was the same so we didn't have any way of creating the store (DB schema can only be changed on `onupgradeneeded`).

Therefore, if we want to have 2 stores for our DB, we need to create them both whenever we create one. The version of our IndexDB has been bumped to reflect the change and adapt to existing DB in the users' browser.

