### PR TITLE
Add strype.graphics and strype.sound imports as default

### DIFF
--- a/src/store/initial-states.ts
+++ b/src/store/initial-states.ts
@@ -16,7 +16,7 @@ const initialStates: StateAppObjects = {
         debugging: false,
         initialState: initialPythonState,
         showKeystroke: false,
-        nextAvailableId: 3,
+        nextAvailableId: 5,
     },
 
     "initialMicrobitState": {

--- a/src/store/initial-states/initial-python-state.ts
+++ b/src/store/initial-states/initial-python-state.ts
@@ -34,7 +34,7 @@ const initialPythonState: EditorFrameObjects = {
         isSelected: false,
         isVisible: true,
         parentId: 0,
-        childrenIds: [],
+        childrenIds: [1, 2],
         jointParentId: 0,
         jointFrameIds: [],
         labelSlotsDict: {},
@@ -60,7 +60,7 @@ const initialPythonState: EditorFrameObjects = {
         isSelected: false,
         isVisible: true,
         parentId: 0,
-        childrenIds: [1,2],
+        childrenIds: [3,4],
         jointParentId: 0,
         jointFrameIds: [],
         labelSlotsDict: {},
@@ -68,8 +68,40 @@ const initialPythonState: EditorFrameObjects = {
     },
 
     1: {
-        frameType: getFrameDefType(AllFrameTypesIdentifier.varassign),
+        frameType: getFrameDefType(AllFrameTypesIdentifier.fromimport),
         id: 1,
+        isDisabled: false,
+        isSelected: false,
+        isVisible: true,
+        parentId: -1,
+        childrenIds: [],
+        jointParentId: 0,
+        jointFrameIds: [],
+        labelSlotsDict: {
+            0: {slotStructures: {operators: [], fields: [{code: "strype.graphics"}]}},
+            1: {slotStructures: {operators: [], fields: [{code: "*"}]}}},
+        caretVisibility: CaretPosition.none,
+    },
+
+    2: {
+        frameType: getFrameDefType(AllFrameTypesIdentifier.fromimport),
+        id: 2,
+        isDisabled: false,
+        isSelected: false,
+        isVisible: true,
+        parentId: -1,
+        childrenIds: [],
+        jointParentId: 0,
+        jointFrameIds: [],
+        labelSlotsDict: {
+            0: {slotStructures: {operators: [], fields: [{code: "strype.sound"}]}},
+            1: {slotStructures: {operators: [], fields: [{code: "*"}]}}},
+        caretVisibility: CaretPosition.none,
+    },
+
+    3: {
+        frameType: getFrameDefType(AllFrameTypesIdentifier.varassign),
+        id: 3,
         isDisabled: false,
         isSelected: false,
         isVisible: true,
@@ -83,9 +115,9 @@ const initialPythonState: EditorFrameObjects = {
         caretVisibility: CaretPosition.none,
     },
 
-    2: {
+    4: {
         frameType: getFrameDefType(AllFrameTypesIdentifier.funccall),
-        id: 2,
+        id: 4,
         isDisabled: false,
         isSelected: false,
         isVisible: true,

--- a/src/store/initial-states/initial-python-state.ts
+++ b/src/store/initial-states/initial-python-state.ts
@@ -78,7 +78,7 @@ const initialPythonState: EditorFrameObjects = {
         jointParentId: 0,
         jointFrameIds: [],
         labelSlotsDict: {
-            0: {slotStructures: {operators: [], fields: [{code: "strype.graphics"}]}},
+            0: {slotStructures: {operators: [{code: "."}], fields: [{code: "strype"}, {code: "graphics"}]}},
             1: {slotStructures: {operators: [], fields: [{code: "*"}]}}},
         caretVisibility: CaretPosition.none,
     },
@@ -94,7 +94,7 @@ const initialPythonState: EditorFrameObjects = {
         jointParentId: 0,
         jointFrameIds: [],
         labelSlotsDict: {
-            0: {slotStructures: {operators: [], fields: [{code: "strype.sound"}]}},
+            0: {slotStructures: {operators: [{code: "."}], fields: [{code: "strype"}, {code: "sound"}]}},
             1: {slotStructures: {operators: [], fields: [{code: "*"}]}}},
         caretVisibility: CaretPosition.none,
     },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2117,13 +2117,13 @@ export const useStore = defineStore("app", {
                     if(!foundDisabledJointFrameToDelete) {
                         const indexOfCurrentInAvailables = availablePositions.findIndex((e)=> e.frameId === currentFrame.id && e.caretPosition === this.currentFrame.caretPosition);
                         // the "next" position of the current
-                        frameToDelete = availablePositions[indexOfCurrentInAvailables+1]??{id:-100, isSlotNavigationPosition: false};
+                        frameToDelete = availablePositions[indexOfCurrentInAvailables+1]??{frameId:-100, isSlotNavigationPosition: false};
                     }
                     // The only times to prevent deletion with 'delete' is when we are inside a body that has no children (except in Joint frames)
                     // or when the next position is a joint root's below OR a strict* block frame below - both enabled (* = that cannot take joint frame, like a function definition, a class definition or "with")
-                    if((framesIdToDelete.length==1 && this.frameObjects[framesIdToDelete[0]]?.frameType.allowChildren && !this.frameObjects[frameToDelete.frameId]?.frameType.isJointFrame 
+                    if((framesIdToDelete.length==1 && this.frameObjects[framesIdToDelete[0]]?.frameType.allowChildren && !this.frameObjects[frameToDelete.frameId]?.frameType.isJointFrame
                             && this.currentFrame.caretPosition == CaretPosition.body && this.frameObjects[framesIdToDelete[0]]?.childrenIds.length == 0)
-                        || (!this.frameObjects[frameToDelete.frameId].isDisabled && (!!this.frameObjects[frameToDelete.frameId]?.frameType.allowJointChildren || (this.frameObjects[frameToDelete.frameId]?.frameType.allowChildren && !this.frameObjects[frameToDelete.frameId]?.frameType.allowJointChildren))
+                        || (!this.frameObjects[frameToDelete.frameId]?.isDisabled && (!!this.frameObjects[frameToDelete.frameId]?.frameType.allowJointChildren || (this.frameObjects[frameToDelete.frameId]?.frameType.allowChildren && !this.frameObjects[frameToDelete.frameId]?.frameType.allowJointChildren))
                             && (frameToDelete.caretPosition??"") === CaretPosition.below)){
                         frameToDelete.frameId = -100;
                     }

--- a/tests/cypress/e2e/autocomplete-graphics-libs.cy.ts
+++ b/tests/cypress/e2e/autocomplete-graphics-libs.cy.ts
@@ -1,4 +1,5 @@
 import { scssVars } from "../support/standard-setup";
+import { clearDefaultImports } from "../support/test-support";
 
 require("cypress-terminal-report/src/installLogsCollector")();
 import "@testing-library/cypress/add-commands";
@@ -19,7 +20,8 @@ describe("Graphics library", () => {
     it("Shows completions for graphics standalone functions", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Add a function frame and trigger auto-complete:
         cy.get("body").type(" ");
         cy.wait(500);
@@ -39,7 +41,8 @@ describe("Graphics library", () => {
     it("Shows completions for object constructor", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Add a function frame and trigger auto-complete:
         cy.get("body").type(" ");
         cy.wait(500);
@@ -53,7 +56,8 @@ describe("Graphics library", () => {
     it("Shows completions for return of graphics load_image", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Add a function call frame and trigger auto-complete:
         cy.get("body").type(" ");
         cy.wait(500);
@@ -67,7 +71,8 @@ describe("Graphics library", () => {
     it("Shows completions for return of graphics get_background", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Add a function call frame and trigger auto-complete:
         cy.get("body").type(" ");
         cy.wait(500);
@@ -81,7 +86,8 @@ describe("Graphics library", () => {
     it("Shows completions for return of sound load_sound", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.sound{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.sound{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Add a function call frame and trigger auto-complete:
         cy.get("body").type(" ");
         cy.wait(500);
@@ -96,7 +102,8 @@ describe("Graphics library", () => {
         cy.readFile("src/assetsFilesystem/images/cat-test.jpg", null).then((catJPEG) => {
             focusEditorAC();
             // Add graphics import:
-            cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+            clearDefaultImports();
+            cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
             // Add a function call frame and trigger auto-complete:
             cy.get("body").type(" {del}");
             cy.wait(500);
@@ -120,7 +127,8 @@ describe("Graphics library", () => {
         cy.readFile("src/assetsFilesystem/sounds/meow.wav", null).then((catWAV) => {
             focusEditorAC();
             // Add graphics import:
-            cy.get("body").type("{uparrow}{uparrow}fstrype.sound{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+            clearDefaultImports();
+            cy.get("body").type("fstrype.sound{rightarrow}*{rightarrow}{downarrow}{downarrow}");
             // Add a function call frame and trigger auto-complete:
             cy.get("body").type(" {del}");
             cy.wait(500);
@@ -140,7 +148,8 @@ describe("Graphics library", () => {
     it("Shows completions for Actor methods", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Make an actor:
         cy.get("body").type("=a=Actor('cat-test.jpg'){rightarrow}");
         // Add a function frame and trigger auto-complete:
@@ -163,7 +172,8 @@ describe("Graphics library", () => {
     it("Shows completions for Image methods", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Make an image:
         cy.get("body").type("=e=Image(100, 100){rightarrow}");
         // Add a function frame and trigger auto-complete:
@@ -183,7 +193,8 @@ describe("Graphics library", () => {
     it("Shows completions for Image methods on clone()", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Make an image:
         cy.get("body").type("=e=Image(100, 100){rightarrow}");
         // Add a function frame and trigger auto-complete:
@@ -203,7 +214,8 @@ describe("Graphics library", () => {
     it("Shows completions for Image methods on Actor.get_image()", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Make an image:
         cy.get("body").type("=a=Actor('blah'){rightarrow}");
         // Add a function frame and trigger auto-complete:
@@ -224,7 +236,8 @@ describe("Graphics library", () => {
         focusEditorAC();
 
         // Go up to imports, add library, add import, then trigger auto-complete:
-        cy.get("body").type("{uparrow}{uparrow}f");
+        clearDefaultImports();
+        cy.get("body").type("f");
         cy.wait(500);
         // Fill in time in the LHS then go across to the RHS:
         cy.get("body").type("strype.graphics{rightarrow}");
@@ -283,7 +296,8 @@ describe("Modules from libraries", () => {
     it("Offers auto-complete in import frames based on libraries", () => {
         focusEditorAC();
         // Go up to imports, add library, add import, then trigger auto-complete:
-        cy.get("body").type("{uparrow}{uparrow}lhttp://localhost:8089/test-library/{rightarrow}i");
+        clearDefaultImports();
+        cy.get("body").type("lhttp://localhost:8089/test-library/{rightarrow}i");
         cy.wait(500);
         cy.get("body").type("{ctrl} ");
         withAC((acIDSel) => {
@@ -296,7 +310,8 @@ describe("Modules from libraries", () => {
         focusEditorAC();
 
         // Go up to imports, add library, add import, then trigger auto-complete:
-        cy.get("body").type("{uparrow}{uparrow}lhttp://localhost:8089/test-library/{rightarrow}f");
+        clearDefaultImports();
+        cy.get("body").type("lhttp://localhost:8089/test-library/{rightarrow}f");
         cy.wait(500);
         // Fill in time in the LHS then go across to the RHS:
         cy.get("body").type("mediacomp{rightarrow}");
@@ -348,7 +363,8 @@ describe("Modules from libraries", () => {
     it("Offers auto-completion for imported modules", () => {
         focusEditorAC();
         // Go up to imports, add library, add import, then trigger auto-complete:
-        cy.get("body").type("{uparrow}{uparrow}lhttp://localhost:8089/test-library{rightarrow}i");
+        clearDefaultImports();
+        cy.get("body").type("lhttp://localhost:8089/test-library{rightarrow}i");
         cy.wait(500);
         // Trigger autocomplete, type "mediacom" then press enter to complete and right arrow to leave frame:
         cy.get("body").type("{ctrl} ");
@@ -371,7 +387,8 @@ describe("Modules from libraries", () => {
     it("Shows completions for return of makeSound", () => {
         focusEditorAC();
         // Add graphics import:
-        cy.get("body").type("{uparrow}{uparrow}lhttp://localhost:8089/test-library{rightarrow}fmediacomp{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("lhttp://localhost:8089/test-library{rightarrow}fmediacomp{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Add a function call frame and trigger auto-complete:
         cy.get("body").type(" ");
         cy.wait(500);

--- a/tests/cypress/e2e/autocomplete-modules.cy.ts
+++ b/tests/cypress/e2e/autocomplete-modules.cy.ts
@@ -1,4 +1,5 @@
 import { scssVars } from "../support/standard-setup";
+import { clearDefaultImports } from "../support/test-support";
 
 require("cypress-terminal-report/src/installLogsCollector")();
 import "@testing-library/cypress/add-commands";
@@ -15,7 +16,8 @@ describe("Modules", () => {
     it("Offers auto-complete in import frames", () => {
         focusEditorAC();
         // Go up to imports, add one, then trigger auto-complete:
-        cy.get("body").type("{uparrow}{uparrow}i");
+        clearDefaultImports();
+        cy.get("body").type("i");
         cy.wait(500);
         cy.get("body").type("{ctrl} ");
         withAC((acIDSel) => {
@@ -79,7 +81,8 @@ describe("Modules", () => {
     it("Offers auto-complete in LHS of from...import frames", () => {
         focusEditorAC();
         // Go up to imports, add one, then trigger auto-complete:
-        cy.get("body").type("{uparrow}{uparrow}f");
+        clearDefaultImports();
+        cy.get("body").type("f");
         cy.wait(500);
         cy.get("body").type("{ctrl} ");
         withAC((acIDSel) => {
@@ -146,7 +149,8 @@ describe("Modules", () => {
         const targetDoc = Cypress.env("mode") == "microbit" ? "Offset ticks value by a given number, which can be either positive or negative." : "Convert seconds since the Epoch to a time tuple expressing UTC";
 
         // Go up to imports, add one, then trigger auto-complete:
-        cy.get("body").type("{uparrow}{uparrow}f");
+        clearDefaultImports();
+        cy.get("body").type("f");
         cy.wait(500);
         // Fill in time in the LHS then go across to the RHS:
         cy.get("body").type("time{rightarrow}");
@@ -220,7 +224,8 @@ describe("Modules", () => {
         // This works on microbit without using Skulpt because we have special cases to look up microbit in our precalculated JSON        
         focusEditorAC();
         // Go up to imports and add an import frame:
-        cy.get("body").type("{uparrow}{uparrow}i");
+        clearDefaultImports();
+        cy.get("body").type("i");
         cy.wait(500);
         // Trigger autocomplete, type "tim" then press enter to complete and right arrow to leave frame:
         cy.get("body").type("{ctrl} ");
@@ -256,7 +261,8 @@ describe("Modules", () => {
     it("Offers auto-completion for imported modules with a from import *", () => {
         focusEditorAC();
         // Go up to the imports and add a "from..import.." frame
-        cy.get("body").type("{uparrow}{uparrow}f");
+        clearDefaultImports();
+        cy.get("body").type("f");
         cy.wait(500);
         // Trigger autocomplete (in first section), type "tim" and hit enter to auto-complete, then right arrow to go across to the second part of the frame:
         cy.get("body").type("{ctrl} ");
@@ -322,7 +328,8 @@ describe("Nested modules", () => {
         // This works on microbit without using Skulpt because we have special cases to look up microbit in our precalculated JSON
         focusEditorAC();
         // Go up to imports and add an import frame:
-        cy.get("body").type("{uparrow}{uparrow}i");
+        clearDefaultImports();
+        cy.get("body").type("i");
         cy.wait(500);
         // Type whole module as one item:
         cy.get("body").type(targetModule);
@@ -342,7 +349,8 @@ describe("Nested modules", () => {
     it("Offers auto-completion for modules with names a.b when imported as a.b.* with from", () => {
         focusEditorAC();
         // Go up to imports and add a from import frame:
-        cy.get("body").type("{uparrow}{uparrow}f");
+        clearDefaultImports();
+        cy.get("body").type("f");
         cy.wait(500);
         // Type whole module as one item:
         cy.get("body").type(targetModule);
@@ -360,7 +368,8 @@ describe("Nested modules", () => {
     it("Offers auto-completion for modules with names a.b when imported as a.b.func with from", () => {
         focusEditorAC();
         // Go up to imports and add a from import frame:
-        cy.get("body").type("{uparrow}{uparrow}f");
+        clearDefaultImports();
+        cy.get("body").type("f");
         cy.wait(500);
         // Type whole module as one item:
         cy.get("body").type(targetModule);
@@ -426,7 +435,8 @@ describe("Imported items", () => {
     it("Offers auto-complete when module is imported", () => {
         focusEditorAC();
         // Go up to imports and add an import frame:
-        cy.get("body").type("{uparrow}{uparrow}i");
+        clearDefaultImports();
+        cy.get("body").type("i");
         cy.wait(500);
         // Type whole module as one item:
         cy.get("body").type(targetModule);
@@ -445,7 +455,8 @@ describe("Imported items", () => {
     it("Doesn't offer auto-complete on original name when module is imported using as", () => {
         focusEditorAC();
         // Go up to imports and add an import frame:
-        cy.get("body").type("{uparrow}{uparrow}i");
+        clearDefaultImports();
+        cy.get("body").type("i");
         cy.wait(500);
         // Space bar alone should give us the "as", so this imports as "t":
         cy.get("body").type(targetModule + " t{rightarrow}");
@@ -502,7 +513,8 @@ describe("Underscore handling", () => {
         // We use our own module because we know it has something with underscores in it:
         it("Does not offer underscore items on modules at all", () => {
             // Go up to imports and add a from time import *
-            cy.get("body").type("{uparrow}{uparrow}fstrype.graphics{rightarrow}*{rightarrow}");
+            clearDefaultImports();
+            cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}");
             cy.get("body").type("{downarrow}{downarrow}");
 
             focusEditorAC();

--- a/tests/cypress/e2e/autocomplete-more.cy.ts
+++ b/tests/cypress/e2e/autocomplete-more.cy.ts
@@ -1,4 +1,5 @@
 import { scssVars } from "../support/standard-setup";
+import { clearDefaultImports } from "../support/test-support";
 
 require("cypress-terminal-report/src/installLogsCollector")();
 import "@testing-library/cypress/add-commands";
@@ -87,7 +88,8 @@ describe("Overlapping imports", () => {
     it("Offers all imports from module even where is overlapping from import:", () => {
         focusEditorAC();
         // Add two imports: import math, and from math import sin, cos
-        cy.get("body").type("{uparrow}{uparrow}imath{downarrow}fmath{rightarrow}sin,cos{downarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("imath{downarrow}fmath{rightarrow}sin,cos{downarrow}{downarrow}{downarrow}");
         // Now we're back in main body, make a function call with math.:
         cy.get("body").type(" math.");
         cy.wait(500);
@@ -110,7 +112,8 @@ describe("Import of structured items", () => {
     it("Shows today in fully qualified date", () => {
         focusEditorAC();
         // Add import: from datetime import date
-        cy.get("body").type("{uparrow}{uparrow}fdatetime{rightarrow}date{downarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fdatetime{rightarrow}date{downarrow}{downarrow}{downarrow}");
         // Now we're back in main body, make a function call with math.:
         cy.get("body").type(" ");
         cy.wait(500);
@@ -125,7 +128,8 @@ describe("Import of structured items", () => {
     it("Shows today in after date.", () => {
         focusEditorAC();
         // Add import: from datetime import date
-        cy.get("body").type("{uparrow}{uparrow}fdatetime{rightarrow}date{downarrow}{downarrow}{downarrow}");
+        clearDefaultImports();
+        cy.get("body").type("fdatetime{rightarrow}date{downarrow}{downarrow}{downarrow}");
         // Now we're back in main body, make a function call with math.:
         cy.get("body").type(" date.");
         cy.wait(500);

--- a/tests/cypress/e2e/autocomplete-user-defined.cy.ts
+++ b/tests/cypress/e2e/autocomplete-user-defined.cy.ts
@@ -1,4 +1,5 @@
 import { scssVars } from "../support/standard-setup";
+import { clearDefaultImports } from "../support/test-support";
 
 require("cypress-terminal-report/src/installLogsCollector")();
 import "@testing-library/cypress/add-commands";
@@ -69,9 +70,11 @@ describe("User-defined items", () => {
 
     it("Offers auto-complete for user-defined variables but inside functions", () => {
         focusEditorAC();
-        // Make an assignment frame that says "myVar=<string>", then make a function definition:
-        cy.get("body").type("=myVar=\"hello\"{enter}");
-        cy.get("body").type("{uparrow}{uparrow}ffoo{rightarrow}{rightarrow}{rightarrow} ");
+        // Make an assignment frame that says "myVar=<string>", then make a function definition.
+        // The 2 arrow-ups navigate from Main up into (empty) Definitions -- unaffected by Imports'
+        // content, since that path never passes through Imports, so this doesn't need clearing the
+        // default imports the way the import-focused tests below do:
+        cy.get("body").type("=myVar=\"hello\"{enter}{uparrow}{uparrow}ffoo{rightarrow}{rightarrow}{rightarrow} ");
         cy.wait(500);
         // Trigger auto-completion:
         cy.get("body").type("{ctrl} ");
@@ -294,7 +297,8 @@ describe("User-defined items", () => {
         const parentClassMethodWithoutParamsToTest = (isTestingMicrobitVersion) ? "clear()" : "remove()";
         focusEditorAC();
         // Add the right import to get Actor or NeoPixel
-        cy.get("body").type(`{uparrow}{uparrow}f${parentImport[0]}{rightarrow}${parentImport[1]}{downarrow}{downarrow}`);
+        clearDefaultImports();
+        cy.get("body").type(`f${parentImport[0]}{rightarrow}${parentImport[1]}{downarrow}{downarrow}`);
         // Make a class frame with "foo(<parent class>)" and delete the init function, add a function "myF", then go to my code
         cy.get("body").type(`cfoo(${parentClassName}{downarrow}{downarrow}{del}fmyF{downarrow}{downarrow}{downarrow}{downarrow}{downarrow}`);
         // Trigger auto-completion on a function call frame:

--- a/tests/cypress/e2e/basics.cy.ts
+++ b/tests/cypress/e2e/basics.cy.ts
@@ -230,6 +230,8 @@ if (Cypress.env("mode") == "microbit") {
 }
 else {
     defaultImports = [
+        /from\s+strype\.graphics\s+import\s*\*/,
+        /from\s+strype\.sound\s+import\s*\*/,
     ];
 
     defaultMyCode  = [

--- a/tests/cypress/e2e/paste-python.cy.ts
+++ b/tests/cypress/e2e/paste-python.cy.ts
@@ -169,28 +169,30 @@ from a.b.c import *
 `);
     });
     
-    it("Supports basic binary operator combinations", () => {
-        for (const op of sampleSize(binary_operators, 3)) {
-            for (const lhs of sampleSize(terminals, 2)) {
-                for (const rhs of sampleSize(terminals, 3)) {
-                    // Keep a space between operands only for keyword operators (they all contains "i")
-                    const operatorSpacing = (op.includes("i")) ? " " : ""; 
-                    // Since the default code contains a project doc, we need to include it to the code
-                    const code = "raise " + lhs + operatorSpacing + op + operatorSpacing + rhs + "\n";
-                    testRoundTripPasteAndDownload(code, undefined, defaultProjectDocFullLine + code);
-                }
+    // One it() per combination, rather than looping through all of them inside a single it() as
+    // this used to do: CI (ubuntu-latest) hit a Cypress/Electron "V8 process OOM" crash partway
+    // through the ~18 round-trip paste+download+compare cycles previously accumulating within one
+    // test. Splitting them like this matches the `basics` loop above, and each new it() gets its
+    // own beforeEach page reload (registered by the paste-test-support.ts import), which resets
+    // memory in between:
+    for (const op of sampleSize(binary_operators, 3)) {
+        for (const lhs of sampleSize(terminals, 2)) {
+            for (const rhs of sampleSize(terminals, 3)) {
+                // Keep a space between operands only for keyword operators (they all contains "i")
+                const operatorSpacing = (op.includes("i")) ? " " : "";
+                // Since the default code contains a project doc, we need to include it to the code
+                const code = "raise " + lhs + operatorSpacing + op + operatorSpacing + rhs + "\n";
+                it("Supports basic binary operator combination: " + code.trim(), () => testRoundTripPasteAndDownload(code, undefined, defaultProjectDocFullLine + code));
             }
         }
-    });
-    it("Supports basic n-ary operator combinations", () => {
-        for (const op of sampleSize(nary_operators, 5)) {
-            // Keep a space between operands only for keyword operators (they all contains "i")
-            const operatorSpacing = (["and", "or"].includes(op)) ? " " : "";
-            // Since the default code contains a project doc, we need to include it to the code
-            const code = "raise " + sampleSize(terminals, 5).join(operatorSpacing + op + operatorSpacing) + "\n";
-            testRoundTripPasteAndDownload(code, undefined, defaultProjectDocFullLine + code);
-        }
-    });
+    }
+    for (const op of sampleSize(nary_operators, 5)) {
+        // Keep a space between operands only for keyword operators (they all contains "i")
+        const operatorSpacing = (["and", "or"].includes(op)) ? " " : "";
+        // Since the default code contains a project doc, we need to include it to the code
+        const code = "raise " + sampleSize(terminals, 5).join(operatorSpacing + op + operatorSpacing) + "\n";
+        it("Supports basic n-ary operator combination: " + code.trim(), () => testRoundTripPasteAndDownload(code, undefined, defaultProjectDocFullLine + code));
+    }
     
     // Check that if you paste something that already has indent on every line, we manage to preserve
     // the relation among the lines correctly:

--- a/tests/cypress/e2e/structured-expressions-brackets.cy.ts
+++ b/tests/cypress/e2e/structured-expressions-brackets.cy.ts
@@ -27,7 +27,9 @@ describe("Test brackets", () => {
         focusEditor();
         cy.get("body").type("f");
         cy.get("body").type("a,(b,c)");
-        assertState((Cypress.env("mode") == "microbit") ? 4 : 3, "a,(b,c)$");        
+        // Frame IDs 1-4 are already taken by the starting project's 2 default imports + 2 Main
+        // frames (see nextAvailableId in initial-states.ts), so the for frame created here gets 5:
+        assertState((Cypress.env("mode") == "microbit") ? 4 : 5, "a,(b,c)$");
     });
 });
 

--- a/tests/cypress/e2e/translation.cy.ts
+++ b/tests/cypress/e2e/translation.cy.ts
@@ -242,7 +242,7 @@ describe("Locale persistence", () => {
         });        
            
 
-        // 2) the locale is correct (usual test + the function call placeholder text, which is in frame 4 for normal editor, and 5 for microbit because of import)
+        // 2) the locale is correct (usual test + the function call placeholder text exists somewhere in the code)
         checkTranslationsForLocale(localeForTest);
         cy.get("span[placeholder='" + getLocalisedString("frame.defaultText.funcCall", localeForTest) + "']").should("exist");
             

--- a/tests/cypress/support/autocomplete-test-support.ts
+++ b/tests/cypress/support/autocomplete-test-support.ts
@@ -148,6 +148,7 @@ export function checkAutocompleteSorted(acIDSel: string, isInFuncCallFrame: bool
         "neopixel",
         "time",
         "strype.graphics",
+        "strype.sound",
         BUILTIN,
     ];
     cy.get(acIDSel + " div.ac-module-header:not(." + scssVars.acEmptyResultsContainerClassName + ")")

--- a/tests/cypress/support/param-prompt-support.ts
+++ b/tests/cypress/support/param-prompt-support.ts
@@ -1,6 +1,6 @@
 
 
-import {cleanFromHTML, waitForEditorSettled} from "./test-support";
+import {cleanFromHTML, clearDefaultImports, waitForEditorSettled} from "./test-support";
 import {Signature, SignatureArg} from "tigerpython-parser";
 import { scssVars, standardBeforeEach, strypeElIds } from "./standard-setup";
 
@@ -212,6 +212,14 @@ function insertKeyboardTypingToImport(keyboardTypingToImport: string | undefined
     // As we don't have an exact way to know when such case arises in func.keyboardTypingToImport,
     // we just delay all key hit reasonably.
     if (keyboardTypingToImport) {
+        // A "{uparrow}{uparrow}" prefix means the rest of the string is meant to be typed at the
+        // top of Imports (assumed empty) -- clear the 2 default imports there first instead of
+        // just navigating past them, so the typed content still ends up in an empty Imports
+        // section exactly as this was written to expect:
+        if (keyboardTypingToImport.startsWith("{uparrow}{uparrow}")) {
+            clearDefaultImports();
+            keyboardTypingToImport = keyboardTypingToImport.slice("{uparrow}{uparrow}".length);
+        }
         cy.get("body").type(keyboardTypingToImport, {delay: 100});
     }
 }

--- a/tests/cypress/support/paste-test-support.ts
+++ b/tests/cypress/support/paste-test-support.ts
@@ -65,17 +65,25 @@ export function checkDownloadedCodeEquals(fullCode: string, format: "py" | "spy"
     // cy.readFile already polls until the file exists (up to its own timeout), so no wait is
     // needed here beforehand:
     cy.readFile(path.join(downloadsFolder, "main." + format)).then((p : string) => {
-        // Before comparing, we fix up a few oddities of our generated code:
-        // Get rid of any spaces at end of lines:
-        p = p.replaceAll(/ +\n/g, "\n");
-        // Get rid of spaces before colons at end of line:
-        p = p.replaceAll(/ +:\n/g, ":\n");
-        // Get rid of spaces before closing brackets:
-        p = p.replace(/ +([)\]}])/g, "$1");
-        // Get rid of any multiple spaces between words:
-        p = p.replace(/([^ \n])  +([^ ])/g, "$1 $2");
+        // Before comparing, we fix up a few oddities of our generated code. These normalisations
+        // apply equally to expected literals that happen to be assembled from raw internal-format
+        // fragments (e.g. getDefaultStrypeProjectImportFullLine's trailing spaces) -- both sides go
+        // through the same cleanup so callers don't need format-specific (trailing-space-free)
+        // variants of shared fragments:
+        const normalise = (s: string): string => {
+            // Get rid of any spaces at end of lines:
+            s = s.replaceAll(/ +\n/g, "\n");
+            // Get rid of spaces before colons at end of line:
+            s = s.replaceAll(/ +:\n/g, ":\n");
+            // Get rid of spaces before closing brackets:
+            s = s.replace(/ +([)\]}])/g, "$1");
+            // Get rid of any multiple spaces between words:
+            s = s.replace(/([^ \n])  +([^ ])/g, "$1 $2");
+            return s;
+        };
+        p = normalise(p);
         // Print out full version in message (without escaped \n), to make it easier to diff:
-        expect(p, "Actual unescaped:\n" + p).to.equal(fullCode.replaceAll("\r\n", "\n"));
+        expect(p, "Actual unescaped:\n" + p).to.equal(normalise(fullCode.replaceAll("\r\n", "\n")));
     });
 }
 

--- a/tests/cypress/support/test-support.ts
+++ b/tests/cypress/support/test-support.ts
@@ -37,14 +37,17 @@ export function navigateToTopOfCode(): void {
 // for the test's own import to be typed/pasted.
 export function clearDefaultImports(): void {
     navigateToTopOfCode();
-    cy.then(() => deleteFramesUpTo("#frameContainer_-1", Cypress.$("#frameContainer_-1 .frame-div").length));
+    cy.then(() => deleteFramesUpTo("#frameContainer_-1"));
 }
 
-// Presses Delete (forward) against `containerSelector`'s frame count, stopping as soon as the
-// container is actually empty rather than always pressing `maxPresses` times. `maxPresses` is
-// expected to be a safe upper bound (a count that includes nested descendants, e.g. the statements
-// inside a function/class definition's body), not an exact number of presses needed -- deleting a
-// top-level block frame removes its whole subtree in one press. Uses Delete rather than Backspace:
+// Presses Delete (forward) against `containerSelector` until it's actually empty. `maxPresses`
+// isn't a count of frames to remove -- the recursion always runs to an empty container, however
+// many presses that takes, since deleting a top-level block frame removes its whole subtree
+// (nested descendants included) in one press. It's purely a safety cap against infinite recursion
+// if a press ever failed to remove a frame (an app bug, a stuck focus, a debounce race): each call
+// passes `maxPresses - 1` down, so a genuinely stuck deletion still terminates -- with a failed
+// assertion below in the caller -- instead of hanging. Callers should not need to pass it; the
+// default is generous enough for any realistic number of frames. Uses Delete rather than Backspace:
 // the app deliberately blocks Backspace from removing a function/class definition frame when the
 // caret is inside its body (to avoid merging the body into the wrong container), which
 // forward-Delete from above the frame doesn't hit, so Delete is the only one of the two that
@@ -53,7 +56,7 @@ export function clearDefaultImports(): void {
 // synchronously queuing every press upfront against stale state. Cypress.$ (bundled jQuery) is
 // used to count rather than cy.get()/cy.find(), because both of those retry-and-fail if a selector
 // matches zero elements -- but that's exactly the "we're done" case this needs to detect.
-function deleteFramesUpTo(containerSelector: string, maxPresses: number): void {
+function deleteFramesUpTo(containerSelector: string, maxPresses = 100): void {
     if (maxPresses <= 0) {
         return;
     }
@@ -96,13 +99,13 @@ export function focusEditorAndClear(): void {
         waitForEditorSettled();
         // Clear top-down, container by container. {downarrow} from an empty/just-cleared container
         // reliably lands at the top of the next one:
-        deleteFramesUpTo("#frameContainer_-1", totalCount);
+        deleteFramesUpTo("#frameContainer_-1");
         cy.get("body").type("{downarrow}");
         waitForEditorSettled();
-        deleteFramesUpTo("#frameContainer_-2", totalCount);
+        deleteFramesUpTo("#frameContainer_-2");
         cy.get("body").type("{downarrow}");
         waitForEditorSettled();
-        deleteFramesUpTo("#frameContainer_-3", totalCount);
+        deleteFramesUpTo("#frameContainer_-3");
     });
     cy.get(".frame-div").should("have.length", 0);
 }

--- a/tests/cypress/support/test-support.ts
+++ b/tests/cypress/support/test-support.ts
@@ -24,9 +24,60 @@ export function focusEditorAndClear(): void {
     // Not totally sure why this hack is necessary, I think it's to give focus into the webpage via an initial click:
     // (on the main code container frame -- would be better to retrieve it properly but the file won't compile if we use Apps.ts and/or the store)
     cy.get("#" + strypeElIds.getFrameUID(-3), {timeout: 15 * 1000}).focus();
-    // Delete existing content (bit of a hack - and it seems having the second backspace separately avoiding test failure):
-    cy.get("body").type("{uparrow}{uparrow}{uparrow}{del}{downarrow}{downarrow}{downarrow}{downarrow}{backspace}");
-    cy.get("body").type("{backspace}");
+    // Some callers invoke this right after another operation that changes the frame tree (e.g. a
+    // file load), which can still be mid-render at this point -- settle first, otherwise the frame
+    // counts read below can be stale and this ends up pressing Delete/Backspace more times than
+    // there are actual frames, which crashes the app rather than just failing an assertion:
+    waitForEditorSettled();
+    // Deletes every frame currently in Main, Definitions and Imports -- not just the default
+    // project's frames, since this is also used to clear out whatever a previous operation (e.g. a
+    // file load) left behind, which can include Definitions content that the default project never
+    // has -- leaving a genuinely blank editor with the caret back at the top of Main, matching
+    // where this helper has always left the caret, since most callers type/paste directly into
+    // Main afterward (callers that instead want Imports, like enterImports() in
+    // media-literals.cy.ts, already do their own extra {uparrow}{uparrow} from here). Reads the
+    // frame counts from the DOM rather than hard-coding them so this doesn't go stale if a
+    // section's content changes shape. The default caret starts at the top of Main, where deleting
+    // forward removes its frames one by one; then navigating up one level at a time and deleting
+    // backward clears Definitions then Imports; then navigating back down returns to Main. Settles
+    // after every keypress -- deleting a frame can go through a delayed-removal debounce, so a
+    // later press can otherwise race ahead of a still-in-flight removal and land on/delete the
+    // wrong frame (or, worse, crash the app by deleting more times than there are frames left).
+    // Cypress.$ (bundled jQuery) is used to count rather than cy.get()/cy.find(), because both of
+    // those retry-and-fail if a selector matches zero elements -- but Definitions (and, depending
+    // on caller, Main/Imports too) is routinely empty, which is exactly the "0 iterations" case
+    // this needs to handle gracefully rather than treating as a failure. Cypress.$ queries the DOM
+    // synchronously and simply returns an empty result, with no such assertion built in.
+    cy.then(() => {
+        const mainCount = Cypress.$("#frameContainer_-3 .frame-div").length;
+        for (let i = 0; i < mainCount; i++) {
+            cy.get("body").type("{del}");
+            waitForEditorSettled();
+        }
+    });
+    cy.get("body").type("{uparrow}");
+    waitForEditorSettled();
+    cy.then(() => {
+        const defsCount = Cypress.$("#frameContainer_-2 .frame-div").length;
+        for (let i = 0; i < defsCount; i++) {
+            cy.get("body").type("{backspace}");
+            waitForEditorSettled();
+        }
+    });
+    cy.get("body").type("{uparrow}");
+    waitForEditorSettled();
+    cy.then(() => {
+        const importsCount = Cypress.$("#frameContainer_-1 .frame-div").length;
+        for (let i = 0; i < importsCount; i++) {
+            cy.get("body").type("{backspace}");
+            waitForEditorSettled();
+        }
+    });
+    cy.get(".frame-div").should("have.length", 0);
+    cy.get("body").type("{downarrow}");
+    waitForEditorSettled();
+    cy.get("body").type("{downarrow}");
+    waitForEditorSettled();
 }
 
 // Waits for the editor to settle after an action (typing, pasting, frame manipulation) rather

--- a/tests/cypress/support/test-support.ts
+++ b/tests/cypress/support/test-support.ts
@@ -15,9 +15,29 @@ export function getDefaultStrypeProjectDocumentationFullLine(mode: string): stri
 }
 
 export function getDefaultStrypeProjectImportFullLine(mode: string): string {
-    return (mode == "microbit") 
+    return (mode == "microbit")
         ? "from microbit import *\n"
-        : "";
+        : "from strype.graphics import * \nfrom strype.sound import * \n";
+}
+
+// Navigates to the top of the code (the top of Imports) from wherever the caret currently is,
+// ready to type/paste a new import above whatever's already there. Implemented as repeated
+// {home}{uparrow} presses rather than a fixed {uparrow} count: {home} is a no-op once already at
+// the start of a line/frame and {uparrow} is a no-op once at the very top, so this reliably
+// reaches the top regardless of how many frames (including default imports) precede it -- unlike
+// an exact {uparrow} count, which breaks every time the starting project's shape changes.
+export function navigateToTopOfCode(): void {
+    cy.get("body").type("{home}{uparrow}{home}{uparrow}{home}{uparrow}");
+}
+
+// Navigates to the top of the code, then deletes whatever's currently in Imports (the 2 default
+// imports on a fresh project) so tests that are specifically about typing/pasting a *new* import
+// and checking autocomplete behave the same as when Imports started out empty, rather than having
+// to account for the defaults now being there too. Leaves the caret at the top of Imports, ready
+// for the test's own import to be typed/pasted.
+export function clearDefaultImports(): void {
+    navigateToTopOfCode();
+    cy.then(() => deleteFramesUpTo("#frameContainer_-1", Cypress.$("#frameContainer_-1 .frame-div").length));
 }
 
 // Presses Delete (forward) against `containerSelector`'s frame count, stopping as soon as the

--- a/tests/cypress/support/test-support.ts
+++ b/tests/cypress/support/test-support.ts
@@ -20,14 +20,40 @@ export function getDefaultStrypeProjectImportFullLine(mode: string): string {
         : "";
 }
 
+// Presses Delete (forward) against `containerSelector`'s frame count, stopping as soon as the
+// container is actually empty rather than always pressing `maxPresses` times. `maxPresses` is
+// expected to be a safe upper bound (a count that includes nested descendants, e.g. the statements
+// inside a function/class definition's body), not an exact number of presses needed -- deleting a
+// top-level block frame removes its whole subtree in one press. Uses Delete rather than Backspace:
+// the app deliberately blocks Backspace from removing a function/class definition frame when the
+// caret is inside its body (to avoid merging the body into the wrong container), which
+// forward-Delete from above the frame doesn't hit, so Delete is the only one of the two that
+// reliably clears block frames with children. Recurses through cy.then() (not a plain JS loop) so
+// each check happens after the previous keypress has actually been applied to the DOM, rather than
+// synchronously queuing every press upfront against stale state. Cypress.$ (bundled jQuery) is
+// used to count rather than cy.get()/cy.find(), because both of those retry-and-fail if a selector
+// matches zero elements -- but that's exactly the "we're done" case this needs to detect.
+function deleteFramesUpTo(containerSelector: string, maxPresses: number): void {
+    if (maxPresses <= 0) {
+        return;
+    }
+    cy.then(() => {
+        if (Cypress.$(containerSelector + " .frame-div").length > 0) {
+            cy.get("body").type("{del}");
+            waitForEditorSettled();
+            deleteFramesUpTo(containerSelector, maxPresses - 1);
+        }
+    });
+}
+
 export function focusEditorAndClear(): void {
     // Not totally sure why this hack is necessary, I think it's to give focus into the webpage via an initial click:
     // (on the main code container frame -- would be better to retrieve it properly but the file won't compile if we use Apps.ts and/or the store)
     cy.get("#" + strypeElIds.getFrameUID(-3), {timeout: 15 * 1000}).focus();
     // Some callers invoke this right after another operation that changes the frame tree (e.g. a
     // file load), which can still be mid-render at this point -- settle first, otherwise the frame
-    // counts read below can be stale and this ends up pressing Delete/Backspace more times than
-    // there are actual frames, which crashes the app rather than just failing an assertion:
+    // counts read below can be stale and this ends up pressing Delete more times than there are
+    // actual frames, which crashes the app rather than just failing an assertion:
     waitForEditorSettled();
     // Deletes every frame currently in Main, Definitions and Imports -- not just the default
     // project's frames, since this is also used to clear out whatever a previous operation (e.g. a
@@ -35,49 +61,30 @@ export function focusEditorAndClear(): void {
     // has -- leaving a genuinely blank editor with the caret back at the top of Main, matching
     // where this helper has always left the caret, since most callers type/paste directly into
     // Main afterward (callers that instead want Imports, like enterImports() in
-    // media-literals.cy.ts, already do their own extra {uparrow}{uparrow} from here). Reads the
-    // frame counts from the DOM rather than hard-coding them so this doesn't go stale if a
-    // section's content changes shape. The default caret starts at the top of Main, where deleting
-    // forward removes its frames one by one; then navigating up one level at a time and deleting
-    // backward clears Definitions then Imports; then navigating back down returns to Main. Settles
-    // after every keypress -- deleting a frame can go through a delayed-removal debounce, so a
-    // later press can otherwise race ahead of a still-in-flight removal and land on/delete the
-    // wrong frame (or, worse, crash the app by deleting more times than there are frames left).
-    // Cypress.$ (bundled jQuery) is used to count rather than cy.get()/cy.find(), because both of
-    // those retry-and-fail if a selector matches zero elements -- but Definitions (and, depending
-    // on caller, Main/Imports too) is routinely empty, which is exactly the "0 iterations" case
-    // this needs to handle gracefully rather than treating as a failure. Cypress.$ queries the DOM
-    // synchronously and simply returns an empty result, with no such assertion built in.
+    // media-literals.cy.ts, already do their own extra {uparrow}{uparrow} from here).
     cy.then(() => {
-        const mainCount = Cypress.$("#frameContainer_-3 .frame-div").length;
-        for (let i = 0; i < mainCount; i++) {
-            cy.get("body").type("{del}");
-            waitForEditorSettled();
+        const totalCount = Cypress.$(".frame-div").length;
+        // Reach the very top of the whole document regardless of the current caret position or how
+        // deeply nested any block frame's content is. {uparrow} is a no-op once already at the
+        // top, so pressing it more times than could possibly be needed is harmless -- but a block
+        // frame's body is itself an extra caret stop beyond the one .frame-div element it counts
+        // as, so totalCount alone can undershoot for nested content; multiplying it gives enough
+        // headroom for that without needing to know the exact nesting depth:
+        for (let i = 0; i < totalCount * 3 + 10; i++) {
+            cy.get("body").type("{uparrow}");
         }
-    });
-    cy.get("body").type("{uparrow}");
-    waitForEditorSettled();
-    cy.then(() => {
-        const defsCount = Cypress.$("#frameContainer_-2 .frame-div").length;
-        for (let i = 0; i < defsCount; i++) {
-            cy.get("body").type("{backspace}");
-            waitForEditorSettled();
-        }
-    });
-    cy.get("body").type("{uparrow}");
-    waitForEditorSettled();
-    cy.then(() => {
-        const importsCount = Cypress.$("#frameContainer_-1 .frame-div").length;
-        for (let i = 0; i < importsCount; i++) {
-            cy.get("body").type("{backspace}");
-            waitForEditorSettled();
-        }
+        waitForEditorSettled();
+        // Clear top-down, container by container. {downarrow} from an empty/just-cleared container
+        // reliably lands at the top of the next one:
+        deleteFramesUpTo("#frameContainer_-1", totalCount);
+        cy.get("body").type("{downarrow}");
+        waitForEditorSettled();
+        deleteFramesUpTo("#frameContainer_-2", totalCount);
+        cy.get("body").type("{downarrow}");
+        waitForEditorSettled();
+        deleteFramesUpTo("#frameContainer_-3", totalCount);
     });
     cy.get(".frame-div").should("have.length", 0);
-    cy.get("body").type("{downarrow}");
-    waitForEditorSettled();
-    cy.get("body").type("{downarrow}");
-    waitForEditorSettled();
 }
 
 // Waits for the editor to settle after an action (typing, pasting, frame manipulation) rather

--- a/tests/playwright/e2e/description-fields.spec.ts
+++ b/tests/playwright/e2e/description-fields.spec.ts
@@ -1,10 +1,46 @@
-import {test, expect} from "@playwright/test";
-import {checkFrameXorTextCursor, doTextHomeEndKeyPress} from "../support/editor";
+import {test, expect, Page} from "@playwright/test";
+import {checkFrameXorTextCursor, doTextHomeEndKeyPress, getDefaultStrypeProjectImportsFullLine} from "../support/editor";
 import {readFileSync} from "node:fs";
 import {loadContent, save, testPlaywrightRoundTripImportAndDownload} from "../support/loading-saving";
 import { setupStrypeTest } from "../support/general";
 
 const defaultStandardStrypeProjectDocLiteralWithDotSpace = "This is the default Strype starter project. ";
+const defaultStrypeProjectImportsLiteral = getDefaultStrypeProjectImportsFullLine();
+
+// Reaches the project description field from wherever the caret currently is. Presses ArrowUp a
+// generous number of times (a no-op once already at the very top, so any excess is harmless) to
+// reach the top of Imports regardless of how many default imports currently exist there, then
+// ArrowLeft to enter the description field itself -- more robust than a fixed "ArrowUp x2" count,
+// which broke when the default project started including import frames.
+async function enterProjectDescriptionField(page: Page) : Promise<void> {
+    await page.keyboard.press("Home");
+    for (let i = 0; i < 20; i++) {
+        await page.keyboard.press("ArrowUp");
+    }
+    await page.keyboard.press("ArrowLeft");
+}
+
+// From the top of Imports (where ArrowRight leaves the description field), moves the caret down
+// into the empty Definitions section so a fresh function definition can be typed there. Checks the
+// actual caret location after each ArrowDown rather than assuming a fixed press count, since that
+// count depends on how many frames are currently in Imports (today: the 2 default imports) --
+// unlike the generous-ArrowUp trick in enterProjectDescriptionField, overshooting here would land
+// in Main (which has real content) rather than harmlessly stopping at the top, so a fixed count
+// that's merely "big enough" isn't safe to use.
+async function enterEmptyDefinitionsSection(page: Page): Promise<void> {
+    for (let i = 0; i < 20; i++) {
+        const inDefinitions = await page.evaluate(() => {
+            const scssVars = (window as any)["StrypeSCSSVarsGlobals"];
+            const caret = document.querySelector("." + scssVars.caretClassName + ":not(." + scssVars.invisibleClassName + ")");
+            return !!caret?.closest("#frameContainer_-2");
+        });
+        if (inDefinitions) {
+            return;
+        }
+        await page.keyboard.press("ArrowDown");
+    }
+    throw new Error("Could not reach the Definitions section");
+}
 
 test.beforeEach(async ({ page, browserName }, testInfo) => {
     await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 90000, skipPyodide: true});
@@ -15,16 +51,13 @@ test.describe("Project description selection", () => {
         await checkFrameXorTextCursor(page);
     });
     test("Enter project description by typing", async ({page}, testInfo) => {
-        await page.keyboard.press("Home");
-        await page.keyboard.press("ArrowUp");
-        await page.keyboard.press("ArrowUp");
-        await page.keyboard.press("ArrowLeft");
+        await enterProjectDescriptionField(page);
         await page.keyboard.type(". A project description");
         expect(readFileSync(await save(page), "utf-8")).toEqual(`
 #(=> Strype:1:std
 '''${defaultStandardStrypeProjectDocLiteralWithDotSpace}A project description'''
 #(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 myString  = "Hello from Strype" 
 print(myString) 
@@ -43,10 +76,7 @@ print(myString)
     for (const selectAll of selectAllCombinations) {
         for (const deleteCommand of [["Backspace"], ["Delete"], [/*no press, just overtype*/]]) {
             test("Replace project description via " + JSON.stringify(selectAll) + " then " + JSON.stringify(deleteCommand), async ({page}, testInfo) => {
-                await page.keyboard.press("Home");
-                await page.keyboard.press("ArrowUp");
-                await page.keyboard.press("ArrowUp");
-                await page.keyboard.press("ArrowLeft");
+                await enterProjectDescriptionField(page);
                 await page.keyboard.type(". Initial project description");
                 await page.waitForTimeout(2000);
                 for (const key of selectAll) {
@@ -68,7 +98,7 @@ print(myString)
 #(=> Strype:1:std
 '''The replacement'''
 #(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 myString  = "Hello from Strype" 
 print(myString) 
@@ -79,13 +109,10 @@ print(myString)
     }
 
     test("Enter project and function description with quotes in it", async ({page}, testInfo) => {
-        await page.keyboard.press("Home");
-        await page.keyboard.press("ArrowUp");
-        await page.keyboard.press("ArrowUp");
-        await page.keyboard.press("ArrowLeft");
+        await enterProjectDescriptionField(page);
         await page.keyboard.type(". \"This is in double quotes\" and ''this is in doubled single quotes'' and this is an unmatched apostrophe of someone's.");
         await page.keyboard.press("ArrowRight");
-        await page.keyboard.press("ArrowDown");
+        await enterEmptyDefinitionsSection(page);
         await page.keyboard.type("f");
         await page.keyboard.type("foo");
         await page.keyboard.press("ArrowRight");
@@ -95,7 +122,7 @@ print(myString)
 #(=> Strype:1:std
 '''${defaultStandardStrypeProjectDocLiteralWithDotSpace}"This is in double quotes" and \\'\\'this is in doubled single quotes\\'\\' and this is an unmatched apostrophe of someone\\'s.'''
 #(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 def foo ( ) :
     '''"This is in double quotes" and \\'\\'this is in doubled single quotes\\'\\' and this is also an unmatched apostrophe of someone\\'s.'''
     pass
@@ -107,17 +134,14 @@ print(myString)
     });
 
     test("Enter project and function description with newlines in it", async ({page}, testInfo) => {
-        await page.keyboard.press("Home");
-        await page.keyboard.press("ArrowUp");
-        await page.keyboard.press("ArrowUp");
-        await page.keyboard.press("ArrowLeft");
+        await enterProjectDescriptionField(page);
         await page.keyboard.type(". This has");
         await page.keyboard.press("Shift+Enter");
         await page.keyboard.type("three");
         await page.keyboard.press("Shift+Enter");
         await page.keyboard.type("lines.");
         await page.keyboard.press("ArrowRight");
-        await page.keyboard.press("ArrowDown");
+        await enterEmptyDefinitionsSection(page);
         await page.keyboard.type("f");
         await page.keyboard.type("foo");
         await page.keyboard.press("ArrowRight");
@@ -135,7 +159,7 @@ print(myString)
 three
 lines.'''
 #(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 def foo ( ) :
     '''This has
     four
@@ -150,16 +174,13 @@ print(myString)
     });
 
     test("Enter project description with triple quotes in it", async ({page}, testInfo) => {
-        await page.keyboard.press("Home");
-        await page.keyboard.press("ArrowUp");
-        await page.keyboard.press("ArrowUp");
-        await page.keyboard.press("ArrowLeft");
+        await enterProjectDescriptionField(page);
         await page.keyboard.type(". This has horrible quotes: \"\"\" ''' \"\"\" ''' and backslashes by quotes \\' and some doubles to end: '' ''");
         expect(readFileSync(await save(page), "utf-8")).toEqual(`
 #(=> Strype:1:std
 '''${defaultStandardStrypeProjectDocLiteralWithDotSpace}This has horrible quotes: """ \\'\\'\\' """ \\'\\'\\' and backslashes by quotes \\\\\\' and some doubles to end: \\'\\' \\'\\''''
 #(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 myString  = "Hello from Strype" 
 print(myString) 

--- a/tests/playwright/e2e/fileIO.spec.ts
+++ b/tests/playwright/e2e/fileIO.spec.ts
@@ -1,5 +1,5 @@
 import { test, Page } from "@playwright/test";
-import { doPagePaste } from "../support/editor";
+import { clearDefaultProject, doPagePaste } from "../support/editor";
 import { checkConsoleContent, runToFinish } from "../support/execution";
 import { setupStrypeTest } from "../support/general";
 
@@ -9,13 +9,9 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
 });
 
 function deleteDefaultProject(): ((page: Page) => Promise<void>) {
-    return async (page) => {
-        await page.waitForTimeout(200);
-        await page.keyboard.press(process.platform == "darwin" ? "Meta+a" : "Control+a");
-        await page.waitForTimeout(200);
-        await page.keyboard.press("Backspace");
-        await page.waitForTimeout(200);
-    };
+    // Ctrl/Cmd+A only selects the current section (Main), not Imports too, so it can't be used to
+    // blank the whole starting project on its own -- use the shared helper instead:
+    return clearDefaultProject;
 }
 
 function copyAssetInTemp(assetPath: string, copyFileName: string): ((page: Page) => Promise<void>) {
@@ -27,7 +23,13 @@ with open("/tmp/${copyFileName}","wb")  as f2  :
 `;
     return async (page) => {
         await deleteDefaultProject()(page);
-        await doPagePaste(page, createAssetCopyCode);        
+        // deleteDefaultProject leaves the caret at the top of Imports; move to Main so this paste
+        // (and the test's own paste that immediately follows, with no navigation in between) both
+        // land in Main in the right order -- the test's code reads the file this writes, so it
+        // must run second:
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("ArrowDown");
+        await doPagePaste(page, createAssetCopyCode);
     };
 }
 

--- a/tests/playwright/e2e/fileIO.spec.ts
+++ b/tests/playwright/e2e/fileIO.spec.ts
@@ -8,12 +8,6 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
     await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 240000});
 });
 
-function deleteDefaultProject(): ((page: Page) => Promise<void>) {
-    // Ctrl/Cmd+A only selects the current section (Main), not Imports too, so it can't be used to
-    // blank the whole starting project on its own -- use the shared helper instead:
-    return clearDefaultProject;
-}
-
 function copyAssetInTemp(assetPath: string, copyFileName: string): ((page: Page) => Promise<void>) {
     const createAssetCopyCode = `text  = "" 
 with open("${assetPath}","rb")  as f  :
@@ -22,8 +16,8 @@ with open("/tmp/${copyFileName}","wb")  as f2  :
     f2.write(content) 
 `;
     return async (page) => {
-        await deleteDefaultProject()(page);
-        // deleteDefaultProject leaves the caret at the top of Imports; move to Main so this paste
+        await clearDefaultProject(page);
+        // clearDefaultProject leaves the caret at the top of Imports; move to Main so this paste
         // (and the test's own paste that immediately follows, with no navigation in between) both
         // land in Main in the right order -- the test's code reads the file this writes, so it
         // must run second:
@@ -35,7 +29,9 @@ with open("/tmp/${copyFileName}","wb")  as f2  :
 
 test.describe("Internal FileIO checkups", () => {
     test("Read N lines of an existing file (text)", async ({page}) => {
-        await deleteDefaultProject()(page);
+        // Ctrl/Cmd+A only selects the current section (Main), not Imports too, so it can't be used to
+        // blank the whole starting project on its own -- use the shared helper instead:
+        await clearDefaultProject(page);
         const readExistingFileCode = `with open("/books/fairy-tales.txt",encoding="utf-8")  as f  :
     for line_index  in range(0,5)  :
         print(f"#{line_index+1} -> {f.readline()}") 
@@ -58,7 +54,7 @@ test.describe("Internal FileIO checkups", () => {
     });
 
     test("Read N bytes of an existing file (binary)", async ({page}) => {
-        await deleteDefaultProject()(page);
+        await clearDefaultProject(page);
         const readExistingFileCode = `with open("/images/cat-test.jpg","rb")  as f  :
     print(f.read(20)) 
 `;
@@ -70,7 +66,7 @@ test.describe("Internal FileIO checkups", () => {
     });
 
     test("Write bytes in a new file", async ({page}) => {
-        await deleteDefaultProject()(page);
+        await clearDefaultProject(page);
         const writeThenReadCode = `with open("/tmp/tests.txt","wb")  as f  :
     bytes_txt  = bytearray([83,116,114,121,112,101]) 
     f.write(bytes_txt) 

--- a/tests/playwright/e2e/fileIO.spec.ts
+++ b/tests/playwright/e2e/fileIO.spec.ts
@@ -1,5 +1,5 @@
 import { test, Page } from "@playwright/test";
-import { clearDefaultProject, doPagePaste } from "../support/editor";
+import { clearDefaultProject, doPagePaste, pressN } from "../support/editor";
 import { checkConsoleContent, runToFinish } from "../support/execution";
 import { setupStrypeTest } from "../support/general";
 
@@ -21,8 +21,7 @@ with open("/tmp/${copyFileName}","wb")  as f2  :
         // (and the test's own paste that immediately follows, with no navigation in between) both
         // land in Main in the right order -- the test's code reads the file this writes, so it
         // must run second:
-        await page.keyboard.press("ArrowDown");
-        await page.keyboard.press("ArrowDown");
+        await pressN("ArrowDown", 2)(page);
         await doPagePaste(page, createAssetCopyCode);
     };
 }

--- a/tests/playwright/e2e/load-save-demos-books.spec.ts
+++ b/tests/playwright/e2e/load-save-demos-books.spec.ts
@@ -4,7 +4,7 @@ import {readFileSync} from "node:fs";
 import {setupStrypeTest} from "../support/general";
 import {createBrowserProxy} from "../support/proxy";
 import {WINDOW_STRYPE_HTMLIDS_PROPNAME} from "@/helpers/sharedIdCssWithTests";
-import {doPagePaste} from "../support/editor";
+import {clearDefaultProject, doPagePaste} from "../support/editor";
 
 let strypeElIds: {[varName: string]: (...args: any[]) => Promise<string>};
 let scssVars: {[varName: string]: string};
@@ -45,8 +45,13 @@ test.describe("Load/save book projects", () => {
         test(`Paste fireworks after moving up ${i} times`, async ({page}) => {
             // Check same as above but with pasting:
             const original = readFileSync("public/book_projects/chapter02/fireworks.spy", "utf8").replace(/\r\n/g, "\n");
-            await page.keyboard.press("Delete");
-            await page.keyboard.press("Delete");
+            await clearDefaultProject(page);
+            // clearDefaultProject leaves the caret at the top of (now empty) Imports; return to
+            // Main so the "move up i times" logic below still exercises pasting with the caret in
+            // Main/Defs/Imports respectively, now that Imports itself has also been cleared of its
+            // default content:
+            await page.keyboard.press("ArrowDown");
+            await page.keyboard.press("ArrowDown");
             for (let j = 0; j < i; j++) {
                 await page.keyboard.press("ArrowUp");
             }

--- a/tests/playwright/e2e/load-save-demos-books.spec.ts
+++ b/tests/playwright/e2e/load-save-demos-books.spec.ts
@@ -4,7 +4,7 @@ import {readFileSync} from "node:fs";
 import {setupStrypeTest} from "../support/general";
 import {createBrowserProxy} from "../support/proxy";
 import {WINDOW_STRYPE_HTMLIDS_PROPNAME} from "@/helpers/sharedIdCssWithTests";
-import {clearDefaultProject, doPagePaste} from "../support/editor";
+import {clearDefaultProject, doPagePaste, pressN} from "../support/editor";
 
 let strypeElIds: {[varName: string]: (...args: any[]) => Promise<string>};
 let scssVars: {[varName: string]: string};
@@ -53,8 +53,7 @@ test.describe("Load/save book projects", () => {
             // Main so the "move up i times" logic below still exercises pasting with the caret in
             // Main/Defs/Imports respectively, now that Imports itself has also been cleared of its
             // default content:
-            await page.keyboard.press("ArrowDown");
-            await page.keyboard.press("ArrowDown");
+            await pressN("ArrowDown", 2)(page);
             for (let j = 0; j < i; j++) {
                 await page.keyboard.press("ArrowUp");
             }

--- a/tests/playwright/e2e/load-save-demos-books.spec.ts
+++ b/tests/playwright/e2e/load-save-demos-books.spec.ts
@@ -12,7 +12,10 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
     // CI run 29398704984 (macos-latest+chromium) showed "moving up 0 times" timing out at 240s
     // waiting on the book-picker dialog to populate ("fireworks" entry never became clickable);
     // siblings "moving up 1/2 times" hit the same wait but recovered on retry. Bumped for margin.
-    await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 360_000, skipPyodide: true});
+    // CI run 29564701756 (same job) still timed out at 360s on "moving up 2 times" (same symptom --
+    // the "fireworks" entry resolved, then went "detached from the DOM, retrying" until timeout,
+    // through all 4 attempts), so bumping again:
+    await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 480_000, skipPyodide: true});
     strypeElIds = createBrowserProxy(page, WINDOW_STRYPE_HTMLIDS_PROPNAME);
     scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
 });

--- a/tests/playwright/e2e/load-save-dividers.spec.ts
+++ b/tests/playwright/e2e/load-save-dividers.spec.ts
@@ -2,7 +2,7 @@ import {expect, Page, test} from "@playwright/test";
 import {load, save} from "../support/loading-saving";
 import fs from "fs";
 import { randomUUID } from "node:crypto";
-import { getDefaultStrypeProjectDocumentationFullLine } from "../support/editor";
+import { getDefaultStrypeProjectDocumentationFullLine, getDefaultStrypeProjectImportsFullLine } from "../support/editor";
 import en from "@/localisation/en/en_main.json";
 import {StrypePEALayoutMode} from "../../cypress/support/frame-types";
 import {dragDividerTo, getSplitterPos} from "../support/dividers";
@@ -37,7 +37,7 @@ async function saveAndCheck(page: Page, dividerStates: RegExp[]) {
     // Since the default code contains a project doc, we need to include it to the code
     expect(savedLines.slice(1 + dividerStates.length)).toEqual(`
 ${getDefaultStrypeProjectDocumentationFullLine()}#(=> Section:Imports
-#(=> Section:Definitions
+${getDefaultStrypeProjectImportsFullLine()}#(=> Section:Definitions
 #(=> Section:Main
 myString  = "Hello from Strype" 
 print(myString) 

--- a/tests/playwright/e2e/load-save-random.spec.ts
+++ b/tests/playwright/e2e/load-save-random.spec.ts
@@ -9,11 +9,11 @@ import en from "../../../src/localisation/en/en_main.json";
 import {WINDOW_STRYPE_HTMLIDS_PROPNAME} from "../../../src/helpers/sharedIdCssWithTests";
 import {Page, test, expect, ElementHandle, JSHandle} from "@playwright/test";
 import { rename } from "fs/promises";
-import {checkFrameXorTextCursor, typeIndividually, waitForEditorSettled} from "../support/editor";
+import {checkFrameXorTextCursor, clearDefaultProject, typeIndividually, waitForEditorSettled} from "../support/editor";
 import {readFileSync} from "node:fs";
 import {createBrowserProxy} from "../support/proxy";
 import {load, save} from "../support/loading-saving";
-import { setupStrypeTest } from "../support/general";
+import { DEFAULT_STARTING_FRAME_COUNT, setupStrypeTest } from "../support/general";
 
 let scssVars: {[varName: string]: string};
 let strypeElIds: {[varName: string]: (...args: any[]) => Promise<string>};
@@ -380,15 +380,14 @@ async function newProject(page: Page) : Promise<void> {
     await page.click("#" + await strypeElIds.getNewProjectLinkId(), {noWaitAfter: true});
     // A full page reload is genuinely slower than the default 5s assertion timeout under load
     // (same reasoning as the equivalent check in loading-saving.ts's load()):
-    await expect(page.locator(".frame-div")).toHaveCount(2, {timeout: 20000});
+    await expect(page.locator(".frame-div")).toHaveCount(DEFAULT_STARTING_FRAME_COUNT, {timeout: 20000});
 }
 
 async function testSpecific(page: Page, sections: FrameEntry[][], projectDoc?: string) : Promise<void> {
-    await page.keyboard.press("Delete");
-    await page.keyboard.press("Delete");
-    await page.keyboard.press("ArrowUp");
-    await page.keyboard.press("ArrowUp");
-    
+    // Clears every default frame (Imports and Main), leaving the caret at the top of Imports --
+    // exactly where the section-by-section loop below needs to start:
+    await clearDefaultProject(page);
+
     if (projectDoc) {
         await page.keyboard.press("ArrowLeft");
         await waitForEditorSettled(page);
@@ -450,10 +449,9 @@ test.describe("Enters, saves and loads random frame", () => {
                 return;
             }
             
-            await page.keyboard.press("Delete");
-            await page.keyboard.press("Delete");
-            await page.keyboard.press("ArrowUp");
-            await page.keyboard.press("ArrowUp");
+            // Clears every default frame (Imports and Main), leaving the caret at the top of
+            // Imports -- exactly where the section-by-section loop below needs to start:
+            await clearDefaultProject(page);
 
             const seed = Math.random().toString();
             console.log(`Seed: "${seed}"`);

--- a/tests/playwright/e2e/load-save-share.spec.ts
+++ b/tests/playwright/e2e/load-save-share.spec.ts
@@ -3,7 +3,7 @@ import { load, save } from "../support/loading-saving";
 import { createBrowserProxy } from "../support/proxy";
 import { WINDOW_STRYPE_HTMLIDS_PROPNAME } from "@/helpers/sharedIdCssWithTests";
 import { readFileSync } from "node:fs";
-import { setupStrypeTest } from "../support/general";
+import { DEFAULT_STARTING_FRAME_COUNT, setupStrypeTest } from "../support/general";
 
 //let scssVars: {[varName: string]: string};
 let strypeElIds: {[varName: string]: (...args: any[]) => Promise<string>};
@@ -36,9 +36,9 @@ async function testLongRoundTripLoadShareNewLoadSave(page: Page, filepath: strin
     await page.waitForSelector("body");
     // Should be no need to tell it we want to discard changes, because unchanged since load
 
-    // Quick sanity check that it is a new project; should only be two frames. Give this a
-    // generous timeout since the reload above can take a while to finish mounting:
-    await expect(page.locator(".frame-header")).toHaveCount(2, { timeout: 20000 });
+    // Quick sanity check that it is a new project. Give this a generous timeout since the reload
+    // above can take a while to finish mounting:
+    await expect(page.locator(".frame-header")).toHaveCount(DEFAULT_STARTING_FRAME_COUNT, { timeout: 20000 });
 
     console.log("Visiting share link: " + shareLink.slice(0, 75));
     

--- a/tests/playwright/e2e/match-statement.spec.ts
+++ b/tests/playwright/e2e/match-statement.spec.ts
@@ -2,14 +2,15 @@ import {test, expect} from "@playwright/test";
 import {readFileSync} from "node:fs";
 import {save, testPlaywrightRoundTripImportAndDownload} from "../support/loading-saving";
 import {setupStrypeTest} from "../support/general";
-import {getDefaultStrypeProjectDocumentationFullLine, pressN, waitForEditorSettled} from "../support/editor";
+import {getDefaultStrypeProjectDocumentationFullLine, getDefaultStrypeProjectImportsFullLine, pressN, waitForEditorSettled} from "../support/editor";
 
 const defaultStandardStrypeProjectDocLiteral = getDefaultStrypeProjectDocumentationFullLine();
+const defaultStrypeProjectImportsLiteral = getDefaultStrypeProjectImportsFullLine();
 
 const basicMatchLiteral = `
 #(=> Strype:1:std
 ${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 match ___strype_blank  :
     case _  :
@@ -22,7 +23,7 @@ print(myString)
 const defaultProjectCodeLiteral = `
 #(=> Strype:1:std
 ${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 myString  = "Hello from Strype" 
 print(myString) 
@@ -59,7 +60,7 @@ test.describe("Add Match statement", () => {
         expect(readFileSync(await save(page), "utf-8")).toEqual(`
 #(=> Strype:1:std
 ${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 match foo  :
     case bar if x>0  :
@@ -250,7 +251,7 @@ print(myString)
         expect(readFileSync(await save(page), "utf-8")).toEqual(`
 #(=> Strype:1:std
 ${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 match value  :
     # 1. Literal patterns
@@ -297,7 +298,7 @@ print(myString)
         expect(readFileSync(await save(page), "utf-8")).toEqual(`
 #(=> Strype:1:std
 ${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 match ___strype_blank  :
     case _  :
@@ -365,7 +366,7 @@ test.describe("Delete Match statement", () => {
         expect(readFileSync(await save(page), "utf-8")).toEqual(`
 #(=> Strype:1:std
 ${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 match ___strype_blank  :
     case _  :
@@ -388,7 +389,7 @@ print(myString)
         expect(readFileSync(await save(page, false), "utf-8")).toEqual(`
 #(=> Strype:1:std
 ${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 match ___strype_blank  :
     pass

--- a/tests/playwright/e2e/rename-identifiers.spec.ts
+++ b/tests/playwright/e2e/rename-identifiers.spec.ts
@@ -1,15 +1,20 @@
-import {test, expect, Locator} from "@playwright/test";
+import {test, expect, Locator, Page} from "@playwright/test";
 import {readFileSync} from "node:fs";
 import {save} from "../support/loading-saving";
 import {setupStrypeTest} from "../support/general";
-import {doPagePaste, getDefaultStrypeProjectDocumentationFullLine, pressN, waitForEditorSettled} from "../support/editor";
+import {doPagePaste, getDefaultStrypeProjectDocumentationFullLine, getDefaultStrypeProjectImportsFullLine, pressN, waitForEditorSettled} from "../support/editor";
 
 const defaultStandardStrypeProjectDocLiteral = getDefaultStrypeProjectDocumentationFullLine();
+const defaultStrypeProjectImportsLiteral = getDefaultStrypeProjectImportsFullLine();
+// One line per default import frame -- used to skip past them after Control+Home, which (unlike
+// PageUp) deterministically jumps to the very top of Imports rather than a viewport-dependent
+// position, so a count derived from the defaults' own current content is reliable here:
+const numberOfDefaultImportFrames = defaultStrypeProjectImportsLiteral.trim().split("\n").length;
 
 const initialProjectCodeLiteral = `
 #(=> Strype:1:std
 ${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
-#(=> Section:Definitions
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
 #(=> Section:Main
 myString  = "Hello from Strype" 
 print(myString) 
@@ -152,6 +157,37 @@ test.beforeEach(async ({ page, browserName }, testInfo) => {
     openedPopoverLocator = page.locator(`.popover.show:has(.${scssVars.renameIdentifierPopoverClassName})`);
 });
 
+// Most of the literals above are used both as the pasted clipboard content and (via the
+// .replaceAll() rename substitutions applied to them) as the basis for the expected saved-file
+// content -- but pasting a fixture whose own Imports section is empty doesn't touch Imports at all
+// (see pasteMixedPython in src/helpers/pythonToFrames.ts: a section with no parsed frames is simply
+// skipped), so the project's own starting default imports are what end up in the saved file, not
+// anything from the pasted text. Baking the defaults into the literal itself would have them
+// pasted too, duplicating them -- so instead this inserts them only on the expected-result side,
+// right after the literal's own (paste-time-empty) Imports section header. Also correct for
+// importCodeLiteral, whose paste *does* add its own import (datetime): that gets inserted at the
+// bottom of Imports (after the existing defaults), so the defaults still belong directly after the
+// header, ahead of it.
+function withDefaultImports(code: string): string {
+    return code.replace("#(=> Section:Imports\n", "#(=> Section:Imports\n" + defaultStrypeProjectImportsLiteral);
+}
+
+// PageUp, pressed while already showing a frame cursor (rather than while editing text), jumps the
+// caret straight to the very top of the document (top of Imports), not just up by one frame --
+// confirmed empirically by probing the app's live caret state, both with the current default
+// imports present and (by temporarily reverting to the pre-default-imports source) without them.
+// Tests below that use PageUp to reach a known point in a pasted Definitions/Main fixture were
+// written when Imports was empty, so PageUp landed directly at the top of Definitions; with
+// defaults now present, they need one extra ArrowDown per default import frame first -- tied to
+// the defaults' own current content (numberOfDefaultImportFrames) rather than a hardcoded number --
+// before their original navigation continues unchanged. (A naive fix here checked the caret's
+// current container and stopped as soon as it left Imports, but that overshoots: the boundary
+// transition into Definitions is itself the first step of each test's own original navigation, so
+// consuming it here caused those tests to land one frame too far.)
+async function skipPastImports(page: Page): Promise<void> {
+    await pressN("ArrowDown", numberOfDefaultImportFrames, true)(page);
+}
+
 test.describe("Basic interaction", () => {
     test("KB shortcut, change", async ({page}) => {
         await page.keyboard.press("ArrowRight");
@@ -288,7 +324,7 @@ test.describe("Variable changes in main section", () => {
         await page.keyboard.press(renameKBShortcut);
         await expect(renameButton).toBeHidden();
         // Check results
-        expect(readFileSync(await save(page), "utf-8")).toEqual(mainCodeMultiVarsCodeLiteral.replaceAll("myString", "_new_myString").replaceAll("anotherString","_new_anotherString").trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(mainCodeMultiVarsCodeLiteral.replaceAll("myString", "_new_myString").replaceAll("anotherString","_new_anotherString")).trimStart());
     });
 
     test("Multi variables and one global one local in function", async ({page}) => {
@@ -321,7 +357,7 @@ test.describe("Variable changes in main section", () => {
             matchCounter++;
             return (matchCounter > 1) ? ("_new_" + match ): match;            
         });
-        expect(readFileSync(await save(page), "utf-8")).toEqual(modifiedCode.trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(modifiedCode).trimStart());
     });
 
     test("For frame and one global one local in function", async ({page}) => {
@@ -373,7 +409,7 @@ test.describe("Variable changes in main section", () => {
             return (matchCounter > 1) ? ("_new_" + match ): match;            
         });
         modifiedCode = modifiedCode.replaceAll("iter2", "_new_iter2");
-        expect(readFileSync(await save(page), "utf-8")).toEqual(modifiedCode.trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(modifiedCode).trimStart());
     });
 });
 
@@ -410,7 +446,7 @@ test.describe("Variable changes in functions", () => {
             matchCounter++;
             return (matchCounter < 2) ? ("_new_" + match ): match;            
         });
-        expect(readFileSync(await save(page), "utf-8")).toEqual(modifiedCode.trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(modifiedCode).trimStart());
     });
 
     test("Global", async ({page}) => {
@@ -436,7 +472,7 @@ test.describe("Variable changes in functions", () => {
         await page.keyboard.press(renameKBShortcut);
         await expect(renameButton).toBeHidden();
         // Check results
-        expect(readFileSync(await save(page), "utf-8")).toEqual(withFunction1CodeLiteral.replaceAll("iter2", "_new_iter2").trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(withFunction1CodeLiteral.replaceAll("iter2", "_new_iter2")).trimStart());
     });
 
     test("For frame (local)", async({page}) => {
@@ -470,7 +506,7 @@ test.describe("Variable changes in functions", () => {
             matchCounter++;
             return (matchCounter < 3) ? ("_new_" + match ): match;
         });
-        expect(readFileSync(await save(page), "utf-8")).toEqual(modifiedCode.trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(modifiedCode).trimStart());
     });
 
     test("For frame (global)", async({page}) => {
@@ -497,7 +533,7 @@ test.describe("Variable changes in functions", () => {
         await page.keyboard.press(renameKBShortcut);
         await expect(renameButton).toBeHidden();
         // Check results
-        expect(readFileSync(await save(page), "utf-8")).toEqual(withFunction2CodeLiteral.replaceAll("iter", "_new_iter").trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(withFunction2CodeLiteral.replaceAll("iter", "_new_iter")).trimStart());
     });
 });
 
@@ -508,6 +544,7 @@ test("Variable change in class", async({page}) => {
     // Rename import name binding
     await page.keyboard.press("PageUp");
     await waitForEditorSettled(page);
+    await skipPastImports(page);
     await pressN("ArrowDown", 2, true)(page);
     await page.keyboard.press("ArrowRight");
     await waitForEditorSettled(page);
@@ -524,9 +561,9 @@ test("Variable change in class", async({page}) => {
     modifiedCode = modifiedCode.replaceAll("var", (match) => {
         // Only the 3 first matches
         matchCounter++;
-        return (matchCounter < 3) ? ("_new_" + match ): match;            
+        return (matchCounter < 3) ? ("_new_" + match ): match;
     });
-    expect(readFileSync(await save(page), "utf-8")).toEqual(modifiedCode.trimStart());
+    expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(modifiedCode).trimStart());
 });
 
 test.describe("Changes in import", () => {
@@ -537,8 +574,7 @@ test.describe("Changes in import", () => {
         // Rename import name binding
         await page.keyboard.press("Control+Home");
         await waitForEditorSettled(page);
-        await page.keyboard.press("ArrowDown");
-        await waitForEditorSettled(page);
+        await pressN("ArrowDown", numberOfDefaultImportFrames + 1, true)(page);
         await page.keyboard.press("ArrowLeft");
         await waitForEditorSettled(page);
         await page.keyboard.press(wordWiseNavigationLeft);
@@ -551,7 +587,7 @@ test.describe("Changes in import", () => {
         await page.keyboard.press(renameKBShortcut);
         await expect(renameButton).toBeHidden();
         // Check results
-        expect(readFileSync(await save(page), "utf-8")).toEqual(importCodeLiteral.replaceAll("dt", "_new_dt").trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(importCodeLiteral.replaceAll("dt", "_new_dt")).trimStart());
     });
 
     test("Module name (before as : should NOT change", async({page}) => {
@@ -561,6 +597,7 @@ test.describe("Changes in import", () => {
         // Rename import name binding
         await page.keyboard.press("Control+Home");
         await waitForEditorSettled(page);
+        await pressN("ArrowDown", numberOfDefaultImportFrames, true)(page);
         await page.keyboard.press("ArrowRight");
         await waitForEditorSettled(page);
         await page.keyboard.type("_new_");
@@ -587,6 +624,7 @@ test.describe("Function change", () => {
         // Rename function
         await page.keyboard.press("PageUp");
         await waitForEditorSettled(page);
+        await skipPastImports(page);
         await page.keyboard.press("ArrowDown");
         await waitForEditorSettled(page);
         await page.keyboard.press("ArrowRight");
@@ -599,7 +637,7 @@ test.describe("Function change", () => {
         await page.keyboard.press(renameKBShortcut);
         await expect(renameButton).toBeHidden();
         // Check results
-        expect(readFileSync(await save(page), "utf-8")).toEqual(singleLocaleInFunctionCodeLiteral.replaceAll("testF", "_new_testF").trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(singleLocaleInFunctionCodeLiteral.replaceAll("testF", "_new_testF")).trimStart());
     });
 
     test("Class function", async({page}) => {
@@ -627,7 +665,7 @@ test.describe("Function change", () => {
             matchCounter++;
             return (matchCounter < 2) ? ("_new_" + match ): match;
         });
-        expect(readFileSync(await save(page), "utf-8")).toEqual(modifiedCode.trimStart());
+        expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(modifiedCode).trimStart());
     });
 
 });
@@ -639,6 +677,7 @@ test("Class change", async({page}) => {
     // Rename local variable
     await page.keyboard.press("PageUp");
     await waitForEditorSettled(page);
+    await skipPastImports(page);
     await page.keyboard.press("ArrowDown");
     await waitForEditorSettled(page);
     await page.keyboard.press("ArrowRight");
@@ -651,5 +690,5 @@ test("Class change", async({page}) => {
     await page.keyboard.press(renameKBShortcut);
     await expect(renameButton).toBeHidden();
     // Check results
-    expect(readFileSync(await save(page), "utf-8")).toEqual(classCodeLiteral.replaceAll("MyClass", "_new_MyClass").trimStart());
+    expect(readFileSync(await save(page), "utf-8")).toEqual(withDefaultImports(classCodeLiteral.replaceAll("MyClass", "_new_MyClass")).trimStart());
 });

--- a/tests/playwright/e2e/scroll-into-view.spec.ts
+++ b/tests/playwright/e2e/scroll-into-view.spec.ts
@@ -139,8 +139,7 @@ test.describe("Undo scrolls location into view", () => {
             await clearDefaultProject(page);
             // clearDefaultProject leaves the caret at the top of Imports; return to Main, which
             // is where this test's content belongs:
-            await page.keyboard.press("ArrowDown");
-            await page.keyboard.press("ArrowDown");
+            await pressN("ArrowDown", 2)(page);
             await doPagePaste(page, Array.from({ length: 100 }, (_, i) => `print("Hello #${i + 1}")`).join("\n"));
             const [actions, scrollTo] = undoTests[testIndex];
             const statesToUndoTo = [];
@@ -207,8 +206,7 @@ test.describe("Printing scrolls into view", () => {
         await clearDefaultProject(page);
         // clearDefaultProject leaves the caret at the top of Imports; return to Main, which is
         // where this test's content belongs:
-        await page.keyboard.press("ArrowDown");
-        await page.keyboard.press("ArrowDown");
+        await pressN("ArrowDown", 2)(page);
         await doPagePaste(page, `
 from strype.graphics import get_key
 while (True):

--- a/tests/playwright/e2e/scroll-into-view.spec.ts
+++ b/tests/playwright/e2e/scroll-into-view.spec.ts
@@ -1,6 +1,6 @@
 import {ElementHandle, expect, JSHandle, Page, test} from "@playwright/test";
 import { checkConsoleContent, runButtonShowsRun, runToFinish, startRunning } from "../support/execution";
-import {checkFrameXorTextCursor, doPagePaste, pressN, waitForEditorSettled} from "../support/editor";
+import {checkFrameXorTextCursor, clearDefaultProject, doPagePaste, pressN, waitForEditorSettled} from "../support/editor";
 import {save} from "../support/loading-saving";
 import {readFileSync} from "node:fs";
 import {setupStrypeTest} from "../support/general";
@@ -136,8 +136,11 @@ test.describe("Undo scrolls location into view", () => {
     ];
     for (let testIndex = 0; testIndex < undoTests.length; testIndex++) {
         test(`Undo test #${testIndex}`, async ({page}) => {
-            await page.keyboard.press("Delete");
-            await page.keyboard.press("Delete");
+            await clearDefaultProject(page);
+            // clearDefaultProject leaves the caret at the top of Imports; return to Main, which
+            // is where this test's content belongs:
+            await page.keyboard.press("ArrowDown");
+            await page.keyboard.press("ArrowDown");
             await doPagePaste(page, Array.from({ length: 100 }, (_, i) => `print("Hello #${i + 1}")`).join("\n"));
             const [actions, scrollTo] = undoTests[testIndex];
             const statesToUndoTo = [];
@@ -201,8 +204,11 @@ test.describe("Undo scrolls location into view", () => {
 
 test.describe("Printing scrolls into view", () => {
     test("Pressing keys repeatedly scrolls into view", async ({page}) => {
-        await page.keyboard.press("Delete");
-        await page.keyboard.press("Delete");
+        await clearDefaultProject(page);
+        // clearDefaultProject leaves the caret at the top of Imports; return to Main, which is
+        // where this test's content belongs:
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("ArrowDown");
         await doPagePaste(page, `
 from strype.graphics import get_key
 while (True):

--- a/tests/playwright/e2e/storage-model.spec.ts
+++ b/tests/playwright/e2e/storage-model.spec.ts
@@ -2,7 +2,7 @@
 // specifically around storing and restoring the state from browser storage.
 
 import { Page, expect, test } from "@playwright/test";
-import { skipPyodideLoading } from "../support/general";
+import { DEFAULT_STARTING_FRAME_COUNT, skipPyodideLoading } from "../support/general";
 import { save } from "../support/loading-saving";
 import {strypeElIds} from "../support/proxy";
 
@@ -40,13 +40,16 @@ test.afterEach(async ({ context }, testInfo) => {
 
 async function assertStartingProject(page: Page)  {
     // Checks the starting project is showing:
-    await expect(page.locator(".frame-div")).toHaveCount(2);
+    await expect(page.locator(".frame-div")).toHaveCount(DEFAULT_STARTING_FRAME_COUNT);
     await expect(page.locator("span", {hasText: "Hello from Strype"})).toHaveCount(1);
     await expect(page.locator("span", {hasText: "This is the default Strype starter project"})).toHaveCount(1);
 }
 
-async function assertStartingPlus(page: Page, paramContent: string) {
-    await expect(page.locator(".frame-div")).toHaveCount(3);
+// expectedFrameCount defaults to the current default project's frame count plus one, but tests
+// that load an old, frozen localStorage snapshot (captured before the default project's shape
+// last changed) need to pass the frame count that snapshot actually contains, not today's count:
+async function assertStartingPlus(page: Page, paramContent: string, expectedFrameCount = DEFAULT_STARTING_FRAME_COUNT + 1) {
+    await expect(page.locator(".frame-div")).toHaveCount(expectedFrameCount);
     await expect(page.locator("span", {hasText: "Hello from Strype"})).toHaveCount(1);
     await expect(page.locator("span", {hasText: "This is the default Strype starter project"})).toHaveCount(1);
     await expect(page.locator("span", {hasText: paramContent})).toHaveCount(1);
@@ -178,7 +181,9 @@ test.describe("Test migration from old system", () => {
         const page = await context.newPage();
         await loadAndWaitForEditor(page);
         // This is the content I used to make the above Unicode escaped version:
-        await assertStartingPlus(page, "Saved state from previous storage model");
+        // The snapshot predates the current default project's imports, so it has one fewer frame
+        // than DEFAULT_STARTING_FRAME_COUNT + 1 would now assume:
+        await assertStartingPlus(page, "Saved state from previous storage model", 3);
         // Check the key has gone:
         const keys = await page.evaluate(() => {
             const keys = [];
@@ -208,7 +213,9 @@ test.describe("Test migration from old system", () => {
         const page1 = await context.newPage();
         await loadAndWaitForEditor(page1);
         // This is the content I used to make the above Unicode escaped version:
-        await assertStartingPlus(page1, "Saved state from previous storage model");
+        // The snapshot predates the current default project's imports, so it has one fewer frame
+        // than DEFAULT_STARTING_FRAME_COUNT + 1 would now assume:
+        await assertStartingPlus(page1, "Saved state from previous storage model", 3);
 
         const page2 = await context.newPage();
         await loadAndWaitForEditor(page2);

--- a/tests/playwright/e2e/structured-expressions-media.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-media.spec.ts
@@ -1,5 +1,5 @@
 import {test, expect} from "@playwright/test";
-import { typeIndividually, doPagePaste, doTextHomeEndKeyPress, assertStateOfIfFrame, checkFrameXorTextCursor, MEDIA_SLOT_PARSED_PLACEHOLDER, assertStateOfFuncCallFrame, waitForEditorSettled } from "../support/editor";
+import { typeIndividually, doPagePaste, doTextHomeEndKeyPress, assertStateOfIfFrame, checkFrameXorTextCursor, clearDefaultProject, MEDIA_SLOT_PARSED_PLACEHOLDER, assertStateOfFuncCallFrame, waitForEditorSettled } from "../support/editor";
 import fs from "fs";
 import { setupStrypeTest } from "../support/general";
 import { save } from "../support/loading-saving";
@@ -172,9 +172,13 @@ test.describe("Media literal copying", () => {
 
 test.describe("Media literal manipulation", () => {
     test("Test surrounding an image literal with brackets", async ({page}) => {
-        await page.keyboard.press("End");
-        await page.keyboard.press("Backspace");
-        await page.keyboard.press("Backspace");
+        // Also clears the default strype.graphics/strype.sound imports, not just Main: with
+        // strype.graphics in scope, "load_image" appears twice in autocomplete (once for the
+        // pasted media literal, once via the module's own general completion), which would
+        // otherwise make the "not visible" check below fail for reasons unrelated to this test:
+        await clearDefaultProject(page);
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("ArrowDown");
         await page.keyboard.type("i");
         await waitForEditorSettled(page);
         await assertStateOfIfFrame(page, "{$}");
@@ -192,9 +196,13 @@ test.describe("Media literal manipulation", () => {
         await expect(page.locator("img[data-code^='load_image']")).toBeVisible();
     });
     test("Test surrounding a sound literal with brackets", async ({page}) => {
-        await page.keyboard.press("End");
-        await page.keyboard.press("Backspace");
-        await page.keyboard.press("Backspace");
+        // Also clears the default strype.graphics/strype.sound imports, not just Main: with
+        // strype.sound in scope, "load_sound" appears twice in autocomplete (once for the pasted
+        // media literal, once via the module's own general completion), which would otherwise
+        // make the "not visible" check below fail for reasons unrelated to this test:
+        await clearDefaultProject(page);
+        await page.keyboard.press("ArrowDown");
+        await page.keyboard.press("ArrowDown");
         await page.keyboard.type("i");
         await waitForEditorSettled(page);
         await assertStateOfIfFrame(page, "{$}");

--- a/tests/playwright/e2e/structured-expressions-navigation.spec.ts
+++ b/tests/playwright/e2e/structured-expressions-navigation.spec.ts
@@ -1,6 +1,6 @@
 import {Page, test, expect} from "@playwright/test";
 import path from "path";
-import {assertStateOfIfFrame, checkFrameXorTextCursor, checkTextSlotCursorPos, doPagePaste, getDefaultStrypeProjectDocumentationFullLine, pressN, waitForEditorSettled} from "../support/editor";
+import {assertStateOfIfFrame, checkFrameXorTextCursor, checkTextSlotCursorPos, doPagePaste, getDefaultStrypeProjectDocumentationFullLine, getDefaultStrypeProjectImportsFullLine, pressN, waitForEditorSettled} from "../support/editor";
 import fs from "fs";
 import {readFileSync} from "node:fs";
 import {save} from "../support/loading-saving";
@@ -166,7 +166,7 @@ test.describe("Check clicking near image literal", () => {
         expect(contents).toEqual(`
 #(=> Strype:1:std
 ${getDefaultStrypeProjectDocumentationFullLine()}#(=> Section:Imports
-#(=> Section:Definitions
+${getDefaultStrypeProjectImportsFullLine()}#(=> Section:Definitions
 #(=> Section:Main
 Actor(load_image("data:image/jpeg;base64,${image}").foo) 
 #(=> Section:End

--- a/tests/playwright/support/editor.ts
+++ b/tests/playwright/support/editor.ts
@@ -288,17 +288,46 @@ export function getDefaultStrypeProjectDocumentationFullLine(): string {
     return "'''This is the default Strype starter project'''\n";
 }
 
-export async function enterCode(page: Page, codeSections : string[]) : Promise<void> {
-    await expect(page.locator(".frame-div")).toHaveCount(2);
-    await page.keyboard.press("ArrowDown");
-    await page.keyboard.press("ArrowDown");
-    await page.keyboard.press("Backspace");
-    await page.keyboard.press("Backspace");
-    // Backspace-deleting a frame can go through a delayed-removal debounce (LabelSlot.vue), so
-    // wait for the count to actually drop by 2 rather than a fixed guess:
+// Deletes every frame currently in Main, Definitions and Imports -- not just the default
+// project's frames (2 default imports plus the myString assignment and print call in Main), since
+// this is also used to clear out whatever a previous operation left behind, which can include
+// Definitions content that the default project never has -- leaving a genuinely blank editor
+// (0 frames) with the caret positioned at the top of Imports, ready for fresh content. Reads the
+// frame counts from the DOM rather than hard-coding them so this doesn't go stale if a section's
+// content changes shape.
+export async function clearDefaultProject(page: Page) : Promise<void> {
+    const mainCount = await page.locator("#frameContainer_-3 .frame-div").count();
+    const defsCount = await page.locator("#frameContainer_-2 .frame-div").count();
+    const importsCount = await page.locator("#frameContainer_-1 .frame-div").count();
+    // The default caret starts at the top of Main; deleting forward removes its frames one by one.
+    // Each deletion can go through a delayed-removal debounce (LabelSlot.vue), so settle after
+    // every single keypress rather than firing them all at once -- otherwise a later press (e.g.
+    // the ArrowUp navigation, or a Backspace in Definitions/Imports) can race ahead of a
+    // still-in-flight removal and land on/delete the wrong frame (or, worse, crash the app by
+    // deleting more times than there are frames left):
+    for (let i = 0; i < mainCount; i++) {
+        await page.keyboard.press("Delete");
+        await waitForEditorSettled(page);
+    }
+    // Navigate up one level at a time, deleting backward to clear Definitions then Imports:
+    await page.keyboard.press("ArrowUp");
+    await waitForEditorSettled(page);
+    for (let i = 0; i < defsCount; i++) {
+        await page.keyboard.press("Backspace");
+        await waitForEditorSettled(page);
+    }
+    await page.keyboard.press("ArrowUp");
+    await waitForEditorSettled(page);
+    for (let i = 0; i < importsCount; i++) {
+        await page.keyboard.press("Backspace");
+        await waitForEditorSettled(page);
+    }
+    // Belt-and-braces check that we truly ended up at 0, on top of the settling above:
     await expect(page.locator(".frame-div")).toHaveCount(0, {timeout: 4000});
-    await page.keyboard.press("ArrowUp");
-    await page.keyboard.press("ArrowUp");
+}
+
+export async function enterCode(page: Page, codeSections : string[]) : Promise<void> {
+    await clearDefaultProject(page);
     for (const codeSection of codeSections) {
         // doPagePaste already waits for the editor (including frame count) to settle:
         await doPagePaste(page, codeSection);

--- a/tests/playwright/support/editor.ts
+++ b/tests/playwright/support/editor.ts
@@ -288,6 +288,25 @@ export function getDefaultStrypeProjectDocumentationFullLine(): string {
     return "'''This is the default Strype starter project'''\n";
 }
 
+// Deletes forward (Delete key) from the top of a container until it's empty. `maxPresses` is
+// expected to be a safe upper bound (a count that includes nested descendants, e.g. the
+// statements inside a function/class definition's body), not an exact number of presses needed --
+// deleting a top-level block frame removes its whole subtree in one press. Uses Delete rather than
+// Backspace: the app deliberately blocks Backspace from removing a function/class definition
+// frame when the caret is inside its body (to avoid merging the body into the wrong container),
+// which forward-Delete from above the frame doesn't hit, so Delete is the only one of the two that
+// reliably clears block frames with children.
+async function deleteFramesUpTo(page: Page, containerSelector: string, maxPresses: number) : Promise<void> {
+    for (let i = 0; i < maxPresses && await page.locator(containerSelector + " .frame-div").count() > 0; i++) {
+        await page.keyboard.press("Delete");
+        // Deletion can go through a delayed-removal debounce (LabelSlot.vue), so settle after
+        // every single keypress rather than firing them all at once -- otherwise a later press can
+        // race ahead of a still-in-flight removal and land on/delete the wrong frame (or, worse,
+        // crash the app by deleting more times than there are frames left):
+        await waitForEditorSettled(page);
+    }
+}
+
 // Deletes every frame currently in Main, Definitions and Imports -- not just the default
 // project's frames (2 default imports plus the myString assignment and print call in Main), since
 // this is also used to clear out whatever a previous operation left behind, which can include
@@ -296,34 +315,34 @@ export function getDefaultStrypeProjectDocumentationFullLine(): string {
 // frame counts from the DOM rather than hard-coding them so this doesn't go stale if a section's
 // content changes shape.
 export async function clearDefaultProject(page: Page) : Promise<void> {
-    const mainCount = await page.locator("#frameContainer_-3 .frame-div").count();
-    const defsCount = await page.locator("#frameContainer_-2 .frame-div").count();
-    const importsCount = await page.locator("#frameContainer_-1 .frame-div").count();
-    // The default caret starts at the top of Main; deleting forward removes its frames one by one.
-    // Each deletion can go through a delayed-removal debounce (LabelSlot.vue), so settle after
-    // every single keypress rather than firing them all at once -- otherwise a later press (e.g.
-    // the ArrowUp navigation, or a Backspace in Definitions/Imports) can race ahead of a
-    // still-in-flight removal and land on/delete the wrong frame (or, worse, crash the app by
-    // deleting more times than there are frames left):
-    for (let i = 0; i < mainCount; i++) {
-        await page.keyboard.press("Delete");
-        await waitForEditorSettled(page);
+    const totalCount = await page.locator(".frame-div").count();
+    // Reach the very top of the whole document regardless of the current caret position or how
+    // deeply nested any block frame's content is. ArrowUp is a no-op once already at the top, so
+    // pressing it more times than could possibly be needed is harmless -- but a block frame's body
+    // is itself an extra caret stop beyond the one .frame-div element it counts as, so totalCount
+    // alone can undershoot for nested content; multiplying it gives enough headroom for that
+    // without needing to know the exact nesting depth:
+    for (let i = 0; i < totalCount * 3 + 10; i++) {
+        await page.keyboard.press("ArrowUp");
     }
-    // Navigate up one level at a time, deleting backward to clear Definitions then Imports:
-    await page.keyboard.press("ArrowUp");
     await waitForEditorSettled(page);
-    for (let i = 0; i < defsCount; i++) {
-        await page.keyboard.press("Backspace");
-        await waitForEditorSettled(page);
-    }
-    await page.keyboard.press("ArrowUp");
+    // Clear top-down, container by container. ArrowDown from an empty/just-cleared container
+    // reliably lands at the top of the next one (mirrored by the equivalent "return to Main"
+    // navigation used elsewhere once everything's been cleared):
+    await deleteFramesUpTo(page, "#frameContainer_-1", totalCount);
+    await page.keyboard.press("ArrowDown");
     await waitForEditorSettled(page);
-    for (let i = 0; i < importsCount; i++) {
-        await page.keyboard.press("Backspace");
-        await waitForEditorSettled(page);
-    }
+    await deleteFramesUpTo(page, "#frameContainer_-2", totalCount);
+    await page.keyboard.press("ArrowDown");
+    await waitForEditorSettled(page);
+    await deleteFramesUpTo(page, "#frameContainer_-3", totalCount);
     // Belt-and-braces check that we truly ended up at 0, on top of the settling above:
     await expect(page.locator(".frame-div")).toHaveCount(0, {timeout: 4000});
+    // Return to the top of Imports, where callers of this function expect to end up:
+    await page.keyboard.press("ArrowUp");
+    await waitForEditorSettled(page);
+    await page.keyboard.press("ArrowUp");
+    await waitForEditorSettled(page);
 }
 
 export async function enterCode(page: Page, codeSections : string[]) : Promise<void> {

--- a/tests/playwright/support/editor.ts
+++ b/tests/playwright/support/editor.ts
@@ -335,6 +335,11 @@ export async function clearDefaultProject(page: Page) : Promise<void> {
     for (let i = 0; i < totalCount * 3 + 10; i++) {
         await page.keyboard.press("ArrowUp");
     }
+    // Settling once here (rather than after every press, as the delete loop below does) is
+    // intentional: that loop needs a per-press settle because deletion is async and debounced and
+    // can race with the next press, but pure caret navigation isn't, so there's nothing to race --
+    // one settle after the whole burst is both correct and far cheaper than settling ~totalCount*3
+    // times:
     await waitForEditorSettled(page);
     // Clear top-down, container by container. ArrowDown from an empty/just-cleared container
     // reliably lands at the top of the next one (mirrored by the equivalent "return to Main"

--- a/tests/playwright/support/editor.ts
+++ b/tests/playwright/support/editor.ts
@@ -292,23 +292,29 @@ export function getDefaultStrypeProjectImportsFullLine(): string {
     return "from strype.graphics import * \nfrom strype.sound import * \n";
 }
 
-// Deletes forward (Delete key) from the top of a container until it's empty. `maxPresses` is
-// expected to be a safe upper bound (a count that includes nested descendants, e.g. the
-// statements inside a function/class definition's body), not an exact number of presses needed --
-// deleting a top-level block frame removes its whole subtree in one press. Uses Delete rather than
+// Deletes forward (Delete key) from the top of a container until it's empty. `maxPresses` isn't a
+// count of frames to remove -- the recursion always runs to an empty container, however many
+// presses that takes, since deleting a top-level block frame removes its whole subtree (nested
+// descendants included) in one press. It's purely a safety cap against an infinite recursion if a
+// press ever failed to remove a frame (an app bug, a stuck focus, a debounce race): each call
+// passes `maxPresses - 1` down, so a genuinely stuck deletion still terminates -- with a failed
+// assertion below in the caller -- instead of hanging. Callers should not need to pass it; the
+// default is generous enough for any realistic number of frames. Uses Delete rather than
 // Backspace: the app deliberately blocks Backspace from removing a function/class definition
 // frame when the caret is inside its body (to avoid merging the body into the wrong container),
 // which forward-Delete from above the frame doesn't hit, so Delete is the only one of the two that
 // reliably clears block frames with children.
-async function deleteFramesUpTo(page: Page, containerSelector: string, maxPresses: number) : Promise<void> {
-    for (let i = 0; i < maxPresses && await page.locator(containerSelector + " .frame-div").count() > 0; i++) {
-        await page.keyboard.press("Delete");
-        // Deletion can go through a delayed-removal debounce (LabelSlot.vue), so settle after
-        // every single keypress rather than firing them all at once -- otherwise a later press can
-        // race ahead of a still-in-flight removal and land on/delete the wrong frame (or, worse,
-        // crash the app by deleting more times than there are frames left):
-        await waitForEditorSettled(page);
+async function deleteFramesUpTo(page: Page, containerSelector: string, maxPresses = 100) : Promise<void> {
+    if (maxPresses <= 0 || await page.locator(containerSelector + " .frame-div").count() === 0) {
+        return;
     }
+    await page.keyboard.press("Delete");
+    // Deletion can go through a delayed-removal debounce (LabelSlot.vue), so settle after
+    // every single keypress rather than firing them all at once -- otherwise a later press can
+    // race ahead of a still-in-flight removal and land on/delete the wrong frame (or, worse,
+    // crash the app by deleting more times than there are frames left):
+    await waitForEditorSettled(page);
+    await deleteFramesUpTo(page, containerSelector, maxPresses - 1);
 }
 
 // Deletes every frame currently in Main, Definitions and Imports -- not just the default
@@ -333,13 +339,13 @@ export async function clearDefaultProject(page: Page) : Promise<void> {
     // Clear top-down, container by container. ArrowDown from an empty/just-cleared container
     // reliably lands at the top of the next one (mirrored by the equivalent "return to Main"
     // navigation used elsewhere once everything's been cleared):
-    await deleteFramesUpTo(page, "#frameContainer_-1", totalCount);
+    await deleteFramesUpTo(page, "#frameContainer_-1");
     await page.keyboard.press("ArrowDown");
     await waitForEditorSettled(page);
-    await deleteFramesUpTo(page, "#frameContainer_-2", totalCount);
+    await deleteFramesUpTo(page, "#frameContainer_-2");
     await page.keyboard.press("ArrowDown");
     await waitForEditorSettled(page);
-    await deleteFramesUpTo(page, "#frameContainer_-3", totalCount);
+    await deleteFramesUpTo(page, "#frameContainer_-3");
     // Belt-and-braces check that we truly ended up at 0, on top of the settling above:
     await expect(page.locator(".frame-div")).toHaveCount(0, {timeout: 4000});
     // Return to the top of Imports, where callers of this function expect to end up:

--- a/tests/playwright/support/editor.ts
+++ b/tests/playwright/support/editor.ts
@@ -288,6 +288,10 @@ export function getDefaultStrypeProjectDocumentationFullLine(): string {
     return "'''This is the default Strype starter project'''\n";
 }
 
+export function getDefaultStrypeProjectImportsFullLine(): string {
+    return "from strype.graphics import * \nfrom strype.sound import * \n";
+}
+
 // Deletes forward (Delete key) from the top of a container until it's empty. `maxPresses` is
 // expected to be a safe upper bound (a count that includes nested descendants, e.g. the
 // statements inside a function/class definition's body), not an exact number of presses needed --

--- a/tests/playwright/support/general.ts
+++ b/tests/playwright/support/general.ts
@@ -9,11 +9,12 @@ export function skipPyodideLoading(page: Page) : Promise<Disposable> {
     });
 }
 
-// The number of frames present in a brand new/default Strype project (currently the imports
-// section and the definitions section). Centralised here so that when a future change adds more
-// starting frames, call sites that need "the default project has loaded" only need updating once --
-// and so that readiness checks use >= rather than an exact count that would then be wrong.
-export const DEFAULT_STARTING_FRAME_COUNT = 2;
+// The number of leaf frames present in a brand new/default Strype project: 2 default imports
+// (from strype.graphics import *, from strype.sound import *) plus the myString assignment and
+// print call in Main. Centralised here so that when a future change adds more starting frames,
+// call sites that need "the default project has loaded" only need updating once -- and so that
+// readiness checks use >= rather than an exact count that would then be wrong.
+export const DEFAULT_STARTING_FRAME_COUNT = 4;
 
 export interface StrypeTestSetupOptions {
     // Passed to testInfo.setTimeout(). Omit to keep Playwright's default (30s).


### PR DESCRIPTION
This makes the in-theory "simple" change to add two import frames to the starting Python state.

The problem was this has a lot of knock-on effects on the tests, many of which implicitly assumed there were no imports in the starting project.  This is fixed in two different ways depending on the test:
 - Delete the imports.  There are now some helper methods to clear the imports to help with this.
 - Keep the imports.   In a few cases we leave the imports in-place but account for them being present e.g. saving the default project should have those imports.

As Claude was doing its thing, it also found an existing bug in frame deletion where deleting could sometimes cause an exception.  You can see more about that in the individual commit comment (the 3rd commit, "Fix crash when Delete has no next frame to move to").

I also tweaked a couple of flaky tests unrelated to this work: bumped one timeout and (at Claude's suggestion after an out-of-memory error) changed one long running paste test to be many short-running tests.  So I think the tests should all pass but we'll see.

Fixes #951