### PR TITLE
Fix sound saving and a flaky test

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -422,8 +422,9 @@ export default defineComponent({
         );
 
         // The events from Bootstrap modal are registered on eventBus.
+        eventBus.on(CustomEventTypes.strypeModalShow, this.onStrypeMenuShowModalDlg);
         eventBus.on(CustomEventTypes.strypeModalShown, this.onStrypeMenuShownModalDlg);
-        eventBus.on(CustomEventTypes.strypeModalHidden, this.onStrypeMenuHideModalDlg);      
+        eventBus.on(CustomEventTypes.strypeModalHidden, this.onStrypeMenuHideModalDlg);
         
         // Event listener for saving project action completion
         eventBus.on(CustomEventTypes.saveStrypeProjectDoneForLoad, this.openLoadProjectDlgAfterSaved);
@@ -437,6 +438,7 @@ export default defineComponent({
 
     beforeUnmount(){
         // Just in case, we remove the Bootstrap modal event handler from eventBus
+        eventBus.off(CustomEventTypes.strypeModalShow, this.onStrypeMenuShowModalDlg);
         eventBus.off(CustomEventTypes.strypeModalShown, this.onStrypeMenuShownModalDlg);
         eventBus.off(CustomEventTypes.strypeModalHidden, this.onStrypeMenuHideModalDlg);
 
@@ -951,6 +953,27 @@ export default defineComponent({
             }
         },
 
+        onStrypeMenuShowModalDlg(event: BvTriggerableEvent) {
+            // This fires just before the dialog becomes visible/interactable (unlike
+            // onStrypeMenuShownModalDlg below, which fires just after). The Examples... and
+            // Book... dialogs reset their category/chapter selection to the first entry whenever
+            // they're opened -- that reset needs to happen here, before the dialog can be
+            // interacted with, rather than in the "shown" handler. Doing it on "shown" left a
+            // window where a fast click (or, in CI, Playwright) could select a different
+            // category/chapter while the dialog was already interactable but the "shown" event
+            // hadn't fired yet, only for that selection to be silently wiped out moments later
+            // when the reset ran -- e.g. clicking "Chapter 2" then having the list of projects
+            // revert back to Chapter 1's, so a project by name in another chapter was never
+            // found (see the regression test for this).
+            const dlgId = event.componentId;
+            if (dlgId == this.loadDemoProjectModalDlgId) {
+                vueComponentsAPIHandler.openDemoDlgComponentAPI?.shown();
+            }
+            else if (dlgId == this.loadBookProjectModalDlgId) {
+                (this.$refs.openBookDlg as InstanceType<typeof OpenBookDlg>).shown();
+            }
+        },
+
         onStrypeMenuShownModalDlg(event: BvTriggerableEvent) {
             const dlgId = event.componentId;
             // This method handles the workflow of the menu entries' related dialog
@@ -991,13 +1014,9 @@ export default defineComponent({
                     this.getSharingLink(defaultSharingProjectMode, true);
                 }, 2000);
             }
-            else if (dlgId == this.loadDemoProjectModalDlgId) {
-                vueComponentsAPIHandler.openDemoDlgComponentAPI?.shown();
-            }
-            else if (dlgId == this.loadBookProjectModalDlgId) {
-                (this.$refs.openBookDlg  as InstanceType<typeof OpenBookDlg>).shown();
-            }
-            else {
+            else if (dlgId != this.loadDemoProjectModalDlgId && dlgId != this.loadBookProjectModalDlgId) {
+                // (The Examples... and Book... dialogs' own "shown" work happens earlier, in
+                // onStrypeMenuShowModalDlg -- see its comment for why.)
                 // When the load or save project dialogs are opened, we focus the Google Drive selector by default when we don't have information about the source target
                 setTimeout(() => {
                     const targetToFocusButton =[...document.querySelectorAll(`#${dlgId} .${scssVars.projectTargetButtonClassName}`)].find((targetButton) => {

--- a/src/components/ModalDlg.vue
+++ b/src/components/ModalDlg.vue
@@ -1,6 +1,6 @@
 <!-- this acts as a wrapper around the bootstrap modals, to have centralised control and customisation -->
 <template>
-    <BModal no-close-on-backdrop :no-header-close="!showCloseBtn" :id="dlgId" :title="dlgTitle" @shown="onShown" @hidden="onHidden"
+    <BModal no-close-on-backdrop :no-header-close="!showCloseBtn" :id="dlgId" :title="dlgTitle" @show="onShow" @shown="onShown" @hidden="onHidden"
         :ok-title="okTitle" :cancel-title="cancelTitle" :size="size" :modal-class="cssClass" :focus="elementToFocusId" no-animation>
         <slot/>
         <!-- When no footer should be shown, we still use an empty div content (but a content nonetheless) to have the right visual rendering:
@@ -106,6 +106,10 @@ export default defineComponent({
             if(dlgId == this.dlgId){
                 this.modalShowFunction();
             }            
+        },
+
+        onShow(event: BvTriggerableEvent){
+            eventBus.emit(CustomEventTypes.strypeModalShow, event);
         },
 
         onShown(event: BvTriggerableEvent){

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -74,6 +74,7 @@ export enum CustomEventTypes {
     closeOtherRenameIdentifierPopup = "closeOtherRenameIdentifierPopup",
     // The following events are used for our modal dialogs, a wrapping mechanism around Bootstrap modals
     showStrypeModal = "bv::show::modal", // request a modal opening, param is a dialog ID
+    strypeModalShow = "bv::modal::show", // event just before a modal is shown (before its content is interactable): param is a BvTriggerableEvent event
     strypeModalShown = "bv::modal::shown", // event after a modal is opened: param is a BvTriggerableEvent event
     hideStrypeModal = "bv::hide::modal", // request a modal closing, param is a BvTriggerableEvent event
     strypeModalHidden = "bv::modal::hidden", // event after a modal is closed: param is a BvTriggerableEvent event

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -804,7 +804,7 @@ function replaceMediaLiteralsAndInvalidOps(s : SlotsStructure) : SlotsStructure 
                     s.fields.splice(i + 1, 0, {code: ""});
                 }
                 if (i == 0 || s.operators[i - 1].code) {
-                    s.operators.splice(i - 1, 0, {code: ""});
+                    s.operators.splice(Math.max(i - 1, 0), 0, {code: ""});
                     s.fields.splice(i, 0, {code: ""});
                 }
             }

--- a/tests/playwright/e2e/load-save-demos-books.spec.ts
+++ b/tests/playwright/e2e/load-save-demos-books.spec.ts
@@ -58,3 +58,33 @@ test.describe("Load/save book projects", () => {
         });
     }
 });
+
+test.describe("Book dialog chapter selection survives dialog opening", () => {
+    // Regression test for the intermittent "fireworks entry never became clickable" CI failures
+    // above: the book dialog used to reset its chapter selection back to Chapter 1 from its
+    // modal's "shown" handler (fired once the dialog is already interactable), so a chapter
+    // picked in the brief window before "shown" actually fired got silently wiped out -- e.g.
+    // Chapter 2 was selected, "fireworks" appeared, then the dialog reverted to Chapter 1's
+    // projects underneath it. That's a genuine timing race (confirmed via CI's resource-monitor
+    // log showing normal, non-spiking load during the hangs -- this isn't runner overload). The
+    // fix moved the reset to the dialog's "show" event (fired before it's interactable), closing
+    // that window.
+    //
+    // This drives the dialog the normal way and checks the selection is still showing Chapter 2's
+    // projects after giving any pending reset every chance to run. It's exercising the same race
+    // as the "Load and save fireworks" tests above, just without the full load-and-save round
+    // trip, so -- like those -- it may not always land inside the window that used to trigger the
+    // bug; it's here as a faster, more targeted check of the same thing.
+    test("Selecting Chapter 2 in the Book dialog keeps showing its projects", async ({page}) => {
+        await page.click("#" + await strypeElIds.getEditorMenuUID());
+        await page.locator("." + scssVars.strypeMenuItemClassName, {hasText: "Book..."}).click();
+        await page.locator(".open-book-dlg-book-group-item", {hasText: "Chapter 2"}).click();
+        const fireworksEntry = page.locator(".open-book-dlg-name", {hasText: "fireworks"});
+        await expect(fireworksEntry).toBeVisible();
+
+        // Give the dialog's "shown" event (and anything it might still trigger) every chance to
+        // fire before checking the selection is still showing Chapter 2's projects:
+        await page.waitForTimeout(2000);
+        await expect(fireworksEntry).toBeVisible();
+    });
+});

--- a/tests/playwright/e2e/load-save-specific.spec.ts
+++ b/tests/playwright/e2e/load-save-specific.spec.ts
@@ -5,6 +5,11 @@ import {setupStrypeTest} from "../support/general";
 import {createBrowserProxy} from "../support/proxy";
 import {WINDOW_STRYPE_HTMLIDS_PROPNAME} from "@/helpers/sharedIdCssWithTests";
 
+// Real (small) media assets -- the loaded project actually gets rendered (including decoding
+// audio for its waveform preview), so placeholder/fake base64 content isn't good enough here:
+const testSoundBase64 = readFileSync("src/assetsFilesystem/sounds/click.wav").toString("base64");
+const testImageBase64 = readFileSync("src/assetsFilesystem/images/backgrounds/floor-tile.png").toString("base64");
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 let strypeElIds: {[varName: string]: (...args: any[]) => Promise<string>};
 test.beforeEach(async ({ page, browserName }, testInfo) => {
@@ -98,5 +103,68 @@ expr_theta  = sum(t_theta for t_theta in seq_theta if t_theta<10) `.trimStart())
         // We don't (yet?) support async and await:
         // expr_iota = [i_iota async for i_iota in aseq_iota]
         // expr_kappa = await coro_kappa()
+    });
+});
+
+test.describe("Load media literals immediately followed by a method call", () => {
+    // Regression test for a bug where loading a project produced saved code like
+    // load_sound("...").___strype_blankplay() even though the affected line was never edited.
+    //
+    // Root cause: replaceMediaLiteralsAndInvalidOps() (in pythonToFrames.ts), which runs while
+    // parsing loaded/pasted Python into frames, collapses a "load_sound(<string>)" name+bracket
+    // pair down to a single media slot, then re-inserts a blank field/operator pair on whichever
+    // side(s) need one so the media slot stays correctly delimited. For the "before" side it used
+    // `s.operators.splice(i - 1, 0, ...)`. When the media literal is the very first field of its
+    // expression (i == 0) -- e.g. a bare `load_sound(...).play()` statement -- that is
+    // `splice(-1, 0, ...)`. A negative index in Array.splice does NOT mean "insert before index
+    // 0"; it means "insert one position before the end", so the new blank operator landed in the
+    // wrong place and desynchronised the fields/operators arrays from that point on. That left a
+    // genuinely-blank field sitting right where the code generator treats an empty slot as
+    // "adjacent to a dot", so on save it got rendered using the internal SPY placeholder text
+    // (___strype_blank) instead of staying invisible.
+    //
+    // This corruption is introduced on every single load/paste of such a line, but it is normally
+    // invisible: pasteMixedPython() schedules a follow-up DOM-based reparse of each newly-inserted
+    // frame (to refresh parameter-prompt placeholders) on the next tick, and that reparse uses a
+    // different, unaffected code path which overwrites the corrupted structure with a correct one.
+    // The bug only survives to a save if that follow-up reparse can't find the frame's DOM element
+    // yet (e.g. because it isn't mounted/rendered at that exact moment) -- a timing-dependent race,
+    // which is why it was reported as intermittent and why only some lines were affected in a
+    // given session. That means this test is exercising a race: driving the real "Load Project"
+    // flow and checking the saved output afterwards, the same way a user would hit this, rather
+    // than reaching in to inspect the mid-repair state directly. It may not reliably reproduce the
+    // bug if it regresses (the follow-up reparse usually wins), but it does cover the actual
+    // user-facing behaviour without relying on internals that only exist for testing.
+    async function assertNoBlankMarkerAfterLoad(page: Page, mainSectionContent: string) {
+        const spySource = [
+            "#(=> Strype:1:std",
+            "#(=> Section:Imports",
+            "#(=> Section:Definitions",
+            "#(=> Section:Main",
+            mainSectionContent,
+            "#(=> Section:End",
+            "",
+        ].join("\n");
+
+        await loadContent(page, spySource);
+        const output = readFileSync(await save(page, false), "utf8").replace(/\r\n/g, "\n");
+        expect(output).not.toContain("___strype_blank");
+    }
+
+    test("Load a sound literal followed by a method call, as a bare statement", async ({page}) => {
+        await assertNoBlankMarkerAfterLoad(page, `load_sound("data:audio/x-wav;base64,${testSoundBase64}").play() `);
+    });
+    test("Load an image literal followed by a method call, as a bare statement", async ({page}) => {
+        await assertNoBlankMarkerAfterLoad(page, `load_image("data:image/png;base64,${testImageBase64}").get_width() `);
+    });
+    test("Load a sound literal followed by a method call, on the RHS of an assignment", async ({page}) => {
+        await assertNoBlankMarkerAfterLoad(page, `mySound  = load_sound("data:audio/x-wav;base64,${testSoundBase64}").play() `);
+    });
+    test("Load several sound-literal method call lines together", async ({page}) => {
+        await assertNoBlankMarkerAfterLoad(page, [
+            `load_sound("data:audio/x-wav;base64,${testSoundBase64}").play() `,
+            `load_sound("data:audio/x-wav;base64,${testSoundBase64}").play() `,
+            `load_sound("data:audio/x-wav;base64,${testSoundBase64}").play() `,
+        ].join("\n"));
     });
 });


### PR DESCRIPTION
Two small fixes from yesterday which I'm filing while I remember what was done, but not urgent, just look at it next week.  Fixes:
 - Fix the bug Michael found with saving [soundliteral].play() sometimes having ___strype_blank in it.  Turned out to just be an indexing issue in one of the slot handlers.  Added a test for this (although it was an intermittent issue but we can watch in case this test ever fails again.)
 - The first test run failed with something I'd seen before where testing opening the fireworks project failed.  That turned out to be a race hazard between loading the dialog and the user clicking; if they clicked quick enough the dialog would later "initialise" to the first chapter and set it back.  Maybe the user would have just been mildly annoyed but it broke the test which was "click on second chapter, click on project".  So I've fixed to do the initialisation earlier.  See what you think about adding the show method; it seemed a sensible fix but if you're not keen we can find a different way.