### PR TITLE
Add dynamic operator spacing

### DIFF
--- a/src/assets/style/_export.module.scss
+++ b/src/assets/style/_export.module.scss
@@ -34,6 +34,17 @@
   frameStringSlotClassName: $strype-classname-frame-string-slot;
   frameStringSlotQuoteClassName: $strype-classname-frame-string-slot-quote;
   frameOperatorSlotClassName: $strype-classname-frame-operator-slot;
+  opTierDotClassName: $strype-classname-op-tier-dot;
+  opTierCommaClassName: $strype-classname-op-tier-comma;
+  opTierEqualsClassName: $strype-classname-op-tier-equals;
+  opTierColonClassName: $strype-classname-op-tier-colon;
+  opTierKeywordHighClassName: $strype-classname-op-tier-keyword-high;
+  opTierKeywordMediumClassName: $strype-classname-op-tier-keyword-medium;
+  opTierKeywordLowClassName: $strype-classname-op-tier-keyword-low;
+  opTierHighClassName: $strype-classname-op-tier-high;
+  opTierMediumClassName: $strype-classname-op-tier-medium;
+  opTierLowClassName: $strype-classname-op-tier-low;
+  opUnaryPrefixClassName: $strype-classname-op-unary-prefix;
   frameCommentSlotClassName: $strype-classname-frame-comment-slot;
   frameStatementCommentSlotClassName: $strype-classname-frame-statement-comment-slot;
   frameCodeSlotClassName: $strype-classname-frame-code-slot;

--- a/src/assets/style/variables.scss
+++ b/src/assets/style/variables.scss
@@ -37,6 +37,20 @@ $strype-classname-error-slot: error-slot;
 $strype-classname-frame-string-slot: string-slot;
 $strype-classname-frame-string-slot-quote: string-slot-quote;
 $strype-classname-frame-operator-slot: operator-slot;
+// precedence-based operator spacing tiers (see src/helpers/operatorPrecedence.ts)
+$strype-classname-op-tier-dot: op-tier-dot;
+$strype-classname-op-tier-comma: op-tier-comma;
+$strype-classname-op-tier-equals: op-tier-equals;
+$strype-classname-op-tier-colon: op-tier-colon;
+$strype-classname-op-tier-keyword-high: op-tier-keyword-high;
+$strype-classname-op-tier-keyword-medium: op-tier-keyword-medium;
+$strype-classname-op-tier-keyword-low: op-tier-keyword-low;
+$strype-classname-op-tier-high: op-tier-high;
+$strype-classname-op-tier-medium: op-tier-medium;
+$strype-classname-op-tier-low: op-tier-low;
+// applied in addition to a tier class for unary-prefix operators (not, ~, lambda):
+// overrides the tier's leading margin to 0, since there's nothing meaningful to their left.
+$strype-classname-op-unary-prefix: op-unary-prefix;
 $strype-classname-frame-comment-slot: comment-slot;
 $strype-classname-frame-statement-comment-slot: statement-comment-slot;
 $strype-classname-frame-code-slot: code-slot;

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -92,6 +92,7 @@ import { isMacOSPlatform } from "@/helpers/common";
 import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
 import { eventBus, projectDocumentationFrameId } from "@/helpers/appContext";
 import { detectBrowser } from "@/helpers/browser";
+import { PrecedenceTier, UNARY_PREFIX_OPERATORS } from "@/helpers/operatorPrecedence";
 
 // Default time to keep in cache: 5 minutes.
 const soundPreviewImages = new Cache<LoadedMedia>({ defaultTtl: 5 * 60 * 1000 });
@@ -147,6 +148,10 @@ export default defineComponent({
         isEditableSlot: Boolean,
         isEmphasised: Boolean,
         isFrozen: Boolean,
+        precedenceTier: {
+            type: String as PropType<PrecedenceTier>,
+            required: false,
+        },
     },
     
     inject: ["editImageInDialog"],    
@@ -296,10 +301,37 @@ export default defineComponent({
             let codeTypeCSS = "";
             let boldClass = "";               
             switch(this.slotType){
-            case SlotType.operator:
-                // For commas, we add a right margin:
-                codeTypeCSS = scssVars.frameOperatorSlotClassName + ((this.code==",") ? " slot-right-margin" : "");
+            case SlotType.operator: {
+                // Spacing is driven by the operator's precedence tier (see operatorPrecedence.ts),
+                // computed once per bracketed/top-level expression in generateFlatSlotBases().
+                const tierClassNames: Record<PrecedenceTier, string> = {
+                    "dot": scssVars.opTierDotClassName,
+                    "comma": scssVars.opTierCommaClassName,
+                    "equals": scssVars.opTierEqualsClassName,
+                    "colon": scssVars.opTierColonClassName,
+                    "keyword-high": scssVars.opTierKeywordHighClassName,
+                    "keyword-medium": scssVars.opTierKeywordMediumClassName,
+                    "keyword-low": scssVars.opTierKeywordLowClassName,
+                    "high": scssVars.opTierHighClassName,
+                    "medium": scssVars.opTierMediumClassName,
+                    "low": scssVars.opTierLowClassName,
+                    // A detected unary "-"/"+" (see generateFlatSlotBases; it now binds as
+                    // tightly as "~", so "medium" is the loosest it practically reaches)
+                    // substitutes this in for "medium" -- same trailing spacing, reusing the
+                    // exact same CSS class, just also picked up by the unary-prefix check
+                    // below to suppress the leading margin ("high" needs no substitute: it's
+                    // already zero margin on both sides):
+                    "sign-medium": scssVars.opTierMediumClassName,
+                };
+                const tierClass = tierClassNames[this.precedenceTier ?? "high"];
+                // Unary-prefix operators (not, ~, lambda always; -/+ only when detected as a
+                // unary sign, indicated by the "sign-medium" tier) have nothing meaningful to
+                // their left -- suppress the tier's leading margin, keep its trailing one:
+                const isUnarySign = this.precedenceTier === "sign-medium";
+                const unaryPrefixClass = (UNARY_PREFIX_OPERATORS.has(this.code) || isUnarySign) ? " " + scssVars.opUnaryPrefixClassName : "";
+                codeTypeCSS = scssVars.frameOperatorSlotClassName + " " + tierClass + unaryPrefixClass;
                 break;
+            }
             case SlotType.string:
                 codeTypeCSS = scssVars.frameStringSlotClassName;
                 break;
@@ -1845,6 +1877,64 @@ export default defineComponent({
     color: blue !important;
 }
 
+// Precedence-based operator spacing tiers (see src/helpers/operatorPrecedence.ts):
+// tighter-binding operators get less visual space, looser-binding ones get more,
+// capped at a "low" tier so deeply-nested low-precedence chains don't keep growing.
+.#{$strype-classname-op-tier-dot} {
+    margin: 0;
+}
+
+.#{$strype-classname-op-tier-comma} {
+    margin: 0 0.3em 0 0;
+}
+
+.#{$strype-classname-op-tier-equals} {
+    margin: 0 0.3em;
+}
+
+.#{$strype-classname-op-tier-colon} {
+    margin: 0;
+}
+
+// Keyword operators get their own tighter-to-looser ladder, parallel to the symbol one
+// below, since a word-shaped operator can never visually collapse all the way to zero
+// space -- "keyword-medium" keeps the same value the old single flat "keyword" tier used,
+// so the common (unmixed) case looks unchanged; "keyword-high"/"keyword-low" only show up
+// once keyword operators of different precedence share the same expression, e.g.
+// "a not in b and c or d" spans all three.
+.#{$strype-classname-op-tier-keyword-high} {
+    margin: 0 0.3em;
+}
+
+.#{$strype-classname-op-tier-keyword-medium} {
+    margin: 0 0.5em;
+}
+
+.#{$strype-classname-op-tier-keyword-low} {
+    margin: 0 0.8em;
+}
+
+.#{$strype-classname-op-tier-high} {
+    margin: 0;
+}
+
+.#{$strype-classname-op-tier-medium} {
+    margin: 0 0.3em;
+}
+
+.#{$strype-classname-op-tier-low} {
+    margin: 0 0.6em;
+}
+
+// Applied in addition to a tier class for unary-prefix operators (not, ~, lambda):
+// there's nothing meaningful to their left (they're always preceded by a blank
+// field), so only the tier's trailing margin should show. Must come after the
+// tier rules above so it wins on equal specificity.
+.#{$strype-classname-op-unary-prefix} {
+    margin-left: 0;
+    margin-right: 0.1em;
+}
+
 .#{$strype-classname-frame-code-slot}{
     color: black !important; 
 }
@@ -1858,9 +1948,6 @@ export default defineComponent({
     color: $frame-statement-comment-slot-base-colour !important;
 }
 
-.slot-right-margin {
-    margin-right: 2px;
-}
 // end classes for slot type
 
 .error-popover {

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -148,7 +148,7 @@ export default defineComponent({
         isEditableSlot: Boolean,
         isEmphasised: Boolean,
         isFrozen: Boolean,
-        precedenceTier: {
+        operatorPrecedenceTier: {
             type: String as PropType<PrecedenceTier>,
             required: false,
         },
@@ -323,11 +323,11 @@ export default defineComponent({
                     // already zero margin on both sides):
                     "sign-medium": scssVars.opTierMediumClassName,
                 };
-                const tierClass = tierClassNames[this.precedenceTier ?? "high"];
+                const tierClass = tierClassNames[this.operatorPrecedenceTier ?? "high"];
                 // Unary-prefix operators (not, ~, lambda always; -/+ only when detected as a
                 // unary sign, indicated by the "sign-medium" tier) have nothing meaningful to
                 // their left -- suppress the tier's leading margin, keep its trailing one:
-                const isUnarySign = this.precedenceTier === "sign-medium";
+                const isUnarySign = this.operatorPrecedenceTier === "sign-medium";
                 const unaryPrefixClass = (UNARY_PREFIX_OPERATORS.has(this.code) || isUnarySign) ? " " + scssVars.opUnaryPrefixClassName : "";
                 codeTypeCSS = scssVars.frameOperatorSlotClassName + " " + tierClass + unaryPrefixClass;
                 break;

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -32,7 +32,7 @@
                 :isEditableSlot="isEditableSlot(slotItem.type)"
                 :isFrozen="isFrozen"
                 :isEmphasised="isSlotEmphasised(slotItem)"
-                :precedenceTier="slotItem.precedenceTier"
+                :operatorPrecedenceTier="slotItem.operatorPrecedenceTier"
                 @requestSlotsRefactoring="checkSlotRefactoring"
             />
     </div>

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -32,6 +32,7 @@
                 :isEditableSlot="isEditableSlot(slotItem.type)"
                 :isFrozen="isFrozen"
                 :isEmphasised="isSlotEmphasised(slotItem)"
+                :precedenceTier="slotItem.precedenceTier"
                 @requestSlotsRefactoring="checkSlotRefactoring"
             />
     </div>

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -1291,7 +1291,10 @@ export const operators = [".","+","-","/","*","%",":","//","**","&","|","~","^",
 // as they will always come from a combination of writing one word then the other (the first will be added as operator);
 // "as" is added in the operator list for imports, but it will be discarded when not dealing with import frames.
 // Important that the longer operators come before the shorter ones with the same prefix:
-export const keywordOperatorsWithSurroundSpaces = [" and ", " in ", " is not ", " is ", " or ", " not in ", " not ", " as ", " if ", " else ", " for "];
+// "lambda" is recognised as a plain prefix keyword operator (like "not") so it can be
+// typed/pasted without crashing and gets sensible precedence-based spacing, but Strype
+// gives it no semantic support (no parameter-list awareness) -- it's a pass-through.
+export const keywordOperatorsWithSurroundSpaces = [" and ", " in ", " is not ", " is ", " or ", " not in ", " not ", " as ", " if ", " else ", " for ", " lambda "];
 export const trimmedKeywordOperators = keywordOperatorsWithSurroundSpaces.map((spacedOp) => spacedOp.trim());
 
 

--- a/src/helpers/operatorPrecedence.ts
+++ b/src/helpers/operatorPrecedence.ts
@@ -1,0 +1,256 @@
+// Computes the visual spacing "tier" of each operator inside one level (i.e. one
+// SlotsStructure.operators array -- top-level or a single bracketed sub-expression)
+// of a Strype expression slot. This mirrors the precedence-based spacing approach
+// used by BlueJ/Greenfoot's frame editor (InfixStructured.calculatePrecedences /
+// Operator.getOperatorPrecedence), adapted for Python operators.
+//
+// This module is intentionally self-contained (no imports from editor.ts/parser.ts)
+// so it stays a pure, independently testable function.
+
+// "sign-medium" is a substitute for "medium", used when a "-"/"+" is a detected unary sign
+// (see calculatePrecedenceTiers' isUnarySignAt parameter): visually identical to "medium"
+// (same CSS class, see LabelSlot.vue) except with no leading margin. There's no "sign-high"
+// because "high" is already zero margin on both sides, and no "sign-low" because unary sign
+// now binds as tightly as "~" (see PRECEDENCE), so it never falls that far -- see the
+// operatorPrecedence.test-equivalent cases in operator-precedence-calculation.spec.ts for
+// why level 2+ isn't reachable for it in practice.
+export type PrecedenceTier = "dot" | "comma" | "equals" | "colon" | "keyword-high" | "keyword-medium" | "keyword-low" | "high" | "medium" | "low" | "sign-medium";
+
+// Tokens that never participate in the precedence ladder at all: they always
+// render with a fixed tier, and are never candidates when searching for the
+// "lowest precedence operator" in a level.
+const FIXED_TIERS: Record<string, PrecedenceTier> = {
+    ".": "dot",
+    "=": "equals",
+    ":": "colon",
+    ",": "comma",
+};
+
+// Tokens that are always word-shaped (keyword) operators. They still participate in the
+// same precedence ladder as symbol operators (so e.g. "a not in b and c or d" gets three
+// distinct keyword tiers, tightest to loosest), but are rendered with their own
+// keyword-high/medium/low tiers rather than the symbol high/medium/low ones, since a
+// word-shaped operator can never visually collapse all the way to zero space.
+const KEYWORD_OPERATORS = new Set(["and", "or", "not", "in", "is", "is not", "not in", "as", "if", "else", "for", "lambda"]);
+
+// Operators that are always used as a unary prefix in Strype's grammar (always solo,
+// always with a blank field before them -- see transformSlotLevel's validity check).
+// They should never get a leading margin (there's nothing meaningful to their left),
+// only a trailing one to separate them from their operand.
+export const UNARY_PREFIX_OPERATORS = new Set(["not", "~", "lambda"]);
+
+// Numeric precedence, ascending = binds tighter (matches BlueJ's convention).
+// Only real (non-fixed-tier, non-boundary) operators appear here -- ternary if/else and
+// comprehension for/in/if are classified as "boundary" (see classifyRoles) and never
+// reach this table.
+const PRECEDENCE: Record<string, number> = {
+    // "lambda" has no semantic support in Strype (no parameter-list awareness) -- it's
+    // recognised as a plain prefix keyword operator, like "not", purely so it can be
+    // typed/pasted without error and gets sensible spacing. Its precedence is the lowest
+    // of any construct still in the ladder:
+    "lambda": 5,
+    "or": 20,
+    "and": 30,
+    "not": 40, // unary keyword "not" -- always solo at index 0 (see transformSlotLevel)
+    // comparisons -- all equal precedence, Python chains these non-associatively
+    "in": 50, "is": 50, "is not": 50, "not in": 50,
+    "==": 50, "!=": 50, "<": 50, "<=": 50, ">": 50, ">=": 50,
+    "|": 60,
+    "^": 70,
+    "&": 80,
+    "<<": 90, ">>": 90,
+    "+": 100, "-": 100, // binary only -- a detected unary sign uses UNARY_SIGN_PRECEDENCE instead
+    "*": 110, "/": 110, "//": 110, "%": 110,
+    "~": 120, // unary -- always solo at index 0
+    "**": 130,
+};
+
+// Real Python binds unary +/-/~ all at the same (very tight) precedence, between binary
+// */÷///% and **. calculatePrecedenceTiers has no way to tell a unary "-"/"+" from a binary
+// one just from its code (unlike "~", which is unconditionally unary) -- the caller passes
+// that in via isUnarySignAt, computed from field context it has and this module deliberately
+// doesn't (see generateFlatSlotBases).
+const UNARY_SIGN_PRECEDENCE = PRECEDENCE["~"];
+
+type Role = "fixed" | "boundary" | "operator";
+
+interface ClassifiedOp {
+    index: number;
+    code: string;
+    role: Role;
+}
+
+// Classifies every operator in the flat array by its role. Ternary "if"/"else" and
+// comprehension "for"/"in"/"if" aren't operators in the classic sense -- they're clause
+// separators, like commas. They always get a fixed "keyword" tier and act as hard
+// segment boundaries, splitting the array into independent clauses rather than
+// participating in the precedence ladder themselves. Without this, a clause's own
+// looser-than-comparison precedence (e.g. the ternary's, or a comprehension's) would
+// make the *whole* array look "mixed" and wrongly tighten operators inside one clause --
+// e.g. "a if b>c else d" would pull "b>c" to the tightest tier just because "if"/"else"
+// happen to sit elsewhere in the same flat array.
+//
+// "in" is the only ambiguous token: it's a genuine comparison operator ("a in b") outside
+// a comprehension, but a clause separator inside one ("for x in y"). Disambiguated by
+// position: once a top-level "for" is seen, every subsequent "in" in this same level is
+// the comprehension's, not an ordinary operator.
+function classifyRoles(operatorCodes: string[]): ClassifiedOp[] {
+    let seenTopLevelFor = false;
+    return operatorCodes.map((code, index) => {
+        if (code in FIXED_TIERS) {
+            return { index, code, role: "fixed" as Role };
+        }
+        if (code === "for") {
+            seenTopLevelFor = true;
+            return { index, code, role: "boundary" as Role };
+        }
+        if (code === "if" || code === "else") {
+            return { index, code, role: "boundary" as Role };
+        }
+        if (seenTopLevelFor && code === "in") {
+            return { index, code, role: "boundary" as Role };
+        }
+        return { index, code, role: "operator" as Role };
+    });
+}
+
+// Mirrors BlueJ's OpPrec pair: the precedence value of the pivot operator
+// chosen for a segment (-1 if the segment had no operators), and the visual
+// "level" that pivot (and thus the segment as a whole, for combining purposes
+// with a parent segment) ended up at.
+interface OpPrec {
+    prec: number;
+    level: number;
+}
+
+// Ports BlueJ's InfixStructured.calculatePrecedences: given a segment of
+// (index, code) pairs containing no fixed/boundary tokens, finds the single
+// lowest-precedence operator (ties broken leftmost), recursively computes the
+// left/right sub-segments' levels around it, and combines them the same way
+// BlueJ does. Records each pivot's raw numeric level into `levels` by index
+// (not yet a tier -- see calculatePrecedenceTiers for why the level-to-tier
+// mapping needs the whole segment's range, not just one operator's own level).
+function tierSegment(segment: ClassifiedOp[], levels: Map<number, number>, isUnarySignAt: boolean[]): OpPrec {
+    let lowestPrec = Number.MAX_SAFE_INTEGER;
+    let lowestPos = -1;
+    for (let i = 0; i < segment.length; i++) {
+        const op = segment[i];
+        const prec = isUnarySignAt[op.index] ? UNARY_SIGN_PRECEDENCE : PRECEDENCE[op.code];
+        if (prec < lowestPrec) {
+            lowestPrec = prec;
+            lowestPos = i;
+        }
+    }
+
+    if (lowestPos === -1) {
+        // No operators in this segment.
+        return { prec: -1, level: 0 };
+    }
+
+    const lhs = segment.slice(0, lowestPos);
+    const rhs = segment.slice(lowestPos + 1);
+    const lhsResult = tierSegment(lhs, levels, isUnarySignAt);
+    const rhsResult = tierSegment(rhs, levels, isUnarySignAt);
+
+    let ourLevel: number;
+    if (lhsResult.prec === lowestPrec || rhsResult.prec === lowestPrec || (lhsResult.prec === -1 && rhsResult.prec === -1)) {
+        // Same precedence chain as a child (or no operators on either side):
+        ourLevel = Math.max(lhsResult.level, rhsResult.level);
+    }
+    else {
+        ourLevel = 1 + Math.max(lhsResult.level, rhsResult.level);
+    }
+
+    const pivot = segment[lowestPos];
+    levels.set(pivot.index, ourLevel);
+
+    return { prec: lowestPrec, level: ourLevel };
+}
+
+// Maps a level to a tier once we know whether this segment is "mixed" (see below).
+// Keyword operators get their own high/medium/low ladder, parallel to the symbol one,
+// since they can never render as tightly as a symbol can.
+function tierForLevel(level: number, isKeyword: boolean): PrecedenceTier {
+    if (level === 0) {
+        return isKeyword ? "keyword-high" : "high";
+    }
+    else if (level === 1) {
+        return isKeyword ? "keyword-medium" : "medium";
+    }
+    else {
+        return isKeyword ? "keyword-low" : "low";
+    }
+}
+
+// isUnarySignAt: parallel to operatorCodes, true at indices where a "-"/"+" is a detected
+// unary sign (see generateFlatSlotBases) rather than an ordinary binary operator. Ignored
+// at every other index. Defaulted so existing call sites without any unary "-"/"+" don't
+// need to pass it.
+export function calculatePrecedenceTiers(operatorCodes: string[], isUnarySignAt: boolean[] = []): PrecedenceTier[] {
+    const tiers: PrecedenceTier[] = new Array(operatorCodes.length).fill("high");
+
+    const classified = classifyRoles(operatorCodes);
+
+    // Assign fixed tiers directly.
+    classified.forEach((op) => {
+        if (op.role === "fixed") {
+            tiers[op.index] = FIXED_TIERS[op.code];
+        }
+        else if (op.role === "boundary") {
+            // Not part of the ladder at all (see classifyRoles), so there's no computed
+            // level to map -- "keyword-medium" is the same neutral default that a solo/
+            // unmixed symbol operator gets ("medium").
+            tiers[op.index] = "keyword-medium";
+        }
+    });
+
+    // Split into segments at every fixed/boundary token, and tier each
+    // "operator"-role segment independently.
+    let currentSegment: ClassifiedOp[] = [];
+    const flushSegment = () => {
+        if (currentSegment.length > 0) {
+            const levels = new Map<number, number>();
+            tierSegment(currentSegment, levels, isUnarySignAt);
+
+            // A segment where every operator lands at level 0 has only a single
+            // precedence present throughout (e.g. "a+b+c", "a<b<c") -- there's
+            // nothing to visually differentiate, so instead of using the tightest
+            // tier we use "medium" (or "keyword-medium") as a neutral default. The
+            // tightest tier is reserved for when the segment actually becomes mixed
+            // (level 0 no longer the only level present): e.g. "a+b+c or d" pulls "+"
+            // down to "high" once "or" introduces a second, looser precedence -- and
+            // likewise "a not in b and c or d" spreads "not in"/"and"/"or" across all
+            // three keyword tiers, since they're three distinct precedences competing
+            // in the same segment.
+            const maxLevel = Math.max(...currentSegment.map((op) => levels.get(op.index) ?? 0));
+
+            currentSegment.forEach((op) => {
+                const isKeyword = KEYWORD_OPERATORS.has(op.code);
+                let tier = (maxLevel === 0)
+                    ? (isKeyword ? "keyword-medium" : "medium")
+                    : tierForLevel(levels.get(op.index) ?? 0, isKeyword);
+                // A detected unary sign substitutes in "sign-medium" for "medium" so the CSS
+                // layer knows to suppress its leading margin ("high" needs no substitute --
+                // already zero margin on both sides; "low" isn't reachable now that unary
+                // sign binds as tightly as "~", see UNARY_SIGN_PRECEDENCE):
+                if (isUnarySignAt[op.index] && tier === "medium") {
+                    tier = "sign-medium";
+                }
+                tiers[op.index] = tier;
+            });
+
+            currentSegment = [];
+        }
+    };
+    classified.forEach((op) => {
+        if (op.role === "operator") {
+            currentSegment.push(op);
+        }
+        else {
+            flushSegment();
+        }
+    });
+    flushSegment();
+
+    return tiers;
+}

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -697,7 +697,7 @@ function parseNextTerm(ps : ParseState) : SlotsStructure {
         ps.nextIndex += 1;
         return concatSlots({fields: [{code: ""}], operators: []}, nextVal, parseNextTerm(ps));
     }
-    if (nextVal === "not" || nextVal === ":" || nextVal === "*") {
+    if (nextVal === "not" || nextVal === ":" || nextVal === "*" || nextVal === "~" || nextVal === "lambda") {
         ps.nextIndex += 1;
         return concatSlots({fields: [{code: ""}], operators: []}, nextVal, parseNextTerm(ps));
     }

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -145,7 +145,7 @@ export const generateFlatSlotBases = (slot: { allowedSlotContent?: AllowedSlotCo
 
         // Add this operator only if it is not blank
         if(operatorSlot.code.length > 0) {
-            addFlatSlot({...operatorSlot, id: slotId, type: SlotType.operator, precedenceTier: precedenceTiers[index]}, false);
+            addFlatSlot({...operatorSlot, id: slotId, type: SlotType.operator, operatorPrecedenceTier: precedenceTiers[index]}, false);
         }
     });
 

--- a/src/helpers/storeMethods.ts
+++ b/src/helpers/storeMethods.ts
@@ -9,6 +9,7 @@ import { cloneDeep, isEqual } from "lodash";
 import scssVars from "@/assets/style/_export.module.scss";
 import { $enum } from "ts-enum-util";
 import { getUserDefinedSignature } from "@/autocompletion/acManager";
+import { calculatePrecedenceTiers } from "@/helpers/operatorPrecedence";
 
 export const retrieveSlotFromSlotInfos = (slotCoreInfos: SlotCoreInfos): FieldSlot => {
     // Retrieve the slot from its id (used for UI), check generateFlatSlotBases() for IDs explanation    
@@ -73,6 +74,36 @@ export const generateFlatSlotBases = (slot: { allowedSlotContent?: AllowedSlotCo
         slotStructure = transformEachLevel(slotStructure, topLevel);
     }
 
+    // Walks backward from the field immediately preceding operators[index], skipping over
+    // blank operator/blank-field placeholder pairs -- these flank every bracket/string/media
+    // field (reserved for a potential "." insertion, e.g. "(x).y") and are otherwise blank
+    // like a genuine unary position, so they can't be told apart by looking at a single
+    // preceding field alone. Returns true as soon as a real operand is found -- a non-blank
+    // field, or a bracket/string/media field -- at any distance back; false if we instead
+    // reach the start of the level, or a non-blank operator (a real operator/keyword
+    // directly followed by a blank gap, e.g. "if -a"'s "-").
+    const hasRealOperandBefore = (index: number): boolean => {
+        for (let i = index; i >= 0; i--) {
+            const field = slotStructure.fields[i];
+            if (!isFieldBaseSlot(field) || field.code.trim() !== "") {
+                return true;
+            }
+            if (i === 0 || slotStructure.operators[i - 1].code !== "") {
+                return false;
+            }
+        }
+        return false;
+    };
+    // A "-"/"+" is a unary sign when it's sitting in an otherwise-blank operand position
+    // (the same rule the live-typing tokenizer and pythonToFrames.ts already use to tell
+    // unary from binary sign) -- passed into calculatePrecedenceTiers so a detected unary
+    // sign binds as tightly as "~" rather than sharing binary +/-'s much looser precedence.
+    const isUnarySignAt = slotStructure.operators.map((operatorSlot, index) =>
+        (operatorSlot.code === "-" || operatorSlot.code === "+") && !hasRealOperandBefore(index));
+    // Computed once per level (i.e. per bracketed/top-level expression), so that
+    // spacing scales with the operators actually present at that level only.
+    const precedenceTiers = calculatePrecedenceTiers(slotStructure.operators.map((operatorSlot) => operatorSlot.code), isUnarySignAt);
+
     slotStructure.operators.forEach((operatorSlot, index) => {
         // Add the precededing field
         currIndex++;
@@ -114,7 +145,7 @@ export const generateFlatSlotBases = (slot: { allowedSlotContent?: AllowedSlotCo
 
         // Add this operator only if it is not blank
         if(operatorSlot.code.length > 0) {
-            addFlatSlot({...operatorSlot, id: slotId, type: SlotType.operator}, false);
+            addFlatSlot({...operatorSlot, id: slotId, type: SlotType.operator, precedenceTier: precedenceTiers[index]}, false);
         }
     });
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -110,7 +110,7 @@ function transformSlotLevel(slots: SlotsStructure, topLevel?: {frameType: string
     //     if the right-hand item is a round or square bracket (function call and list index, respectively)
     let valid = true;
     for (let i = 0; i < slots.operators.length; i++) {
-        if (slots.operators[i].code.trim() === "not" || slots.operators[i].code.trim() === "~") {
+        if (slots.operators[i].code.trim() === "not" || slots.operators[i].code.trim() === "~" || slots.operators[i].code.trim() === "lambda") {
             // Unary operators only valid at start of bracketed expression:
             if (i != 0) {
                 valid = false;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -75,7 +75,7 @@ export interface FlatSlotBase extends BaseSlot {
     type: SlotType;
     // Only meaningful when type === SlotType.operator: the visual spacing tier
     // computed by calculatePrecedenceTiers(), used to pick the operator's CSS class.
-    precedenceTier?: PrecedenceTier;
+    operatorPrecedenceTier?: PrecedenceTier;
 }
 
 export function isFieldStringSlot(field: FieldSlot): field is StringSlot {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,6 +2,7 @@ import i18n from "@/i18n";
 import Compiler from "@/compiler/compiler";
 import { useStore } from "@/store/store";
 import scssVars from "@/assets/style/_export.module.scss";
+import { PrecedenceTier } from "@/helpers/operatorPrecedence";
 import quoteCircleProject from "@/assets/images/quote-circle/quote-circle-project.png";
 import quoteCircleFuncdef from "@/assets/images/quote-circle/quote-circle-funcdef.png";
 import quoteCircleClass from "@/assets/images/quote-circle/quote-circle-class.png";
@@ -72,6 +73,9 @@ export interface MediaSlot extends BaseSlot {
 export interface FlatSlotBase extends BaseSlot {
     id: string;
     type: SlotType;
+    // Only meaningful when type === SlotType.operator: the visual spacing tier
+    // computed by calculatePrecedenceTiers(), used to pick the operator's CSS class.
+    precedenceTier?: PrecedenceTier;
 }
 
 export function isFieldStringSlot(field: FieldSlot): field is StringSlot {

--- a/tests/cypress/e2e/paste-python.cy.ts
+++ b/tests/cypress/e2e/paste-python.cy.ts
@@ -31,6 +31,20 @@ describe("Python round-trip", () => {
         "raise (1+2-3)==(4*5/6)\n",
         // ** binds tighter than unary -, hence the space before:
         "raise foo**-6.7**False**True**'bye'\n",
+        // Unary ~ (bitwise not) directly followed by a binary operator, with no
+        // parentheses to separate them -- regression test for a paste-import bug
+        // where parseNextTerm() didn't recognise "~" as a unary prefix, so it
+        // consumed "~" as a whole term on its own and then choked on the operand
+        // that follows, expecting an operator there instead:
+        "raise ~a&b\n",
+        "raise ~a\n",
+        // "lambda" has no semantic support (no parameter-list awareness) -- it's a
+        // pass-through prefix keyword operator, like "not". Regression coverage for
+        // a paste-import crash ("Unknown operator ... varargslist") since lambdef
+        // wasn't handled by parseNextTerm() at all:
+        "raise lambda n:-n\n",
+        "raise lambda :x\n",
+        "raise sorted(x,key= lambda n:-n,reverse=True)\n",
         "try:\n    x = 0\nexcept:\n    x = 1\n",
         // Expand operator:
         "f(*a)\n",

--- a/tests/manual/operator-spacing-demo.py
+++ b/tests/manual/operator-spacing-demo.py
@@ -1,0 +1,95 @@
+# Demo file for visually checking precedence-based operator spacing.
+# Paste this into Strype (Ctrl+V into the editor) and look at the gaps around
+# operators: tighter-binding operators (., **, unary ~, *, /) should sit close
+# to their operands; looser-binding ones (or, and, comparisons, +, -) should
+# have more visual space; comma should hug the left side and have space after.
+
+a = 1
+b = 2
+c = 3
+d = 4
+e = 5
+f = 6
+g = 7
+h = 8
+i = 9
+nums = [1, 2, 3, 4, 5]
+lookup = {1: "x", 2: "y"}
+name = "hello"
+
+# Same-precedence chains should space evenly, no growing gaps
+r1 = a+b+c+d+e
+r2 = a*b*c*d*e
+
+# Mixed precedence: loosest operator gets the most space
+r3 = a+b*c
+r4 = a*b+c*d
+r5 = a+b*c-d/e
+
+# Comparisons (all one precedence tier) vs arithmetic inside them
+r6 = a<b<c
+r7 = a+b < c+d
+r8 = a==b and c!=d or e>=f
+
+# Boolean operators: or is loosest, and tighter, not tightest of the three
+r9 = a and b or c
+r10 = (not a) and (not b)
+r11 = a or b and c or d
+
+# Membership and identity
+r12 = a in nums and b not in nums
+r13 = a is b or a is not c
+
+# Bitwise and shifts
+r14 = a|b^c&d
+r15 = a<<b>>c
+r16 = (a|b) ^ (c&d)
+
+# Power and unary
+r17 = a**b**c
+r18 = (-a)+b*(-c)
+r19 = (~a) & b
+
+# Ternary conditional
+r20 = a if b>c else d
+r21 = (a+b) if (c and d) else (e-f)
+
+# Comprehensions: for/in/if should be tight/uniform, inner expr spaced by its own precedence
+r22 = [x for x in nums]
+r23 = [x+1 for x in nums if x>2]
+r24 = {x for x in nums}
+r25 = {x: x*2 for x in nums if x!=3}
+
+# Function calls: commas tight-before/space-after, kwargs '=' with no space
+r26 = max(a, b, c)
+r27 = pow(a, b, mod=c+d)
+r28 = sorted(nums, key=lambda n: -n, reverse=True)
+
+# Nested brackets: each bracket's operators should tier independently
+r29 = (a+b)*(c+d)
+r30 = ((a+b)*(c+d))/((e-f)*(g+h))
+
+# Slicing and attribute/dot access
+r31 = nums[1:3]
+r32 = nums[::2]
+r33 = name.upper().lower()
+
+# A deliberately busy one mixing most tiers at once
+r34 = nums[0]+nums[1] if a in nums and name.upper()!="X" else lookup[1]+lookup[2]
+
+# Mixed-tier chains, deliberately with NO brackets: each of these spans several
+# precedence levels in one flat expression, so you should see multiple distinct
+# gap sizes within the SAME line, not just one tier per example.
+r35 = a or b and c in nums or d==e and f+g*h
+r36 = a|b and c^d or e&f
+r37 = a<b|c>>d+e*f
+r38 = a+b*c-d//e%f**g
+r39 = a+b<c-d<e*f
+r40 = a or b+c and d*e or f==g
+# All 3 real symbol tiers (high/medium/low) in one unbracketed chain:
+r41 = a+b*c**d
+# The full precedence ladder end to end, strictly loosest to tightest -- shows
+# the CSS spacing capping at "low" rather than growing forever as it gets deep:
+r42 = a or b and c|d^e&f<<g+h*i
+r43 = a and b in nums or not c==d
+r44 = a+b*c<d-e/f and g**h>i

--- a/tests/playwright/e2e/operator-precedence-calculation.spec.ts
+++ b/tests/playwright/e2e/operator-precedence-calculation.spec.ts
@@ -1,0 +1,247 @@
+import { test, expect } from "@playwright/test";
+import { calculatePrecedenceTiers, PrecedenceTier } from "@/helpers/operatorPrecedence";
+
+// NOTE: this is really a *unit* test for the pure calculatePrecedenceTiers() function (see
+// src/helpers/operatorPrecedence.ts) -- none of it touches a browser page, the DOM, or the
+// live app. It's written as a Playwright spec purely to reuse the test infrastructure
+// already in this repo (it runs alongside the rest of the Playwright suite with `npm run
+// test:playwright`), rather than pulling in a second test framework (e.g. Vitest) just for
+// one module. For the equivalent coverage against the real, rendered app -- typing/pasting/
+// loading actual expressions and reading the CSS tier classes back from the live DOM -- see
+// operator-precedence-spacing.spec.ts in this same directory.
+
+test.describe("calculatePrecedenceTiers", () => {
+    test("gives a sole operator the neutral 'medium' tier (nothing to contrast against)", () => {
+        // a+b -- only one precedence present (trivially), so it's not "mixed" yet.
+        expect(calculatePrecedenceTiers(["+"])).toEqual(["medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("gives an equal-precedence chain the neutral 'medium' tier throughout", () => {
+        // a+b+c -- a single precedence spans the whole segment, so every '+' is "medium".
+        expect(calculatePrecedenceTiers(["+", "+"])).toEqual(["medium", "medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("ties correctly for mixed precedence", () => {
+        // a+b*c: '+' is looser (more space) than '*' (tighter, less space) -- this segment
+        // is genuinely mixed, so the tightest-binding operator ('*') gets pulled to "high".
+        expect(calculatePrecedenceTiers(["+", "*"])).toEqual(["medium", "high"] satisfies PrecedenceTier[]);
+    });
+
+    test("pulls a same-precedence chain from 'medium' down to 'high' once the segment becomes mixed", () => {
+        // a+b+c (isolated) -- single precedence throughout, neutral "medium":
+        expect(calculatePrecedenceTiers(["+", "+"])).toEqual(["medium", "medium"] satisfies PrecedenceTier[]);
+        // a+b+c or d -- introducing "or" makes the segment mixed, so the '+' chain --
+        // now the tightest-binding operator present -- is pulled down to "high". "or" is
+        // the sole (loosest) keyword here, one level looser than the '+' chain, so it
+        // lands on "keyword-medium" rather than the flat "keyword" tier of before:
+        const tiers = calculatePrecedenceTiers(["+", "+", "or"]);
+        expect(tiers).toEqual(["high", "high", "keyword-medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("caps deep same-precedence chains at the neutral 'medium' tier throughout", () => {
+        // a+b+c+d+e+f+g (6 '+' operators, all in the same precedence chain, never mixed)
+        const tiers = calculatePrecedenceTiers(["+", "+", "+", "+", "+", "+"]);
+        expect(tiers.every((t) => t === "medium")).toBe(true);
+    });
+
+    test("caps deep mixed-precedence nesting at the 'low'/'keyword-low' tier rather than growing further", () => {
+        // Alternating strictly-looser-then-tighter operators nested many levels deep:
+        // or, and, |, ^, &, <<, +, * -- each strictly tighter than the last, so precedence
+        // recursion keeps incrementing the level, but must still collapse to high/medium/low
+        // (or keyword-high/medium/low for the two keyword operators). This segment is
+        // thoroughly mixed, so the standard level-to-tier mapping applies throughout.
+        const tiers = calculatePrecedenceTiers(["or", "and", "|", "^", "&", "<<", "+", "*"]);
+        // "or"/"and" are both keywords, and both deep enough (levels 7 and 6) to be capped
+        // at "keyword-low" -- they still land on one of the three keyword tiers, never a
+        // made-up 4th one, even though their raw levels differ:
+        expect(tiers[0]).toBe("keyword-low"); // 'or'
+        expect(tiers[1]).toBe("keyword-low"); // 'and'
+        // The symbol operators must likewise each be one of the three real (non-keyword) tiers:
+        const symbolTiers = [tiers[2], tiers[3], tiers[4], tiers[5], tiers[6], tiers[7]];
+        symbolTiers.forEach((t) => expect(["high", "medium", "low"]).toContain(t));
+        expect(tiers[7]).toBe("high"); // '*' is the tightest-binding operator here
+    });
+
+    test("spreads three differently-precedenced keyword operators across all three keyword tiers", () => {
+        // a not in b and c or d: "not in" (a comparison, prec 50) binds tightest, "and"
+        // (prec 30) is next, "or" (prec 20) is loosest -- three distinct precedences
+        // competing in one segment, so keyword operators get real tiering just like
+        // symbol operators do, rather than a single flat "keyword" tier for all of them:
+        const tiers = calculatePrecedenceTiers(["not in", "and", "or"]);
+        expect(tiers).toEqual(["keyword-high", "keyword-medium", "keyword-low"] satisfies PrecedenceTier[]);
+    });
+
+    test("still only shows two keyword tiers when only two precedences are present", () => {
+        // a and b or c: "and" (prec 30) tighter than "or" (prec 20) -- only two distinct
+        // precedences, so only two tiers show up, same as the symbol ladder would:
+        expect(calculatePrecedenceTiers(["and", "or"])).toEqual(["keyword-high", "keyword-medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("gives 'not' the neutral keyword tier when solo, and '~' the neutral symbol tier when solo", () => {
+        // Solo/unmixed, so each gets its own ladder's neutral default -- "keyword-medium"
+        // for the keyword "not", "medium" for the symbol "~":
+        expect(calculatePrecedenceTiers(["not"])).toEqual(["keyword-medium"] satisfies PrecedenceTier[]);
+        // '~' alone is a sole (unmixed) operator, so it gets the same "medium" default as
+        // any other lone operator -- its unary-prefix leading margin is separately
+        // suppressed at the CSS layer (see LabelSlot.vue), independent of tier.
+        expect(calculatePrecedenceTiers(["~"])).toEqual(["medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("gives comma/dot/equals/colon their fixed tiers and never selects them as a pivot", () => {
+        expect(calculatePrecedenceTiers([","])).toEqual(["comma"] satisfies PrecedenceTier[]);
+        expect(calculatePrecedenceTiers(["."])).toEqual(["dot"] satisfies PrecedenceTier[]);
+        expect(calculatePrecedenceTiers(["="])).toEqual(["equals"] satisfies PrecedenceTier[]);
+        expect(calculatePrecedenceTiers([":"])).toEqual(["colon"] satisfies PrecedenceTier[]);
+
+        // foo(a, b=1+2): the '+' must tier correctly (as a sole/neutral operator, "medium"),
+        // unaffected by the ',' and '=' around it.
+        const tiers = calculatePrecedenceTiers([",", "=", "+"]);
+        expect(tiers).toEqual(["comma", "equals", "medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("splits independently at each comma, unaffected by precedence on the other side", () => {
+        // f(a+b, c*d, e/f): each segment gets its own independent tiering; each is a sole
+        // operator in its own segment, so each defaults to "medium".
+        const tiers = calculatePrecedenceTiers(["+", ",", "*", ",", "/"]);
+        expect(tiers).toEqual(["medium", "comma", "medium", "comma", "medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("treats ternary if/else as hard segment boundaries, not ordinary operators", () => {
+        // a+b if c else d+e -- if/else aren't operators in the classic sense (they're
+        // clause separators, like commas), so they split the array into three independent
+        // segments (before 'if', between 'if'/'else', after 'else') instead of competing
+        // for the precedence pivot. Each '+' is a sole operator in its own branch, so each
+        // stays "medium" -- unaffected by if/else sitting elsewhere in the same array:
+        const tiers = calculatePrecedenceTiers(["+", "if", "else", "+"]);
+        expect(tiers[0]).toBe("medium");
+        expect(tiers[3]).toBe("medium");
+        expect(tiers[1]).toBe("keyword-medium");
+        expect(tiers[2]).toBe("keyword-medium");
+    });
+
+    test("doesn't let a ternary's if/else tighten a comparison in its condition", () => {
+        // a if b>c else d -- '>' sits in its own segment (between 'if' and 'else'), so it
+        // gets the neutral "medium" default like any other sole operator, rather than
+        // being pulled to "high" just because if/else's own (looser) precedence would
+        // otherwise make this look like a "mixed" segment:
+        const tiers = calculatePrecedenceTiers(["if", ">", "else"]);
+        expect(tiers[0]).toBe("keyword-medium");
+        expect(tiers[1]).toBe("medium");
+        expect(tiers[2]).toBe("keyword-medium");
+    });
+
+    test("treats comprehension for/in/if as hard segment boundaries, not ordinary operators", () => {
+        // [x+1 for x in range(10) if x>2] -- 'range(10)' is a nested bracket, not part of
+        // this level. The '+' and '>' are each a sole operator in their own segment
+        // (comma/comprehension markers are hard boundaries), so each is "medium".
+        const tiers = calculatePrecedenceTiers(["+", "for", "in", "if", ">"]);
+        expect(tiers).toEqual(["medium", "keyword-medium", "keyword-medium", "keyword-medium", "medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("disambiguates a real comparison 'in' from a comprehension 'in' by position", () => {
+        // Real comparison, before any 'for': a in b -- solo, so the neutral keyword default:
+        expect(calculatePrecedenceTiers(["in"])).toEqual(["keyword-medium"] satisfies PrecedenceTier[]);
+        // Comprehension clause separator, after 'for': [x for x in y] -- boundary role,
+        // same fixed neutral default:
+        const tiers = calculatePrecedenceTiers(["for", "in"]);
+        expect(tiers).toEqual(["keyword-medium", "keyword-medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("handles an empty operators array", () => {
+        expect(calculatePrecedenceTiers([])).toEqual([] satisfies PrecedenceTier[]);
+    });
+
+    test("treats 'lambda' as a pass-through prefix keyword operator, binding loosest of all", () => {
+        // lambda n: -n -- fields would be ["", "n", "", "n"], no semantic understanding
+        // of the parameter list is needed for tiering purposes. "lambda" is solo in its
+        // own segment (":" splits it off from the body), so it gets the neutral
+        // "keyword-medium" default; the lone "-" gets the neutral "medium" default.
+        expect(calculatePrecedenceTiers(["lambda", ":", "-"])).toEqual(["keyword-medium", "colon", "medium"] satisfies PrecedenceTier[]);
+        // lambda binds looser than everything else still in the ladder if it ever shares
+        // a segment with other real operators (see PRECEDENCE) -- solo here, though:
+        expect(calculatePrecedenceTiers(["lambda"])).toEqual(["keyword-medium"] satisfies PrecedenceTier[]);
+    });
+});
+
+test.describe("calculatePrecedenceTiers: per-level independence", () => {
+    // generateFlatSlotBases() (see src/helpers/storeMethods.ts) calls calculatePrecedenceTiers()
+    // once per SlotsStructure level, recursing into brackets separately -- so calling it
+    // directly, once per level, here is a faithful (and DOM-free) stand-in for that wiring.
+    // The live-DOM equivalent of these two cases (typing/pasting the real bracketed
+    // expressions and reading the rendered tier classes) is in
+    // operator-precedence-spacing.spec.ts's "(a+b)*(c+d)" tests.
+
+    test("tiers each level independently of its neighbours", () => {
+        // (a+b)*(c+d): each bracket's '+' is a sole operator within its own level, and the
+        // outer level (blank placeholder, '*', blank placeholder) has only one real
+        // operator -- so all three render as "medium".
+        expect(calculatePrecedenceTiers(["+"])).toEqual(["medium"] satisfies PrecedenceTier[]); // inside (a+b)
+        const outerTiers = calculatePrecedenceTiers(["", "*", ""]);
+        expect(outerTiers[1]).toBe("medium"); // outer '*', solo
+        expect(calculatePrecedenceTiers(["+"])).toEqual(["medium"] satisfies PrecedenceTier[]); // inside (c+d)
+    });
+
+    test("pulls the outer operator to 'high' once the outer level is itself mixed", () => {
+        // (a+b)*(c+d)+e: the outer level now has two real operators ('*' and '+') at
+        // different precedences, so it's mixed and the tighter one ('*') is pulled to
+        // "high". The inner brackets are completely unaffected either way.
+        expect(calculatePrecedenceTiers(["+"])).toEqual(["medium"] satisfies PrecedenceTier[]); // inside (a+b), unaffected
+        const outerTiers = calculatePrecedenceTiers(["", "*", "+"]);
+        expect(outerTiers[1]).toBe("high"); // outer '*'
+        expect(outerTiers[2]).toBe("medium"); // outer '+'
+        expect(calculatePrecedenceTiers(["+"])).toEqual(["medium"] satisfies PrecedenceTier[]); // inside (c+d), unaffected
+    });
+});
+
+test.describe("calculatePrecedenceTiers: detected unary sign ('-'/'+')", () => {
+    // The isUnarySignAt parameter is how generateFlatSlotBases (storeMethods.ts) tells this
+    // function that a particular "-"/"+" is acting as a unary sign rather than an ordinary
+    // binary operator (it can't be told apart from the code alone, unlike "~"/"not"/"lambda"
+    // -- see UNARY_PREFIX_OPERATORS). Real Python binds unary +/-/~ all at the same, very
+    // tight precedence (between binary */÷///% and **) -- a detected unary sign uses that
+    // same tight value here, not binary +/-'s much looser one.
+
+    test("a solo unary sign gets the neutral 'sign-medium' tier (same rule as any solo operator)", () => {
+        // -x alone: nothing to contrast against, so -- like any solo operator -- it gets the
+        // neutral default rather than the tightest tier. "sign-medium" is that default with
+        // the leading margin suppressed (there's nothing meaningful to a unary sign's left).
+        expect(calculatePrecedenceTiers(["-"], [true])).toEqual(["sign-medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("an ordinary binary '-' is unaffected when not flagged as a unary sign", () => {
+        // x-y: same array as the unary case above, but isUnarySignAt is false here --
+        // ordinary binary "-", neutral "medium" like any other solo binary operator:
+        expect(calculatePrecedenceTiers(["-"], [false])).toEqual(["medium"] satisfies PrecedenceTier[]);
+        // Omitting isUnarySignAt entirely defaults to "nothing is unary", same result:
+        expect(calculatePrecedenceTiers(["-"])).toEqual(["medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("a mixed unary sign binds tight enough to reach 'high', pulling the binary operator around it looser", () => {
+        // -x+y: unary "-" now binds as tightly as "~", tighter than binary "+", so "+"
+        // becomes the pivot and "-" is pulled to "high" (needing no substitute -- "high" is
+        // already zero margin on both sides) while "+" lands on the ordinary "medium":
+        expect(calculatePrecedenceTiers(["-", "+"], [true, false])).toEqual(["high", "medium"] satisfies PrecedenceTier[]);
+        // -x*y: same story against '*', which is tighter than binary +/- but still looser
+        // than a unary sign:
+        expect(calculatePrecedenceTiers(["-", "*"], [true, false])).toEqual(["high", "medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("two adjacent unary operators of tied precedence both get the neutral default", () => {
+        // ~-x: "~" (always unary, precedence 120) and a detected unary "-" (also 120) tie,
+        // so -- same as any equal-precedence chain -- both get the neutral default rather
+        // than being pulled apart. "-" additionally substitutes to "sign-medium":
+        expect(calculatePrecedenceTiers(["~", "-"], [false, true])).toEqual(["medium", "sign-medium"] satisfies PrecedenceTier[]);
+    });
+
+    test("a unary sign binds looser than '**' on its left, matching real Python's -x**y == -(x**y)", () => {
+        // -x**y: "**" (130) is the only thing tighter than a unary sign (120), so "-" is
+        // pulled to "sign-medium" (looser) while "**" stays "high":
+        expect(calculatePrecedenceTiers(["-", "**"], [true, false])).toEqual(["sign-medium", "high"] satisfies PrecedenceTier[]);
+    });
+
+    test("a unary sign among multiple binary operators still resolves per-operator correctly", () => {
+        // -x+y*z: unary "-" (tight) and "*" (tighter than binary +/-) both end up "high",
+        // while the loosest operator present, binary "+", is pulled to "medium":
+        expect(calculatePrecedenceTiers(["-", "+", "*"], [true, false, false])).toEqual(["high", "medium", "high"] satisfies PrecedenceTier[]);
+    });
+});

--- a/tests/playwright/e2e/operator-precedence-spacing.spec.ts
+++ b/tests/playwright/e2e/operator-precedence-spacing.spec.ts
@@ -1,0 +1,430 @@
+import {Page, test, expect} from "@playwright/test";
+import {waitForEditorSettled, typeIndividually, doPagePaste, doTextHomeEndKeyPress, enterCode, pressN} from "../support/editor";
+import {loadContent} from "../support/loading-saving";
+import {setupStrypeTest} from "../support/general";
+
+// Tests for precedence-driven operator spacing (see src/helpers/operatorPrecedence.ts):
+// operators are given a CSS "tier" class (dot/comma/equals/colon/high/medium/low, or
+// keyword-high/keyword-medium/keyword-low for word-shaped operators) based on their
+// relative precedence within one bracketed/top-level expression, plus a separate "unary
+// prefix" marker (not/~/lambda) that suppresses their leading margin.
+//
+// Rather than asserting on final downloaded/exported text (which never contains the tier
+// classes -- those are DOM/CSS only, see the "non-DOM tests pin behavior" note in the
+// project's own conventions), these tests read the live DOM directly: each operator span
+// carries the tier as a CSS class (see LabelSlot.vue's getSpanTypeClass()), which we read
+// back via window.StrypeSCSSVarsGlobals (the same mechanism tests/playwright/support/editor.ts
+// uses for its own DOM assertions).
+//
+// Expected tiers for every static expression case below were verified against the real
+// calculatePrecedenceTiers() function (see tests/unit/operatorPrecedence.test.ts for the
+// same cases as pure-function unit tests) rather than hand-traced, to avoid transcription
+// errors -- this file re-verifies them end to end through the actual DOM instead.
+
+interface OpTierInfo {
+    code: string;
+    tier: string;
+    isUnaryPrefix: boolean;
+}
+
+function op(code: string, tier: string, isUnaryPrefix = false): OpTierInfo {
+    return {code, tier, isUnaryPrefix};
+}
+
+// Reads every rendered operator span within the given frame's header (in the main code
+// section) and returns its code, precedence tier, and whether it carries the unary-prefix
+// "no leading margin" marker. DOM order matches visual/left-to-right order.
+async function getOperatorTierInfo(page: Page, frameIndex = 0): Promise<OpTierInfo[]> {
+    const scssVars: Record<string, string> = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
+    const tierClassToName: Record<string, string> = {
+        [scssVars.opTierDotClassName]: "dot",
+        [scssVars.opTierCommaClassName]: "comma",
+        [scssVars.opTierEqualsClassName]: "equals",
+        [scssVars.opTierColonClassName]: "colon",
+        [scssVars.opTierKeywordHighClassName]: "keyword-high",
+        [scssVars.opTierKeywordMediumClassName]: "keyword-medium",
+        [scssVars.opTierKeywordLowClassName]: "keyword-low",
+        [scssVars.opTierHighClassName]: "high",
+        [scssVars.opTierMediumClassName]: "medium",
+        [scssVars.opTierLowClassName]: "low",
+    };
+    const header = page.locator("#frameContainer_-3 ." + scssVars.frameHeaderClassName).nth(frameIndex);
+    return header.locator("." + scssVars.frameOperatorSlotClassName).evaluateAll((spans, data) => {
+        return spans.map((el) => {
+            const classes = Array.from(el.classList);
+            const tierClassName = classes.find((c) => c in data.tierClassToName);
+            return {
+                code: (el.textContent ?? "").replace(/​/g, ""),
+                tier: tierClassName ? data.tierClassToName[tierClassName] : "<none>",
+                isUnaryPrefix: classes.includes(data.unaryPrefixClassName),
+            };
+        });
+    }, {tierClassToName, unaryPrefixClassName: scssVars.opUnaryPrefixClassName});
+}
+
+// A minimal, self-contained .spy project file (see tests/cypress/fixtures/*.spy for the
+// established format) with a single statement in the Main section.
+function spyWithMainLine(line: string): string {
+    return `#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+#(=> Section:Main
+${line}
+#(=> Section:End
+`;
+}
+
+async function startVarAssign(page: Page, rhs: string): Promise<void> {
+    // The leading space is required: on the fresh default project, the frame cursor is
+    // active (not a text cursor), and a bare letter like "r" gets consumed as a frame-creation
+    // shortcut key (e.g. "r" for a return frame) instead of being typed as literal text. A
+    // leading space is itself the shortcut for a blank function-call frame, which is what
+    // gives us an actual text cursor to type "r=<rhs>" into -- exactly the pattern used
+    // throughout structured-expressions.spec.ts (e.g. its "Have \"a=\"" test types " a=").
+    await typeIndividually(page, ` r=${rhs}`);
+}
+
+async function selectAllInSlot(page: Page): Promise<void> {
+    await doTextHomeEndKeyPress(page, false, false); // Home
+    await doTextHomeEndKeyPress(page, true, true); // Shift+End, extends the selection across the whole slot
+}
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    await setupStrypeTest(page, browserName, testInfo, {skipPyodide: true, timeoutMs: 60000});
+});
+
+// Reused by both "loading a file" and "pasting at the frame cursor" below, so both entry
+// points are proven to reach the exact same tiering result via two different code paths
+// (native .spy deserialisation vs. the paste-import AST walker in pythonToFrames.ts).
+const EXPRESSION_CASES: [string, string, OpTierInfo[]][] = [
+    ["a+b+c (homogeneous chain -> neutral medium)", "a+b+c", [op("+", "medium"), op("+", "medium")]],
+    ["a<b<c (chained comparison -> neutral medium)", "a<b<c", [op("<", "medium"), op("<", "medium")]],
+    ["a+b*c (mixed: '*' pulled tight)", "a+b*c", [op("+", "medium"), op("*", "high")]],
+    ["a+b+c or d (mixed by 'or': '+' pulled tight)", "a+b+c or d", [op("+", "high"), op("+", "high"), op("or", "keyword-medium")]],
+    ["a**b**c (homogeneous ** chain)", "a**b**c", [op("**", "medium"), op("**", "medium")]],
+    ["a and b or c (two distinct keyword tiers)", "a and b or c", [op("and", "keyword-high"), op("or", "keyword-medium")]],
+    ["a|b^c&d (three distinct bitwise tiers)", "a|b^c&d", [op("|", "low"), op("^", "medium"), op("&", "high")]],
+    ["a not in b and c or d (three distinct keyword tiers)", "a not in b and c or d", [op("not in", "keyword-high"), op("and", "keyword-medium"), op("or", "keyword-low")]],
+    ["a in nums and b not in nums (mixed keyword precedences)", "a in nums and b not in nums", [op("in", "keyword-high"), op("and", "keyword-medium"), op("not in", "keyword-high")]],
+    ["not a (unary keyword, no leading margin)", "not a", [op("not", "keyword-medium", true)]],
+    ["~a (unary symbol, no leading margin)", "~a", [op("~", "medium", true)]],
+    ["a,b,c (tuple, comma tier)", "a,b,c", [op(",", "comma"), op(",", "comma")]],
+    ["f(a,b=c+d) (comma + kwarg '=' + mixed '+')", "f(a,b=c+d)", [op(",", "comma"), op("=", "equals"), op("+", "medium")]],
+    ["a if b>c else d (ternary)", "a if b>c else d", [op("if", "keyword-medium"), op(">", "medium"), op("else", "keyword-medium")]],
+    ["[x for x in nums if x>2] (comprehension)", "[x for x in nums if x>2]", [op("for", "keyword-medium"), op("in", "keyword-medium"), op("if", "keyword-medium"), op(">", "medium")]],
+    // The '-' here sits right after the colon with nothing before it, so it's a detected
+    // unary sign (see storeMethods.ts's isUnarySignAt) -- same "medium"-equivalent tier as
+    // an ordinary solo binary '-' would get, but with the leading margin suppressed:
+    ["lambda n: -n (pass-through lambda, unary '-' after colon)", "lambda n: -n", [op("lambda", "keyword-medium", true), op(":", "colon"), op("-", "medium", true)]],
+    ["-a (detected unary minus, no leading margin)", "-a", [op("-", "medium", true)]],
+    // Once '-' is pulled to 'high' by mixing with a tighter/looser sibling, "high" already
+    // has zero margin on both sides -- no separate unary-prefix marker is needed or applied
+    // (see LabelSlot.vue: the marker is only set when the tier is exactly "sign-medium"):
+    ["-a+b (unary '-' binds tighter than binary '+', pulled to 'high')", "-a+b", [op("-", "high"), op("+", "medium")]],
+    ["-a*b (unary '-' still tighter than '*', pulled to 'high')", "-a*b", [op("-", "high"), op("*", "medium")]],
+    ["-a**b (unary '-' looser than '**', matches Python's -a**b == -(a**b))", "-a**b", [op("-", "medium", true), op("**", "high")]],
+    ["+a-b*c (unary '+' tight -> 'high' with no marker needed; binary '-' unaffected)", "+a-b*c", [op("+", "high"), op("-", "medium"), op("*", "high")]],
+    ["a+b*c**d (all three real tiers at once)", "a+b*c**d", [op("+", "low"), op("*", "medium"), op("**", "high")]],
+];
+
+test.describe("Loading a file", () => {
+    for (const [label, expr, expected] of EXPRESSION_CASES) {
+        test(`Loaded file tiers operators correctly: ${label}`, async ({page}) => {
+            await loadContent(page, spyWithMainLine(`r = ${expr}`));
+            await waitForEditorSettled(page);
+            expect(await getOperatorTierInfo(page)).toEqual(expected);
+        });
+    }
+});
+
+test.describe("Pasting content at the frame cursor", () => {
+    for (const [label, expr, expected] of EXPRESSION_CASES) {
+        test(`Pasted content tiers operators correctly: ${label}`, async ({page}) => {
+            await enterCode(page, ["", "", `r = ${expr}`]);
+            await waitForEditorSettled(page);
+            expect(await getOperatorTierInfo(page)).toEqual(expected);
+        });
+    }
+});
+
+test.describe("Editing an expression changes tiers dynamically", () => {
+    test("a+b+c tightens once '*d' is appended, and reverts on backspace", async ({page}) => {
+        await startVarAssign(page, "a+b+c");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("+", "medium")]);
+
+        await typeIndividually(page, "*d");
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("+", "medium"), op("*", "high")]);
+
+        await page.keyboard.press("Backspace");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("Backspace");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("+", "medium")]);
+    });
+
+    test("a+b+c keeps the same tiers when wrapped in brackets, and reverts when unwrapped", async ({page}) => {
+        await startVarAssign(page, "a+b+c");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("+", "medium")]);
+
+        await selectAllInSlot(page);
+        await doPagePaste(page, "(a+b+c)");
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("+", "medium")]);
+
+        await selectAllInSlot(page);
+        await doPagePaste(page, "a+b+c");
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("+", "medium")]);
+    });
+
+    test("a+b+c loosens all the way to 'high' when ' or d' is appended, and reverts on backspace", async ({page}) => {
+        await startVarAssign(page, "a+b+c");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("+", "medium")]);
+
+        await typeIndividually(page, " or d");
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "high"), op("+", "high"), op("or", "keyword-medium")]);
+
+        // Operators are stored without their literal surrounding spaces, so the number of
+        // backspaces needed to undo typing a keyword operator doesn't equal the typed
+        // character count -- select-and-replace instead of guessing a backspace count:
+        await selectAllInSlot(page);
+        await doPagePaste(page, "a+b+c");
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("+", "medium")]);
+    });
+
+    test("a*b tightens to 'high' once '+c' is appended, and reverts on backspace", async ({page}) => {
+        await startVarAssign(page, "a*b");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("*", "medium")]);
+
+        await typeIndividually(page, "+c");
+        expect(await getOperatorTierInfo(page)).toEqual([op("*", "high"), op("+", "medium")]);
+
+        await pressN("Backspace", 2, true)(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("*", "medium")]);
+    });
+
+    test("(a+b)*(c+d): outer '*' is 'medium' alone, pulled to 'high' once '+e' mixes the outer level", async ({page}) => {
+        await startVarAssign(page, "(a+b)*(c+d)");
+        await waitForEditorSettled(page);
+        // DOM order: inner-left '+', outer '*', inner-right '+'. The outer level has only
+        // one real operator ('*'), so it's neutral/solo -- "medium", same as the inner chains:
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("*", "medium"), op("+", "medium")]);
+
+        await typeIndividually(page, "+e");
+        // Now the outer level has two real operators ('*' and '+') at different precedences,
+        // so it's genuinely mixed: '*' is pulled tight to "high", the new '+' lands at "medium".
+        // The inner brackets are completely unaffected either way (per-level scoping):
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("*", "high"), op("+", "medium"), op("+", "medium")]);
+
+        // And removing the "+e" suffix again reverts the outer level back to solo/neutral:
+        await pressN("Backspace", 2, true)(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("*", "medium"), op("+", "medium")]);
+    });
+
+    test("a+b*c keeps its mixed tiers when wrapped in brackets, and reverts when unwrapped", async ({page}) => {
+        await startVarAssign(page, "a+b*c");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("*", "high")]);
+
+        await selectAllInSlot(page);
+        await doPagePaste(page, "(a+b*c)");
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("*", "high")]);
+
+        await selectAllInSlot(page);
+        await doPagePaste(page, "a+b*c");
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("*", "high")]);
+    });
+
+    test("typing a|b^c&d incrementally settles on three distinct tiers", async ({page}) => {
+        await startVarAssign(page, "a|b^c&d");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("|", "low"), op("^", "medium"), op("&", "high")]);
+    });
+
+    test("typing a+b*c**d incrementally settles on all three real tiers", async ({page}) => {
+        await startVarAssign(page, "a+b*c**d");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "low"), op("*", "medium"), op("**", "high")]);
+    });
+
+    test("typing 'not a' gives 'not' the neutral keyword tier with no leading margin", async ({page}) => {
+        await startVarAssign(page, "not a");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("not", "keyword-medium", true)]);
+    });
+
+    test("typing '~a' gives '~' the neutral tier with no leading margin", async ({page}) => {
+        await startVarAssign(page, "~a");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("~", "medium", true)]);
+    });
+
+    test("typing 'lambda n: -n' gives 'lambda' the neutral keyword tier with no leading margin", async ({page}) => {
+        await startVarAssign(page, "lambda n:-n");
+        await waitForEditorSettled(page);
+        // The '-' immediately after the colon has a blank field before it, so it's a
+        // detected unary sign too -- same "medium"-equivalent tier, also no leading margin:
+        expect(await getOperatorTierInfo(page)).toEqual([op("lambda", "keyword-medium", true), op(":", "colon"), op("-", "medium", true)]);
+    });
+
+    test("a long homogeneous chain stays 'medium' throughout as it's typed and then shrunk by backspacing", async ({page}) => {
+        await startVarAssign(page, "a+b+c+d+e");
+        await waitForEditorSettled(page);
+        let tiers = await getOperatorTierInfo(page);
+        expect(tiers.length).toBe(4);
+        expect(tiers.every((t) => t.tier === "medium")).toBe(true);
+
+        // Backspace off "+d+e" (4 characters), leaving "a+b+c":
+        await pressN("Backspace", 4, true)(page);
+        tiers = await getOperatorTierInfo(page);
+        expect(tiers).toEqual([op("+", "medium"), op("+", "medium")]);
+
+        // Backspace off "+c", leaving a single solo operator "a+b":
+        await pressN("Backspace", 2, true)(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium")]);
+    });
+
+    test("a comma-separated list stays on the 'comma' tier throughout as it grows and shrinks", async ({page}) => {
+        await startVarAssign(page, "a,b,c");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op(",", "comma"), op(",", "comma")]);
+
+        await pressN("Backspace", 2, true)(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op(",", "comma")]);
+
+        await typeIndividually(page, ",c,d");
+        expect(await getOperatorTierInfo(page)).toEqual([op(",", "comma"), op(",", "comma"), op(",", "comma")]);
+    });
+
+    test("'and'/'or' get distinct keyword tiers when mixed, and revert to the neutral one when not", async ({page}) => {
+        await startVarAssign(page, "a and b or c");
+        await waitForEditorSettled(page);
+        // Two distinct keyword precedences present ("and" tighter than "or"), so they
+        // land on two different keyword tiers rather than a single flat one:
+        expect(await getOperatorTierInfo(page)).toEqual([op("and", "keyword-high"), op("or", "keyword-medium")]);
+
+        // Remove " or c", leaving a single "and": operators are stored without their literal
+        // surrounding spaces, so select-and-replace rather than guess a backspace count:
+        await selectAllInSlot(page);
+        await doPagePaste(page, "a and b");
+        // Solo again, so back to the neutral keyword default:
+        expect(await getOperatorTierInfo(page)).toEqual([op("and", "keyword-medium")]);
+
+        // Re-extend with a comparison instead of "or": now mixed with "and", so the
+        // tighter-binding "==" is pulled to the tightest symbol tier ("high"), while "and"
+        // -- now the sole (loosest) keyword present -- keeps its neutral "keyword-medium":
+        await typeIndividually(page, "==c");
+        expect(await getOperatorTierInfo(page)).toEqual([op("and", "keyword-medium"), op("==", "high")]);
+    });
+
+    test("typing 'a not in b and c or d' spreads three keyword operators across all three keyword tiers", async ({page}) => {
+        await startVarAssign(page, "a not in b");
+        await waitForEditorSettled(page);
+        // Solo, so the neutral default:
+        expect(await getOperatorTierInfo(page)).toEqual([op("not in", "keyword-medium")]);
+
+        await typeIndividually(page, " and c");
+        // Two distinct precedences now ("not in" tighter than "and"):
+        expect(await getOperatorTierInfo(page)).toEqual([op("not in", "keyword-high"), op("and", "keyword-medium")]);
+
+        await typeIndividually(page, " or d");
+        // Three distinct precedences: tightest-to-loosest across all three keyword tiers:
+        expect(await getOperatorTierInfo(page)).toEqual([op("not in", "keyword-high"), op("and", "keyword-medium"), op("or", "keyword-low")]);
+    });
+
+    test("building a ternary incrementally: 'if' appears first, then 'else' once typed", async ({page}) => {
+        await startVarAssign(page, "a if b");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("if", "keyword-medium")]);
+
+        await typeIndividually(page, " else c");
+        expect(await getOperatorTierInfo(page)).toEqual([op("if", "keyword-medium"), op("else", "keyword-medium")]);
+    });
+
+    test("editing back and forth between mixed and unmixed keeps the tiers self-consistent", async ({page}) => {
+        // A general "check everything works" sweep: build a nested, mixed expression, tear
+        // most of it down, then build something different in its place, checking the tiers
+        // are correct (and the editor never ends up in a broken/inconsistent state) at each step.
+        await startVarAssign(page, "(a+b*c)-(d/e)");
+        await waitForEditorSettled(page);
+        // Outer level: '-' alone (solo, medium); inner brackets: '+','*' mixed (medium/high) and '/' alone (medium):
+        expect(await getOperatorTierInfo(page)).toEqual([
+            op("+", "medium"), op("*", "high"), // inside (a+b*c)
+            op("-", "medium"), // outer, solo
+            op("/", "medium"), // inside (d/e)
+        ]);
+
+        // Delete back to just "(a+b*c)": select-and-replace rather than guess a backspace
+        // count near a bracket boundary:
+        await selectAllInSlot(page);
+        await doPagePaste(page, "(a+b*c)");
+        expect(await getOperatorTierInfo(page)).toEqual([op("+", "medium"), op("*", "high")]);
+
+        // Now build something different in its place:
+        await typeIndividually(page, "**(f&g)");
+        expect(await getOperatorTierInfo(page)).toEqual([
+            op("+", "medium"), op("*", "high"), // unchanged, inside (a+b*c)
+            op("**", "medium"), // outer, solo
+            op("&", "medium"), // inside (f&g)
+        ]);
+    });
+
+    test("typing '-a' gives a detected unary minus a suppressed leading margin, and this updates as it's mixed with other operators", async ({page}) => {
+        await startVarAssign(page, "-a");
+        await waitForEditorSettled(page);
+        // Solo unary sign: neutral "medium"-equivalent tier, marker set (no leading margin):
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);
+
+        await typeIndividually(page, "+b");
+        // '-' still binds tighter than binary '+' so it's pulled to "high" -- already zero
+        // margin both sides, so the marker is dropped (nothing left to suppress):
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "high"), op("+", "medium")]);
+
+        await pressN("Backspace", 2, true)(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);
+    });
+
+    test("the same '-' token is retiered live depending on whether it sits in a unary or binary position", async ({page}) => {
+        await startVarAssign(page, "a-b");
+        await waitForEditorSettled(page);
+        // Ordinary binary '-', preceded by a non-blank field ("a") -- neutral tier, no marker:
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium")]);
+
+        // Replace with a '-' that now has a blank field before it -- same code, same
+        // resulting CSS class ("medium"), but now flagged as a detected unary sign:
+        await selectAllInSlot(page);
+        await doPagePaste(page, "-a");
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);
+
+        await selectAllInSlot(page);
+        await doPagePaste(page, "a-b");
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium")]);
+    });
+
+    test("'-a' keeps its unary tier when wrapped in brackets, and reverts when unwrapped", async ({page}) => {
+        await startVarAssign(page, "-a");
+        await waitForEditorSettled(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);
+
+        await selectAllInSlot(page);
+        await doPagePaste(page, "(-a)");
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);
+
+        await selectAllInSlot(page);
+        await doPagePaste(page, "-a");
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);
+    });
+
+    test("typing '-a**b' shows a detected unary minus losing out to the tighter-binding '**', matching Python's -a**b == -(a**b)", async ({page}) => {
+        await startVarAssign(page, "-a**b");
+        await waitForEditorSettled(page);
+        // '**' is the only thing tighter than a unary sign, so '-' is pulled looser to
+        // "medium" (still with its marker) while '**' takes "high":
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true), op("**", "high")]);
+
+        await pressN("Backspace", 3, true)(page);
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);
+    });
+});


### PR DESCRIPTION
I was looking to fix the bug we discussed last meeting where spacing around the keywords operators was too tight.  But then I thought while I was fixing that I'd get the AI to implement Stride's dynamic operator spacing, where it picks the spacing based on the expression dynamically.  So for example 1+2 gets default spacing, then 1+2*3 has tighter spacing around the multiply than the addition, and if you have a third tier (** does it I think) then it changes again.  With the largest range of operators the symbol-operator spacing comes down to zero, but that doesn't suit keyword operators (and in general, keyword operators want a bit more spacing around them) so keyword operators have their own tier.  There's also a separate part of the system for unary operators (not, ~, +, -) which should not have left-hand spacing.

As part of this, also discovered that unary ~ and "lambda" keyword could not be pasted into Strype, so fixed that.  If you want to see what it looks like, spin up a dev server from this branch and try loading the file tests/manual/operator-spacing-demo.py which has a variety of operator expressions for you to be able to see what it's like.  The spacing should change as you add/delete operators if they are different precedences.  I wonder if the keywords have slightly too much space (especially when next to a blank slot which matters for us internally but isn't obvious to the user (e.g. in "(a) and (b)" there's a blank slot either side of the "and")  but if we're happy with the principle of the system we can tweak exact spacing later on.

Sorry for another PR; I think this is the downside of AI, more PRs to review...  But it's not really as big as it looks on the main code side, because a lot of the change is a big new test file.