### PR TITLE
Fix a few paste bugs

### DIFF
--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -279,11 +279,23 @@ function findStringEnd(line : string, startIndex : number, quoteType : string) :
 // and a list of transformed lines.  Comments are transformed to identifiers, as are blanks, so that
 // we can see them after Skulpt's parse.
 // Note the disabledLines are one-based, not zero-based
-function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") : {disabledLines : number[], frameStateLines : Map<number, SavedFrameState>, transformedLines : string[], strypeDirectives: Map<string, string>} { 
+// transformedLineOrigin[i] gives the (one-based) index into codeLines that transformedLines[i] came
+// from. A single codeLine can produce zero lines (lines fully inside a multi-line triple-quoted
+// string, which are collapsed onto the line where the string closes), one line, or two lines (code
+// with a trailing comment, which is moved onto its own line) -- so transformedLines.length does not
+// generally equal codeLines.length, and callers that need to map a Skulpt-reported line number back
+// to the original source must go through this array rather than assuming a 1:1 correspondence.
+function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") : {disabledLines : number[], frameStateLines : Map<number, SavedFrameState>, transformedLines : string[], transformedLineOrigin : number[], strypeDirectives: Map<string, string>} {
     codeLines = [...codeLines];
     const disabledLines : number[] = [];
     const frameStateLines : Map<number, SavedFrameState> = new Map<number, SavedFrameState>();
     const transformedLines : string[] = [];
+    // Parallel to transformedLines; see doc comment above.
+    const transformedLineOrigin : number[] = [];
+    const pushTransformedLine = (i : number, line : string) : void => {
+        transformedLines.push(line);
+        transformedLineOrigin.push(i + 1);
+    };
     const strypeDirectives: Map<string, string> = new Map<string, string>();
 
     // A reference to the lines containing a comment block (that is, consecutive comment lines), see inline-method below for details.
@@ -357,7 +369,7 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
                 if (key == "LibraryDisabled") {
                     disabledLines.push(transformedLines.length + 1);
                 }
-                transformedLines.push(directiveIndent + STRYPE_LIBRARY_PREFIX + toUnicodeEscapes(value));
+                pushTransformedLine(i, directiveIndent + STRYPE_LIBRARY_PREFIX + toUnicodeEscapes(value));
                 // We know this is only whitespace because directiveMatch also matched:
                 mostRecentIndent = directiveIndent;
             }
@@ -373,7 +385,7 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
                     }
                 }
                 // Push a blank to make line numbers match:
-                transformedLines.push("");
+                pushTransformedLine(i, "");
                 // +1 to mean the line after us:
                 frameStateLines.set(transformedLines.length + 1, composite);
             }
@@ -381,7 +393,7 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
                 // Not one we have to deal with during parsing, probably a config setting, so record for later processing:
                 strypeDirectives.set(key, value);
                 // Push a blank to make line numbers match:
-                transformedLines.push("");
+                pushTransformedLine(i, "");
                 mostRecentIndent = "";
             }
         }
@@ -432,10 +444,10 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
                 smallestAdjIndent = mostRecentIndent.length <= nextIndent.length ? mostRecentIndent : nextIndent;
             }
             if (codeLines[i].length > smallestAdjIndent.length) {
-                transformedLines.push(codeLines[i] + STRYPE_WHOLE_LINE_BLANK);
+                pushTransformedLine(i, codeLines[i] + STRYPE_WHOLE_LINE_BLANK);
             }
             else {
-                transformedLines.push(smallestAdjIndent + STRYPE_WHOLE_LINE_BLANK);
+                pushTransformedLine(i, smallestAdjIndent + STRYPE_WHOLE_LINE_BLANK);
             }
             checkRearrangeCommentsIdent();
         }
@@ -499,16 +511,18 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
                         const after = line.slice(charIndex+1);
                         if (before.trim() == "") {
                             // Just a single line comment by itself:
-                            transformedLines.push(before + STRYPE_COMMENT_PREFIX + toUnicodeEscapes(after));
+                            pushTransformedLine(i, before + STRYPE_COMMENT_PREFIX + toUnicodeEscapes(after));
                             mostRecentIndent = before;
                             aCommentBlockLines.push(transformedLines.length-1);
                         }
                         else {
-                            // Code followed by comment, put comment on next line:
+                            // Code followed by comment, put comment on next line.  Both lines originate
+                            // from this same source line i, so both get the same origin entry -- this is
+                            // deliberately not a 1:1 push, see transformedLineOrigin's doc comment above:
                             mostRecentIndent = getIndent(before);
-                            transformedLines.push(before);
+                            pushTransformedLine(i, before);
                             checkRearrangeCommentsIdent();
-                            transformedLines.push(mostRecentIndent + STRYPE_COMMENT_PREFIX + toUnicodeEscapes(after));
+                            pushTransformedLine(i, mostRecentIndent + STRYPE_COMMENT_PREFIX + toUnicodeEscapes(after));
                         }
                         // Make sure we don't push the line again:
                         charIndex = -1;
@@ -522,7 +536,7 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
             }
             if (charIndex >= 0 && currentTripleQuoteString == null) {
                 // Got to the end without finding a comment, and we're not in a string (processed specially) so preserve it in full:
-                transformedLines.push(line);
+                pushTransformedLine(i, line);
                 mostRecentIndent = getIndent(line.trimEnd());
                 checkRearrangeCommentsIdent();
             }
@@ -535,7 +549,7 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
     // We might have comments at the end of the code, so we need to check their indentation:
     checkRearrangeCommentsIdent();
 
-    return { disabledLines, frameStateLines: frameStateLines, transformedLines, strypeDirectives };
+    return { disabledLines, frameStateLines: frameStateLines, transformedLines, transformedLineOrigin, strypeDirectives };
 }
 
 // Information about a set of "copied" frames.  This is the result of parsing
@@ -588,7 +602,6 @@ export function offsetAllIds(frames: CopiedFrames, offset: number) : CopiedFrame
 // has pasted in, return the string after turning it into frames.
 // If unsuccessful, throws CopyFailure with a string with some info about where the Python parse failed.
 function copyFramesFromParsedPython(codeLines: string[], currentStrypeLocation: STRYPE_LOCATION, format: "py" | "spy", linenoMapping?: Record<number, number>) : CopiedFrames {
-    const mapLineno = (lineno : number) : number => linenoMapping ? linenoMapping[lineno] : lineno;
     const indents = new Map<number, string>();
     
     // Then find the common amount of indentation on non-blank lines and remove it:
@@ -621,6 +634,13 @@ function copyFramesFromParsedPython(codeLines: string[], currentStrypeLocation: 
     }
 
     const transformed = transformCommentsAndBlanks(codeLines, format);
+    // A Skulpt-reported line number is an index into transformed.transformedLines, which doesn't
+    // correspond 1:1 with codeLines (see transformedLineOrigin's doc comment), so we must go via
+    // transformedLineOrigin to get back to a codeLines line number before applying linenoMapping:
+    const mapLineno = (lineno : number) : number => {
+        const originalLineno = transformed.transformedLineOrigin[lineno - 1] ?? lineno;
+        return linenoMapping ? linenoMapping[originalLineno] : originalLineno;
+    };
     const parsedBySkulpt = parseWithSkulpt(transformed.transformedLines, mapLineno);
     if (typeof parsedBySkulpt === "string") {
         throw new CopyFailure(parsedBySkulpt);

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -648,6 +648,16 @@ function concatSlots(lhs: SlotsStructure, operator: string, rhs: SlotsStructure)
     return joined;
 }
 
+// Whether a parsed expression is "simple" enough that re-using it as an operand
+// (as we do when expanding an augmented assignment like "a += b" into "a = a + b")
+// doesn't need extra brackets to stay unambiguous: a single token, a single function
+// call, or a single member/method-call chain. All of those only ever join sub-parts
+// with a blank ("") or a "." operator; anything else (a real binary/unary operator)
+// means brackets are needed to preserve the original semantics.
+function isSimpleAugAssignOperand(slots: SlotsStructure) : boolean {
+    return slots.operators.every((op) => op.code === "" || op.code === ".");
+}
+
 // Dig down the tree and find the actual value.  Skips down through
 // all parents with a single child.  If there is no value or no children,
 // an error will be thrown.  This shouldn't happen for the items we are
@@ -1047,11 +1057,27 @@ function copyFramesFromPython(p: ParsedConcreteTree, s : CopyState) : CopyState 
     case Sk.ParseTables.sym.expr_stmt:
         if (p.children) {
             const index = p.children.findIndex((x) => x.value === "=");
+            const augIndex = p.children.findIndex((x) => x.type === Sk.ParseTables.sym.augassign);
             if (index >= 0) {
                 checkValidMatchContent(s.parent?.frameType.type, p.lineno);
                 // An assignment
                 const lhs = toSlots({...p, children: p.children.slice(0, index)});
                 const rhs = toSlots({...p, children: p.children.slice(index + 1)});
+                s = addFrame(makeFrame(AllFrameTypesIdentifier.varassign, {0: {slotStructures: lhs}, 1: {slotStructures: rhs}}, s.isSPY), p.lineno, s);
+            }
+            else if (augIndex >= 0) {
+                checkValidMatchContent(s.parent?.frameType.type, p.lineno);
+                // Strype has no dedicated frame for augmented assignment (e.g. "a += b"), so we
+                // expand it into the equivalent "a = a + b" instead. This isn't behaviour-compliant
+                // for targets with side effects (e.g. "a().x += b" would evaluate "a()" twice) but
+                // that's an accepted, unlikely-to-occur limitation.
+                const lhs = toSlots({...p, children: p.children.slice(0, augIndex)});
+                const rhsOperand = toSlots({...p, children: p.children.slice(augIndex + 1)});
+                // Strip the trailing "=" from e.g. "+=" to get the underlying operator "+":
+                const op = digValue(p.children[augIndex]).slice(0, -1);
+                const bracketedRhsOperand = isSimpleAugAssignOperand(rhsOperand) ? rhsOperand :
+                    {fields: [{code: ""}, {...rhsOperand, openingBracketValue: "("}, {code: ""}], operators: [{code: ""}, {code: ""}]};
+                const rhs = concatSlots(cloneDeep(lhs), op, bracketedRhsOperand);
                 s = addFrame(makeFrame(AllFrameTypesIdentifier.varassign, {0: {slotStructures: lhs}, 1: {slotStructures: rhs}}, s.isSPY), p.lineno, s);
             }
             else {

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -403,8 +403,34 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
                     break;
                 }
             }
-            const smallestAdjIndent = nextIsJointContinuation ? mostRecentIndent
-                : (mostRecentIndent.length <= nextIndent.length ? mostRecentIndent : nextIndent);
+            let smallestAdjIndent : string;
+            if (nextIsJointContinuation && mostRecentIndent.length > nextIndent.length) {
+                // Dedenting all the way to the elif/else/except/finally's own indent would insert a
+                // statement between the two parts of that compound statement, which Python doesn't
+                // allow. But the blank may be nested several levels deeper than the joint continuation
+                // (e.g. inside an if-chain that's itself inside the body the elif/else is continuing),
+                // in which case only the immediate nesting matters -- so find the shallowest indent
+                // among the lines back to (but excluding) the joint continuation's own level, which is
+                // the indentation of the body that directly and immediately precedes it, and hence where
+                // the blank line actually belongs:
+                let directChildIndent : string | null = null;
+                for (let k = i - 1; k >= 0; k--) {
+                    if (codeLines[k].trim() === "") {
+                        continue;
+                    }
+                    const ind = getIndent(codeLines[k]);
+                    if (ind.length <= nextIndent.length) {
+                        break;
+                    }
+                    if (directChildIndent === null || ind.length < directChildIndent.length) {
+                        directChildIndent = ind;
+                    }
+                }
+                smallestAdjIndent = directChildIndent ?? mostRecentIndent;
+            }
+            else {
+                smallestAdjIndent = mostRecentIndent.length <= nextIndent.length ? mostRecentIndent : nextIndent;
+            }
             if (codeLines[i].length > smallestAdjIndent.length) {
                 transformedLines.push(codeLines[i] + STRYPE_WHOLE_LINE_BLANK);
             }

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -1720,12 +1720,20 @@ export function pasteMixedPython(completeSource: string, at: CurrentFrame, clear
     }
     
     let posAfter = at;
-    
+    // Set to true if the main-code paste was rejected by insertFramesAtPosition (e.g. pasting a
+    // joint frame like "else" at a position where it wouldn't form legal code).  Only mainFrames
+    // can trigger this: imports/classDefs/funcDefs are never joint frames themselves, and a joint
+    // frame pasted without its parent if/try can only ever land in mainFrames (see
+    // splitLinesToSections), so insertFramesAtPosition's non-joint branch -- which never rejects --
+    // is the only one those three other groups can hit. In that case the frames were never
+    // actually added to the store, so we must not treat them as pasted below.
+    let pasteRejected = false;
+
     // The rule for cursor positions for pasting in other sections is the point closest to the frame cursor;
     // see individual comments below
-    
+
     if (importFrames.frameIds.length > 0) {
-        const currentCaretContainerPosition = (curLocation == STRYPE_LOCATION.IMPORTS_SECTION) 
+        const currentCaretContainerPosition = (curLocation == STRYPE_LOCATION.IMPORTS_SECTION)
             ? {...at}
             // If we're not in the imports, we know we're below it:
             : getLastCaretPosInsideParent(useStore().getImportsFrameContainerId);
@@ -1756,7 +1764,7 @@ export function pasteMixedPython(completeSource: string, at: CurrentFrame, clear
             // Adjust in case we also paste more in the defs:
             at = adjusted ?? at;
         }
-        
+
     }
     if (funcDefFrames.frameIds.length > 0) {
         let currentCaretContainerPosition: { id: number; caretPosition: CaretPosition };
@@ -1795,14 +1803,22 @@ export function pasteMixedPython(completeSource: string, at: CurrentFrame, clear
     }
     if (mainFrames.frameIds.length > 0) {
         // If we're not in the main section, closest cursor will be the top:
-        const currentCaretContainerPosition = (curLocation == STRYPE_LOCATION.IN_FUNCDEF || curLocation == STRYPE_LOCATION.MAIN_CODE_SECTION) 
-            ? {...at} 
+        const currentCaretContainerPosition = (curLocation == STRYPE_LOCATION.IN_FUNCDEF || curLocation == STRYPE_LOCATION.MAIN_CODE_SECTION)
+            ? {...at}
             : {id : useStore().getMainCodeFrameContainerId, caretPosition: CaretPosition.body};
         offsetAllIds(mainFrames, useStore().nextAvailableId);
         const adjusted = useStore().insertFramesAtPosition({target: currentCaretContainerPosition, sourceFrames: mainFrames, ignoreStateBackup});
-        if (curLocation == STRYPE_LOCATION.IN_FUNCDEF || curLocation == STRYPE_LOCATION.MAIN_CODE_SECTION) {
-            posAfter = adjusted ?? posAfter;
+        if (adjusted == null) {
+            pasteRejected = true;
+            // Nothing was actually inserted, so make sure it's not treated as pasted below:
+            mainFrames.frames = {};
         }
+        else if (curLocation == STRYPE_LOCATION.IN_FUNCDEF || curLocation == STRYPE_LOCATION.MAIN_CODE_SECTION) {
+            posAfter = adjusted;
+        }
+    }
+    if (pasteRejected) {
+        useStore().showMessage(MessageDefinitions.ForbiddenFramePaste, 10000);
     }
     if (!dontSetCaretAfter) {
         useStore().setCurrentFrame(posAfter, true);

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -390,13 +390,21 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
             // We indent this to the largest of its indent,
             // and the (smallest of the indent before us and the indent after us).
             let nextIndent = "";
+            let nextIsJointContinuation = false;
             for (let j = i + 1; j < codeLines.length; j++) {
                 if (codeLines[j].trim() != "") {
                     nextIndent = getIndent(codeLines[j]);
+                    // If the next line is elif/else/except/finally, it's a continuation of the
+                    // compound statement the blank line is inside, not a new statement at its own
+                    // (shallower) indent.  Dedenting the blank line to match it would insert a
+                    // statement between the two parts of the compound statement, which Python
+                    // doesn't allow, so we must keep the blank line at the deeper indent instead:
+                    nextIsJointContinuation = /^\s*(elif|else|except|finally)\b/.test(codeLines[j]);
                     break;
                 }
             }
-            const smallestAdjIndent = mostRecentIndent.length <= nextIndent.length ? mostRecentIndent : nextIndent;
+            const smallestAdjIndent = nextIsJointContinuation ? mostRecentIndent
+                : (mostRecentIndent.length <= nextIndent.length ? mostRecentIndent : nextIndent);
             if (codeLines[i].length > smallestAdjIndent.length) {
                 transformedLines.push(codeLines[i] + STRYPE_WHOLE_LINE_BLANK);
             }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2656,19 +2656,33 @@ export const useStore = defineStore("app", {
             const areFramesJoint = payload.sourceFrames.frames[payload.sourceFrames.frameIds[0]].frameType.isJointFrame;
             if (areFramesJoint) {
                 // Joint frames.  We can only paste if we're inside the body of the joint parent
-                // or one of its joint frames, at the last position of the body:
-                let parentId: number;
-                if (payload.target.caretPosition == CaretPosition.body) {
-                    parentId = payload.target.id;
+                // or one of its joint frames, at the last position of the body -- or immediately
+                // below the joint parent's own frame, which is where the caret naturally ends up
+                // once nothing follows its whole chain (e.g. pasting a trailing "else" right after
+                // finishing an if/elif with nothing else in the body).  That's the joint parent's
+                // own "below" position, not one of its children's, so it needs to append after any
+                // existing joint children rather than being treated as "top of its body":
+                let jointParentId: number;
+                let newIndex: number;
+                if (payload.target.caretPosition == CaretPosition.below
+                    && this.frameObjects[payload.target.id].frameType.allowJointChildren
+                    && !this.frameObjects[payload.target.id].frameType.isJointFrame) {
+                    jointParentId = payload.target.id;
+                    newIndex = this.frameObjects[jointParentId].jointFrameIds.length;
                 }
                 else {
-                    parentId = getParentOrJointParent(payload.target.id);
+                    let parentId: number;
+                    if (payload.target.caretPosition == CaretPosition.body) {
+                        parentId = payload.target.id;
+                    }
+                    else {
+                        parentId = getParentOrJointParent(payload.target.id);
+                    }
+
+                    const insideJointParentBody = !this.frameObjects[parentId].frameType.isJointFrame;
+                    newIndex = insideJointParentBody ? 0 : this.getIndexInParent(parentId) + 1;
+                    jointParentId = insideJointParentBody ? parentId : getParentOrJointParent(parentId);
                 }
-                
-                const insideJointParentBody = !this.frameObjects[parentId].frameType.isJointFrame;
-                const newIndex = insideJointParentBody ? 0 : this.getIndexInParent(parentId) + 1;
-                
-                const jointParentId = insideJointParentBody ? parentId : getParentOrJointParent(parentId);
                 if (!this.frameObjects[jointParentId].frameType.allowJointChildren) {
                     // This frame doesn't allow joint children; bail out instantly
                     return null;

--- a/tests/cypress/e2e/paste-python.cy.ts
+++ b/tests/cypress/e2e/paste-python.cy.ts
@@ -105,6 +105,7 @@ describe("Python round-trip", () => {
 
     it("Shows an error for invalid code with wrong code", () => {
         // Since the default code contains a project doc, we need to include it to the code
+        // The fixture's invalidity comes from a "@" (matrix mult) operator, which Strype doesn't support
         testRoundTripImportAndDownload("tests/cypress/fixtures/python-invalid-hints-extract.py", defaultProjectDocFullLine);
         assertVisibleError(/invalid.*import.*operator.*line: 24/si);
     });

--- a/tests/cypress/fixtures/python-invalid-hints-extract.py
+++ b/tests/cypress/fixtures/python-invalid-hints-extract.py
@@ -20,8 +20,8 @@ for filename in os.listdir("."):
                 rindex = len(row) - (1 if filename.startswith("Human") else 2)
                 while rindex >= 0 and ((not row[rindex].strip()) or row[rindex].strip() == "NA"):
                     rindex -= 1
-                
-                if rindex < 0:
+
+                if rindex @ 0 < 0:
                     continue  # Skip rows with no non-empty cells
 
                 if filename.startswith("Human"):

--- a/tests/playwright/e2e/load-save-random.spec.ts
+++ b/tests/playwright/e2e/load-save-random.spec.ts
@@ -929,6 +929,33 @@ test.describe("Enters, saves and loads specific frames", () => {
             }]]);
     });
 
+    // Regression test for the multi-level-nesting case of the blank-before-joint-continuation bug
+    // fixed alongside https://github.com/k-pet-group/Strype/issues/757 : the blank line here sits
+    // one level shallower than the enclosing if/elif chain's own body, but two levels deeper than
+    // the "else" that follows -- it belongs at the "for" body's own indent (matching "if"), not at
+    // either adjacent line's indent (the elif body's, nor the outer else's).
+    test("Tests blank line before an outer else, nested inside an if/elif chain", async ({page}) => {
+        await testSpecific(page, [[], [], [
+            {
+                "frameType": "for",
+                "slotContent": ["i", "myList"],
+                "body": [
+                    {
+                        "frameType": "if",
+                        "slotContent": ["a"],
+                        "body": [{"frameType": "raise", "slotContent": ["b"]}],
+                        "joint": [
+                            {"frameType": "elif", "slotContent": ["c"], "body": [{"frameType": "raise", "slotContent": ["d"]}]},
+                        ],
+                    },
+                    {"frameType": "blank", "slotContent": []},
+                ],
+                "joint": [
+                    {"frameType": "else", "slotContent": [], "body": [{"frameType": "raise", "slotContent": ["e"]}]},
+                ],
+            }]]);
+    });
+
     test("Tests blank and comment at start of disabled try", async ({page}) => {
         await testSpecific(page, [[], [], [
             {

--- a/tests/playwright/e2e/paste-augmented-assignment.spec.ts
+++ b/tests/playwright/e2e/paste-augmented-assignment.spec.ts
@@ -1,0 +1,65 @@
+import {test, expect, Page} from "@playwright/test";
+import {enterCode, waitForEditorSettled, assertStateOfVarAssignFrame} from "../support/editor";
+import {setupStrypeTest} from "../support/general";
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    await setupStrypeTest(page, browserName, testInfo, {skipPyodide: true});
+});
+
+// Strype has no dedicated frame for augmented assignment ("a += b"), so pasting one is expanded
+// into the equivalent variable-assignment frame "a = a + b" instead of failing to parse.
+async function checkAugAssign(page: Page, code: string, expectedLHS: string, expectedRHS: string) : Promise<void> {
+    await enterCode(page, ["", "", code + "\n"]);
+    await waitForEditorSettled(page);
+    await assertStateOfVarAssignFrame(page, expectedLHS, expectedRHS);
+}
+
+test.describe("Pasting augmented assignment expands to a plain assignment", () => {
+    const operators : [string, string][] = [
+        ["+=", "+"],
+        ["-=", "-"],
+        ["*=", "*"],
+        ["/=", "/"],
+        ["//=", "//"],
+        ["%=", "%"],
+        ["**=", "**"],
+        ["&=", "&"],
+        ["|=", "|"],
+        ["^=", "^"],
+        [">>=", ">>"],
+        ["<<=", "<<"],
+    ];
+    for (const [augOp, plainOp] of operators) {
+        test(`Supports pasting "a ${augOp} b"`, ({page}) => checkAugAssign(page, `a ${augOp} b`, "{a}", `{a}${plainOp}{b}`));
+    }
+
+    test("Supports a more complex (subscript) target", ({page}) => checkAugAssign(page, "a[i] += b", "{a}[{i}]{}", "{a}[{i}]{}+{b}"));
+    test("Supports a more complex (attribute) target", ({page}) => checkAugAssign(page, "obj.x -= y", "{obj}.{x}", "{obj}.{x}-{y}"));
+});
+
+test.describe("Pasting augmented assignment brackets the RHS only when needed", () => {
+    // A single token, a function call, or a member/method-call chain don't need brackets around
+    // the RHS operand to keep the expansion's meaning unambiguous:
+    test("Doesn't bracket a single-token RHS", ({page}) => checkAugAssign(page, "a += b", "{a}", "{a}+{b}"));
+    test("Doesn't bracket a function-call RHS", ({page}) => checkAugAssign(page, "a += f(x)", "{a}", "{a}+{f}_({x})_{}"));
+    test("Doesn't bracket a method-call RHS", ({page}) => checkAugAssign(page, "a += obj.method(x)", "{a}", "{a}+{obj}.{method}_({x})_{}"));
+    test("Doesn't double-bracket an already-bracketed RHS", ({page}) => checkAugAssign(page, "a += (b + c)", "{a}", "{a}+{}_({b}+{c})_{}"));
+
+    // Anything else with an operator of its own needs brackets, otherwise the expansion would
+    // silently change the meaning of the code (e.g. "a - b + c" is not the same as "a - (b + c)"):
+    test("Brackets a compound RHS under a non-associative operator", ({page}) => checkAugAssign(page, "a -= b + c", "{a}", "{a}-{}_({b}+{c})_{}"));
+    test("Brackets a compound RHS under multiplication", ({page}) => checkAugAssign(page, "a *= b - c", "{a}", "{a}*{}_({b}-{c})_{}"));
+    test("Brackets a unary-minus RHS", ({page}) => checkAugAssign(page, "a += -b", "{a}", "{a}+{}_({}-{b})_{}"));
+});
+
+test.describe("Pasting augmented assignment works in nested locations", () => {
+    test("Works inside an if body", async ({page}) => {
+        await enterCode(page, ["", "", "if True:\n    total += 1\n"]);
+        await waitForEditorSettled(page);
+        // The if's body frame becomes the relevant "first frame" once we descend into it, but
+        // assertStateOfVarAssignFrame only ever looks at the first frame in Main, so instead just
+        // check the rendered text directly for the nested augmented assignment's expansion:
+        const bodyText = await page.locator("#frameContainer_-3 .frame-div").first().innerText();
+        expect(bodyText.replaceAll("​", "")).toEqual("if\nTrue\n:\ntotal\n⇐\ntotal\n+\n1");
+    });
+});

--- a/tests/playwright/e2e/paste-joint-frames.spec.ts
+++ b/tests/playwright/e2e/paste-joint-frames.spec.ts
@@ -86,6 +86,25 @@ test.describe("Pasting else only succeeds at a valid position in an if/elif chai
         await assertMessageBanner(page, null);
         await expect(page.locator("#frameContainer_-3")).toContainText("else");
     });
+
+    test("Allows pasting else immediately below the whole if/elif chain", async ({page}) => {
+        // This is the caret position enterCode() naturally leaves the cursor at -- immediately
+        // below the whole chain, not nested inside the last branch's body. That's a distinct
+        // position from "top of the elif's body" above (same visual spot, different underlying
+        // target), and is where a user would most naturally try to paste a trailing "else" right
+        // after finishing typing/pasting the if/elif:
+        await enterCode(page, ["", "", ifElifCode]);
+        await doPagePaste(page, elseCode);
+        await assertMessageBanner(page, null);
+        await expect(page.locator("#frameContainer_-3")).toContainText("else");
+    });
+
+    test("Allows pasting elif immediately below a lone if with no existing joint children", async ({page}) => {
+        await enterCode(page, ["", "", "if True:\n    a()\n"]);
+        await doPagePaste(page, "elif True:\n    c()\n");
+        await assertMessageBanner(page, null);
+        await expect(page.locator("#frameContainer_-3")).toContainText("elif");
+    });
 });
 
 // Regression test for https://github.com/k-pet-group/Strype/issues/757 : a blank line immediately

--- a/tests/playwright/e2e/paste-joint-frames.spec.ts
+++ b/tests/playwright/e2e/paste-joint-frames.spec.ts
@@ -1,0 +1,43 @@
+import {test, expect, Page} from "@playwright/test";
+import {enterCode} from "../support/editor";
+import {setupStrypeTest} from "../support/general";
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    await setupStrypeTest(page, browserName, testInfo, {skipPyodide: true});
+});
+
+// Mirrors Cypress's assertVisibleError() in paste-python.cy.ts: the message banner and its close
+// button are exposed via the same CSS classes on window.StrypeSCSSVarsGlobals.
+async function assertMessageBanner(page: Page, expectedText: RegExp | null) : Promise<void> {
+    const scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
+    const banner = page.locator("." + scssVars.messageBannerContainerClassName);
+    if (expectedText != null) {
+        await expect(banner.locator("span").first()).toHaveText(expectedText);
+        await banner.locator("." + scssVars.messageBannerCrossClassName).click();
+    }
+    // Whether it never existed, or we just closed it, it should now not exist:
+    await expect(banner).toHaveCount(0);
+}
+
+// Regression test for https://github.com/k-pet-group/Strype/issues/757 : a blank line immediately
+// before elif/else/except/finally used to be dedented to that keyword's own (shallower) indent,
+// which split the compound statement in two and made the whole paste fail to parse.
+test.describe("Pasting handles a blank line before a joint continuation", () => {
+    test("Allows a blank line before elif", async ({page}) => {
+        await enterCode(page, ["", "", "if True:\n    a()\n\nelif True:\n    b()\n"]);
+        await assertMessageBanner(page, null);
+        await expect(page.locator("#frameContainer_-3")).toContainText("elif");
+    });
+
+    test("Allows a blank line before else", async ({page}) => {
+        await enterCode(page, ["", "", "if True:\n    a()\n\nelse:\n    b()\n"]);
+        await assertMessageBanner(page, null);
+        await expect(page.locator("#frameContainer_-3")).toContainText("else");
+    });
+
+    test("Allows a blank line before except", async ({page}) => {
+        await enterCode(page, ["", "", "try:\n    a()\n\nexcept:\n    b()\n"]);
+        await assertMessageBanner(page, null);
+        await expect(page.locator("#frameContainer_-3")).toContainText("except");
+    });
+});

--- a/tests/playwright/e2e/paste-joint-frames.spec.ts
+++ b/tests/playwright/e2e/paste-joint-frames.spec.ts
@@ -1,5 +1,5 @@
 import {test, expect, Page} from "@playwright/test";
-import {enterCode} from "../support/editor";
+import {enterCode, doPagePaste, waitForEditorSettled} from "../support/editor";
 import {setupStrypeTest} from "../support/general";
 
 test.beforeEach(async ({ page, browserName }, testInfo) => {
@@ -18,6 +18,75 @@ async function assertMessageBanner(page: Page, expectedText: RegExp | null) : Pr
     // Whether it never existed, or we just closed it, it should now not exist:
     await expect(banner).toHaveCount(0);
 }
+
+// Finds the runtime frame ID of the (unique) top-level frame in Main whose header text starts
+// with the given text (e.g. "if" or "elif"), by reading the "frameHeader_<id>" element IDs that
+// Frame.vue/FrameHeader.vue render -- see getFrameHeaderUID() in src/helpers/editor.ts.
+async function getFrameIdByHeaderText(page: Page, headerText: string) : Promise<number> {
+    const id = await page.evaluate((headerText) => {
+        const headers = Array.from(document.querySelectorAll("#frameContainer_-3 [id^=\"frameHeader_\"]"));
+        const match = headers.find((h) => h.textContent?.trim().startsWith(headerText));
+        return match?.id ?? null;
+    }, headerText);
+    if (id == null) {
+        throw new Error(`Could not find a frame header in Main starting with "${headerText}"`);
+    }
+    return parseInt(id.replace("frameHeader_", ""), 10);
+}
+
+// Clicks the "top of body" caret (CaretPosition.body -> "caretBody" in the DOM ID) of the frame
+// with the given runtime ID. The click handler lives on the caret's wrapping container element
+// (see getCaretContainerUID() in src/helpers/editor.ts and CaretContainer.vue's toggleCaret()),
+// not on the visual Caret element itself (which is invisible/non-interactive until selected).
+async function clickBodyCaret(page: Page, frameId: number) : Promise<void> {
+    // Caret containers for positions that aren't currently selected are deliberately
+    // zero-size/hidden until selected, which defeats Playwright's coordinate-based click (it
+    // can't compute an on-screen point to click). The container's own click handler
+    // (toggleCaret() in CaretContainer.vue) only needs a real "click" event to fire though, so
+    // dispatch one directly in the page instead of going through Playwright's mouse simulation:
+    const id = "caret_caretBody_of_frame_" + frameId;
+    await page.evaluate((id) => {
+        document.getElementById(id)?.dispatchEvent(new MouseEvent("click", {bubbles: true, cancelable: true}));
+    }, id);
+    await waitForEditorSettled(page);
+}
+
+// Regression tests for https://github.com/k-pet-group/Strype/issues/543 : pasting a joint frame
+// (e.g. "else") at a cursor position where it can't legally attach used to either misplace it
+// between existing branches or crash with an uncaught exception, and gave the user no feedback
+// either way. It should instead be rejected with a visible error, leaving the existing structure
+// untouched -- while still succeeding at a genuinely valid position.
+test.describe("Pasting else only succeeds at a valid position in an if/elif chain", () => {
+    const ifElifCode = "if True:\n    a()\nelif True:\n    b()\n";
+    const elseCode = "else:\n    x = -9\n";
+
+    test("Rejects pasting else at the top of the if's own body", async ({page}) => {
+        await enterCode(page, ["", "", ifElifCode]);
+        const ifId = await getFrameIdByHeaderText(page, "if");
+        // The top of the "if" body (above "a()") still has the "elif" chain following it, so a
+        // trailing "else" can't legally go there:
+        await clickBodyCaret(page, ifId);
+        const frameCountBefore = await page.locator("#frameContainer_-3 .frame-div").count();
+        await doPagePaste(page, elseCode);
+        await assertMessageBanner(page, /illegal code/i);
+        // The structure must be completely unaffected by the rejected paste -- no "else" branch
+        // added, and the same number of frames as before (not comparing innerText directly, since
+        // it can pick up transient autocomplete tooltip text unrelated to the frame structure):
+        await expect(page.locator("#frameContainer_-3")).not.toContainText("else");
+        await expect(page.locator("#frameContainer_-3 .frame-div")).toHaveCount(frameCountBefore);
+    });
+
+    test("Allows pasting else at the top of the elif's body", async ({page}) => {
+        await enterCode(page, ["", "", ifElifCode]);
+        const elifId = await getFrameIdByHeaderText(page, "elif");
+        // The top of the "elif" body (above "b()") is the last branch, so a trailing "else" can
+        // legally attach after it:
+        await clickBodyCaret(page, elifId);
+        await doPagePaste(page, elseCode);
+        await assertMessageBanner(page, null);
+        await expect(page.locator("#frameContainer_-3")).toContainText("else");
+    });
+});
 
 // Regression test for https://github.com/k-pet-group/Strype/issues/757 : a blank line immediately
 // before elif/else/except/finally used to be dedented to that keyword's own (shallower) indent,


### PR DESCRIPTION
This fixes a few paste issues, split by commit so might be easiest to review individual commits:
 - Support pasting/loading "a += b" by turning it into "a = a + b".  Brackets are added if b is not a single-item expression (so if you paste "x += 3 * 5" it comes out to "x = x + (3 * 5)".
 - Fix an issue where pasting a blank line in the middle of an if/else (before the else) was causing an exception, when really we should accept it (see https://github.com/k-pet-group/Strype/issues/757)
 - Fixed an issue where pasting else above elif could cause an invalid state (see https://github.com/k-pet-group/Strype/issues/543)
 - In the course of doing this, the AI spotted an invalid state we could get into where the cursor position was below an if despite having joint frames following (this cursor position sort of exists in our minds, but it shouldn't be reachable by the user) and pastes there would fail.  So it fixed that in the last commit.