### PR TITLE
Show shortcuts while text editing

### DIFF
--- a/src/components/AddFrameCommand.vue
+++ b/src/components/AddFrameCommand.vue
@@ -74,6 +74,22 @@ export default defineComponent({
     color: rgb(180, 180, 180);
 }
 
+.frame-cmd-container.text-editing-command,
+.frame-cmd-container.text-editing-command .frame-cmd-btn {
+    cursor: default;
+}
+
+.text-editing-command-keys-plus {
+    margin-right: 5px;
+}
+
+// Unlike the other frame-cmd-btn-large usages (e.g. the "space" symbol for the function call
+// shortcut), the code completion shortcut's key boxes aren't crammed into a row with many others,
+// so there's no need to condense the font horizontally to save space.
+.text-editing-command .frame-cmd-btn-large {
+    font-stretch: normal !important;
+}
+
 .frame-cmd-btn {
     margin-right: 5px;
     cursor: pointer;

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -49,6 +49,16 @@
                                                         "
                                                     />
                                                 </p>
+                                                <p v-if="codeCompletionCommand">
+                                                    <div class="frame-cmd-container text-editing-command">
+                                                        <span class="text-editing-command-keys">
+                                                            <button class="frame-cmd-btn frame-cmd-btn-large">{{ codeCompletionCommand.ctrlSymbol }}</button>
+                                                            <span class="text-editing-command-keys-plus">+</span>
+                                                            <button class="frame-cmd-btn frame-cmd-btn-large">{{ codeCompletionCommand.spaceSymbol }}</button>
+                                                        </span>
+                                                        <span>{{ codeCompletionCommand.description }}</span>
+                                                    </div>
+                                                </p>
                                             <!-- this conditional rendering is only used for our code editor to see the closing <div> right -->
                                             <!-- #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE -->
                                             </div>
@@ -105,7 +115,7 @@
 import AddFrameCommand from "@/components/AddFrameCommand.vue";
 import { computeAddFrameCommandContainerSize, CustomEventTypes, getActiveContextMenu, getAddFrameCmdElementUID, getCaretContainerUID, getCommandsContainerUID, getCommandsRightPaneContainerId, getCurrentFrameSelectAllAction, getFrameUID, getEditorMiddleUID, getMenuLeftPaneUID, hiddenShorthandFrames, notifyDragEnded, waitForPanesSettled } from "@/helpers/editor";
 import { useStore } from "@/store/store";
-import { AddFrameCommandDef, AllFrameTypesIdentifier, CaretPosition, CollapsedState, defaultEmptyStrypeLayoutDividerSettings, FrameObject, PythonExecRunningState, SelectAllFramesAction, StrypePEALayoutMode, StrypeSyncTarget } from "@/types/types";
+import { AddFrameCommandDef, AllFrameTypesIdentifier, CaretPosition, CollapsedState, defaultEmptyStrypeLayoutDividerSettings, FrameObject, isSlotStringLiteralType, PythonExecRunningState, SelectAllFramesAction, SlotType, StrypePEALayoutMode, StrypeSyncTarget } from "@/types/types";
 import $ from "jquery";
 import { defineComponent } from "vue";
 import { mapStores } from "pinia";
@@ -281,6 +291,22 @@ export default defineComponent({
             }
 
             return this.appStore.generateAvailableFrameCommands(this.appStore.currentFrame.id, this.appStore.currentFrame.caretPosition);
+        },
+
+        // When a text cursor is focused inside a code or string slot (but not a comment/documentation slot),
+        // we show the code completion shortcut instead of the (then empty) list of add frame commands.
+        // Note this shortcut is Ctrl+Space on every platform, including macOS (not Cmd+Space).
+        codeCompletionCommand(): {ctrlSymbol: string; spaceSymbol: string; description: string} | null {
+            const focusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
+            if(!this.appStore.isEditing || !focusSlotCursorInfos || focusSlotCursorInfos.slotInfos.slotType == SlotType.comment){
+                return null;
+            }
+
+            const description = (isSlotStringLiteralType(focusSlotCursorInfos.slotInfos.slotType))
+                ? this.$t("autoCompletion.codeCompletionFilePaths")
+                : this.$t("autoCompletion.codeCompletion");
+
+            return {ctrlSymbol: this.$t("contextMenu.ctrl"), spaceSymbol: this.$t("autoCompletion.spaceKey"), description};
         },
 
         progressPercentWidthStyle(): string {

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -59,6 +59,16 @@
                                                         <span>{{ codeCompletionCommand.description }}</span>
                                                     </div>
                                                 </p>
+                                                <p v-if="wrapSelectionCommands.length">
+                                                    <div
+                                                        v-for="wrapSelectionCommand in wrapSelectionCommands"
+                                                        :key="wrapSelectionCommand.symbol"
+                                                        class="frame-cmd-container text-editing-command"
+                                                    >
+                                                        <button class="frame-cmd-btn">{{ wrapSelectionCommand.symbol }}</button>
+                                                        <span>{{ wrapSelectionCommand.description }}</span>
+                                                    </div>
+                                                </p>
                                             <!-- this conditional rendering is only used for our code editor to see the closing <div> right -->
                                             <!-- #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE -->
                                             </div>
@@ -115,7 +125,7 @@
 import AddFrameCommand from "@/components/AddFrameCommand.vue";
 import { computeAddFrameCommandContainerSize, CustomEventTypes, getActiveContextMenu, getAddFrameCmdElementUID, getCaretContainerUID, getCommandsContainerUID, getCommandsRightPaneContainerId, getCurrentFrameSelectAllAction, getFrameUID, getEditorMiddleUID, getMenuLeftPaneUID, hiddenShorthandFrames, notifyDragEnded, waitForPanesSettled } from "@/helpers/editor";
 import { useStore } from "@/store/store";
-import { AddFrameCommandDef, AllFrameTypesIdentifier, CaretPosition, CollapsedState, defaultEmptyStrypeLayoutDividerSettings, FrameObject, isSlotStringLiteralType, PythonExecRunningState, SelectAllFramesAction, SlotType, StrypePEALayoutMode, StrypeSyncTarget } from "@/types/types";
+import { AddFrameCommandDef, AllFrameTypesIdentifier, areSlotCoreInfosEqual, CaretPosition, CollapsedState, defaultEmptyStrypeLayoutDividerSettings, FrameObject, isSlotStringLiteralType, PythonExecRunningState, SelectAllFramesAction, SlotType, StrypePEALayoutMode, StrypeSyncTarget } from "@/types/types";
 import $ from "jquery";
 import { defineComponent } from "vue";
 import { mapStores } from "pinia";
@@ -307,6 +317,31 @@ export default defineComponent({
                 : this.$t("autoCompletion.codeCompletion");
 
             return {ctrlSymbol: this.$t("contextMenu.ctrl"), spaceSymbol: this.$t("autoCompletion.spaceKey"), description};
+        },
+
+        // When the user has a text selection inside a code slot (not a comment/documentation slot, and not
+        // a string literal slot -- wrapping a selection in quotes there wouldn't make sense), typing one of
+        // these bracket/quote characters wraps the selection with it. We show those shortcuts here as a hint.
+        wrapSelectionCommands(): {symbol: string; description: string}[] {
+            const focusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
+            const anchorSlotCursorInfos = this.appStore.anchorSlotCursorInfos;
+            if(!this.appStore.isEditing || !focusSlotCursorInfos || !anchorSlotCursorInfos){
+                return [];
+            }
+
+            const hasSelection = !areSlotCoreInfosEqual(focusSlotCursorInfos.slotInfos, anchorSlotCursorInfos.slotInfos) || focusSlotCursorInfos.cursorPos != anchorSlotCursorInfos.cursorPos;
+            const slotType = focusSlotCursorInfos.slotInfos.slotType;
+            if(!hasSelection || slotType == SlotType.comment || isSlotStringLiteralType(slotType)){
+                return [];
+            }
+
+            return [
+                {symbol: "(", description: this.$t("autoCompletion.wrapRoundBrackets")},
+                {symbol: "[", description: this.$t("autoCompletion.wrapSquareBrackets")},
+                {symbol: "{", description: this.$t("autoCompletion.wrapCurlyBrackets")},
+                {symbol: "\"", description: this.$t("autoCompletion.wrapDoubleQuotes")},
+                {symbol: "'", description: this.$t("autoCompletion.wrapSingleQuotes")},
+            ];
         },
 
         progressPercentWidthStyle(): string {

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -249,11 +249,11 @@
     "codeCompletion": "Code completion",
     "codeCompletionFilePaths": "Code completion (file paths)",
     "spaceKey": "space",
-    "wrapRoundBrackets": "Wrap in round brackets",
-    "wrapSquareBrackets": "Wrap in square brackets",
-    "wrapCurlyBrackets": "Wrap in curly brackets",
-    "wrapDoubleQuotes": "Wrap in double quotes",
-    "wrapSingleQuotes": "Wrap in single quotes"
+    "wrapRoundBrackets": "Wrap in ()",
+    "wrapSquareBrackets": "Wrap in []",
+    "wrapCurlyBrackets": "Wrap in {'{}'}",
+    "wrapDoubleQuotes": "Wrap in \"",
+    "wrapSingleQuotes": "Wrap in '"
   },
   "commandTabs": {
     "0": "Add Frame"

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -245,7 +245,10 @@
     "importedModules": "Imported modules",
     "builtinFiles": "Built-in files",
     "invalidState": "No completion available",
-    "noDocumentation": "No documentation available"
+    "noDocumentation": "No documentation available",
+    "codeCompletion": "Code completion",
+    "codeCompletionFilePaths": "Code completion (file paths)",
+    "spaceKey": "space"
   },
   "commandTabs": {
     "0": "Add Frame"

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -248,7 +248,12 @@
     "noDocumentation": "No documentation available",
     "codeCompletion": "Code completion",
     "codeCompletionFilePaths": "Code completion (file paths)",
-    "spaceKey": "space"
+    "spaceKey": "space",
+    "wrapRoundBrackets": "Wrap in round brackets",
+    "wrapSquareBrackets": "Wrap in square brackets",
+    "wrapCurlyBrackets": "Wrap in curly brackets",
+    "wrapDoubleQuotes": "Wrap in double quotes",
+    "wrapSingleQuotes": "Wrap in single quotes"
   },
   "commandTabs": {
     "0": "Add Frame"

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -247,13 +247,13 @@
     "invalidState": "Aucune complétion disponible",
     "noDocumentation": "Aucune documentation disponible",
     "codeCompletion": "Complétion de code",
-    "codeCompletionFilePaths": "Complétion de code (chemins de fichiers)",
+    "codeCompletionFilePaths": "Complétion de code (chemins d'accès de fichiers)",
     "spaceKey": "espace",
-    "wrapRoundBrackets": "Entourer de parenthèses",
-    "wrapSquareBrackets": "Entourer de crochets",
-    "wrapCurlyBrackets": "Entourer d'accolades",
-    "wrapDoubleQuotes": "Entourer de guillemets doubles",
-    "wrapSingleQuotes": "Entourer de guillemets simples"
+    "wrapRoundBrackets": "Entourer de ()",
+    "wrapSquareBrackets": "Entourer de []",
+    "wrapCurlyBrackets": "Entourer de {'{}'}",
+    "wrapDoubleQuotes": "Entourer de \"",
+    "wrapSingleQuotes": "Entourer de '"
   },
   "commandTabs": {
     "0": "Ajoute un cadre"

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -245,7 +245,10 @@
     "importedModules": "Modules importés",
     "builtinFiles": "Fichiers intégrés",
     "invalidState": "Aucune complétion disponible",
-    "noDocumentation": "Aucune documentation disponible"
+    "noDocumentation": "Aucune documentation disponible",
+    "codeCompletion": "Complétion de code",
+    "codeCompletionFilePaths": "Complétion de code (chemins de fichiers)",
+    "spaceKey": "espace"
   },
   "commandTabs": {
     "0": "Ajoute un cadre"

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -248,7 +248,12 @@
     "noDocumentation": "Aucune documentation disponible",
     "codeCompletion": "Complétion de code",
     "codeCompletionFilePaths": "Complétion de code (chemins de fichiers)",
-    "spaceKey": "espace"
+    "spaceKey": "espace",
+    "wrapRoundBrackets": "Entourer de parenthèses",
+    "wrapSquareBrackets": "Entourer de crochets",
+    "wrapCurlyBrackets": "Entourer d'accolades",
+    "wrapDoubleQuotes": "Entourer de guillemets doubles",
+    "wrapSingleQuotes": "Entourer de guillemets simples"
   },
   "commandTabs": {
     "0": "Ajoute un cadre"

--- a/tests/playwright/e2e/commands-pane.spec.ts
+++ b/tests/playwright/e2e/commands-pane.spec.ts
@@ -1,0 +1,105 @@
+import {expect, test} from "@playwright/test";
+import {setupStrypeTest} from "../support/general";
+import {waitForEditorSettled} from "../support/editor";
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    await setupStrypeTest(page, browserName, testInfo, {skipPyodide: true});
+});
+
+// The default starter project always has a "myString = "Hello from Strype"" assignment followed
+// by a "print(myString)" call -- these give us a plain code slot (the "myString" argument to
+// print) and a string literal slot ("Hello from Strype") to focus/select in the tests below.
+function getPlainCodeSlot(page: import("@playwright/test").Page) {
+    return page.locator(".label-slot-input").filter({hasText: /^myString$/}).last();
+}
+
+function getStringLiteralSlot(page: import("@playwright/test").Page) {
+    return page.locator(".label-slot-input").filter({hasText: "Hello"}).first();
+}
+
+test.describe("Frame commands pane -- frame cursor", () => {
+    test("shows the basic frame commands, without elif/else, at an empty line", async ({page}) => {
+        await expect(page.locator("#addFrameCmd_if")).toBeVisible();
+        await expect(page.locator("#addFrameCmd_elif")).toHaveCount(0);
+        await expect(page.locator("#addFrameCmd_else")).toHaveCount(0);
+    });
+
+    test("shows elif/else once positioned after an if frame", async ({page}) => {
+        await page.keyboard.press("i");
+        await waitForEditorSettled(page);
+        // Leave the condition slot -- the frame cursor lands right after the if frame, where
+        // joint (elif/else) frames become valid additions:
+        await page.keyboard.press("Escape");
+        await waitForEditorSettled(page);
+
+        await expect(page.locator("#addFrameCmd_elif")).toBeVisible();
+        await expect(page.locator("#addFrameCmd_else")).toBeVisible();
+    });
+});
+
+test.describe("Commands pane -- code completion shortcut", () => {
+    test("shown while editing a plain code slot", async ({page}) => {
+        const panel = page.locator("#addFramePanel");
+        await getPlainCodeSlot(page).click();
+
+        await expect(panel).toContainText("Code completion");
+        await expect(panel).not.toContainText("file paths");
+    });
+
+    test("shown with the file-paths label while editing a string literal slot", async ({page}) => {
+        const panel = page.locator("#addFramePanel");
+        await getStringLiteralSlot(page).click();
+
+        await expect(panel).toContainText("Code completion (file paths)");
+    });
+
+    test("not shown while editing a comment", async ({page}) => {
+        const panel = page.locator("#addFramePanel");
+        await page.keyboard.press("#");
+        await waitForEditorSettled(page);
+        await page.keyboard.type("hello world");
+
+        await expect(panel).not.toContainText("Code completion");
+    });
+});
+
+test.describe("Commands pane -- wrap-selection shortcuts", () => {
+    test("shown for a selection inside a plain code slot", async ({page}) => {
+        const panel = page.locator("#addFramePanel");
+        await getPlainCodeSlot(page).dblclick();
+
+        await expect(panel).toContainText("Wrap in round brackets");
+        await expect(panel).toContainText("Wrap in square brackets");
+        await expect(panel).toContainText("Wrap in curly brackets");
+        await expect(panel).toContainText("Wrap in double quotes");
+        await expect(panel).toContainText("Wrap in single quotes");
+
+        // Collapsing the selection back to a plain cursor should hide them again:
+        await page.keyboard.press("ArrowRight");
+        await expect(panel).not.toContainText("Wrap in");
+    });
+
+    test("not shown for a selection inside a string literal slot", async ({page}) => {
+        const panel = page.locator("#addFramePanel");
+        await getStringLiteralSlot(page).dblclick();
+
+        await expect(panel).toContainText("Code completion (file paths)");
+        await expect(panel).not.toContainText("Wrap in");
+    });
+
+    test("not shown for a selection inside a comment", async ({page}) => {
+        const panel = page.locator("#addFramePanel");
+        await page.keyboard.press("#");
+        await waitForEditorSettled(page);
+        await page.keyboard.type("hello world");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("Home");
+        await page.keyboard.down("Shift");
+        await page.keyboard.press("ArrowRight");
+        await page.keyboard.press("ArrowRight");
+        await page.keyboard.up("Shift");
+
+        await expect(panel).not.toContainText("Wrap in");
+        await expect(panel).not.toContainText("Code completion");
+    });
+});

--- a/tests/playwright/e2e/commands-pane.spec.ts
+++ b/tests/playwright/e2e/commands-pane.spec.ts
@@ -68,11 +68,11 @@ test.describe("Commands pane -- wrap-selection shortcuts", () => {
         const panel = page.locator("#addFramePanel");
         await getPlainCodeSlot(page).dblclick();
 
-        await expect(panel).toContainText("Wrap in round brackets");
-        await expect(panel).toContainText("Wrap in square brackets");
-        await expect(panel).toContainText("Wrap in curly brackets");
-        await expect(panel).toContainText("Wrap in double quotes");
-        await expect(panel).toContainText("Wrap in single quotes");
+        await expect(panel).toContainText("Wrap in ()");
+        await expect(panel).toContainText("Wrap in []");
+        await expect(panel).toContainText("Wrap in {}");
+        await expect(panel).toContainText("Wrap in \"");
+        await expect(panel).toContainText("Wrap in '");
 
         // Collapsing the selection back to a plain cursor should hide them again:
         await page.keyboard.press("ArrowRight");


### PR DESCRIPTION
This is a small PR which adds a feature I'd wanted for a while: showing the Ctrl-Space shortcut while editing a slot in the commands pane so that it's discoverable.  It's not actually clickable (it would remove focus from the text slot so it would be fiddly to restore focus then show the dialog).  Also when you have a selection in slots, adds the Wrap-in-brackets items as shortcuts, as they are also not really discoverable at the moment.

This is a precursor to a future planned change; I want to add the ability to insert microphone recordings as sound literals and webcam images as media literals.  Having a menu item for them is awkward so I think a keyboard shortcut is suitable (Ctrl-Shift-M or whatever we pick) and this way it could actually be discoverable.