### PR TITLE
Fix bugs with match and console input

### DIFF
--- a/src/helpers/execPythonCode.ts
+++ b/src/helpers/execPythonCode.ts
@@ -1,6 +1,6 @@
 // refs: http://skulpt.org/using.html#html and for the input/event part https://stackoverflow.com/questions/43733896/wait-for-an-event-to-occur-within-a-function-in-javascript-for-skulpt
 
-import { LineAndSlotPositions } from "@/types/types";
+import { LineAndSlotPositions, PythonExecRunningState } from "@/types/types";
 import { useStore } from "@/store/store";
 import i18n from "@/i18n";
 import { nextTick } from "vue";
@@ -12,8 +12,11 @@ const STRYPE_INPUT_INTERRUPT_ERR_MSG = "ExternalError: " + STRYPE_RUN_ACTION_MSG
 // Declation of JS objects required for using Skulpt:
 // the output HTML object, a text area in our case. Declared globally in the script for ease of usage
 // a Sk object that is FROM THE SKULPT LIBRARY, it is the main entry point of Skulpt
-let consoleTextArea: HTMLTextAreaElement = {} as HTMLTextAreaElement; 
-let codeExecStateRunningCheckFn: (() => boolean) | undefined = undefined;
+let consoleTextArea: HTMLTextAreaElement = {} as HTMLTextAreaElement;
+// Used by sInput() below to detect that the user has stopped execution while an input() call is
+// still pending, so it can reject the pending promise and remove its console event listeners
+// instead of leaving them dangling for the next run (see https://github.com/k-pet-group/Strype/issues/927).
+const codeExecStateRunningCheckFn: () => boolean = () => useStore().pythonExecRunningState != PythonExecRunningState.NotRunning;
 
 // The function used for "output" from Skulpt, to be registered against the Skulpt object
 function outf(text: string) {
@@ -113,7 +116,7 @@ export function sInput() : Promise<string> {
         // therefore, we shouldn't hang on this method and exit as soon as possible. To do so, we need to regularly check if
         // stopping the code execution has been requested: if so, we reject the input and make sure we leave in a clean UI state.
         const checkInterruptionHandle = setInterval(() => {
-            if (codeExecStateRunningCheckFn && !codeExecStateRunningCheckFn()) {
+            if (!codeExecStateRunningCheckFn()) {
                 clearTimeout(checkInterruptionHandle);
                 if(isConsoleTextAreaLocked){
                     consoleTextArea.disabled = true;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -797,7 +797,7 @@ export function generateAllFrameDefinitionTypes(regenerateExistingFrames?: boole
         colour: "#E0DFE4",
         forbiddenChildrenTypes: Object.values(AllFrameTypesIdentifier).filter((type) => type != StandardFrameTypesIdentifiers.case && type != StandardFrameTypesIdentifiers.blank && type != StandardFrameTypesIdentifiers.comment),
         // A match statement must always have one case at least, so we enforce it upon frame creation
-        defaultChildrenTypes: [{...EmptyFrameObject, frameType: CaseDefinition, labelSlotsDict: {0: {slotStructures:{fields:[{code:"_"}], operators: []}}, 1: {slotStructures:{fields:[{code:""}], operators: []}}}}],
+        defaultChildrenTypes: [{...EmptyFrameObject, frameType: CaseDefinition, labelSlotsDict: {0: {slotStructures:{fields:[{code:"_"}], operators: []}}}}],
 
     };
 

--- a/tests/playwright/e2e/console-execution.spec.ts
+++ b/tests/playwright/e2e/console-execution.spec.ts
@@ -67,6 +67,69 @@ test.describe("Test stdin works", () => {
     });
 });
 
+test.describe("Test stopping during a pending input doesn't break the next run (issue #927)", () => {
+    // sInput()'s cleanup of a stopped-but-still-pending input() call (removing its console
+    // keydown/composition listeners, see execPythonCode.ts) is driven by a 1-second polling
+    // interval rather than any DOM-observable event, so we wait a little over a second after
+    // stopping to give that cleanup a chance to run before starting the next execution -- that's
+    // exactly the race these tests are meant to cover (without the fix, the stale listeners are
+    // never removed no matter how long we wait).
+    const STALE_INPUT_CLEANUP_WAIT_MS = 1500;
+
+    test("Check console still accepts input after stopping with a second input still pending", async ({page}) => {
+        const code = "name = input('What is your name?\\n')\nprint('Hello ' + name)\nspecies = input('What is your species?\\n')\nprint('Hello ' + name + ' the ' + species)\n";
+        await enterCode(page, ["", "", code]);
+        let button = await startRunning(page);
+        await expect(page.locator("#peaConsole")).toBeEnabled();
+        await expect(page.locator("#peaConsole")).toBeFocused();
+        // Validate the first input, leaving the second one pending:
+        await page.locator("#peaConsole").pressSequentially("George\n", {delay: 75});
+        await checkConsoleContent(page, "What is your name?\nGeorge\nHello George\nWhat is your species?\n");
+        await expect(button).toContainText("Stop");
+        // Stop while the second input is still pending:
+        await button.click();
+        await runButtonShowsRun(button);
+        await page.waitForTimeout(STALE_INPUT_CLEANUP_WAIT_MS);
+
+        // Run again, and check that typing into the console actually works this time:
+        button = await startRunning(page);
+        await expect(page.locator("#peaConsole")).toBeEnabled();
+        await expect(page.locator("#peaConsole")).toBeFocused();
+        await page.locator("#peaConsole").pressSequentially("Amy\n", {delay: 75});
+        await checkConsoleContent(page, "What is your name?\nAmy\nHello Amy\nWhat is your species?\n");
+        await expect(button).toContainText("Stop");
+        await page.locator("#peaConsole").pressSequentially("dog\n", {delay: 75});
+        await checkConsoleContent(page, "What is your name?\nAmy\nHello Amy\nWhat is your species?\ndog\nHello Amy the dog\n");
+        await runButtonShowsRun(button);
+        await checkFrameErrorCount(page, 0);
+    });
+
+    test("Check Enter still validates input after stopping with an unvalidated input pending", async ({page}) => {
+        const code = "name = input('What is your name?\\n')\nprint('Hello ' + name)\n";
+        await enterCode(page, ["", "", code]);
+        let button = await startRunning(page);
+        await expect(page.locator("#peaConsole")).toBeEnabled();
+        await expect(page.locator("#peaConsole")).toBeFocused();
+        // Type something but don't validate it with Enter:
+        await page.locator("#peaConsole").pressSequentially("Geo", {delay: 75});
+        await checkConsoleContent(page, "What is your name?\nGeo");
+        await expect(button).toContainText("Stop");
+        // Stop while the input is still pending and unvalidated:
+        await button.click();
+        await runButtonShowsRun(button);
+        await page.waitForTimeout(STALE_INPUT_CLEANUP_WAIT_MS);
+
+        // Run again, type something, and check Enter actually validates it this time:
+        button = await startRunning(page);
+        await expect(page.locator("#peaConsole")).toBeEnabled();
+        await expect(page.locator("#peaConsole")).toBeFocused();
+        await page.locator("#peaConsole").pressSequentially("Amy\n", {delay: 75});
+        await checkConsoleContent(page, "What is your name?\nAmy\nHello Amy\n");
+        await runButtonShowsRun(button);
+        await checkFrameErrorCount(page, 0);
+    });
+});
+
 test.describe("Test assets filesystem", () => {
     test("Check reading and processing book", async ({page}) => {
         await enterCode(page, ["", "", `

--- a/tests/playwright/e2e/match-statement.spec.ts
+++ b/tests/playwright/e2e/match-statement.spec.ts
@@ -3,6 +3,7 @@ import {readFileSync} from "node:fs";
 import {save, testPlaywrightRoundTripImportAndDownload} from "../support/loading-saving";
 import {setupStrypeTest} from "../support/general";
 import {getDefaultStrypeProjectDocumentationFullLine, getDefaultStrypeProjectImportsFullLine, pressN, waitForEditorSettled} from "../support/editor";
+import {checkConsoleContent, runToFinish} from "../support/execution";
 
 const defaultStandardStrypeProjectDocLiteral = getDefaultStrypeProjectDocumentationFullLine();
 const defaultStrypeProjectImportsLiteral = getDefaultStrypeProjectImportsFullLine();
@@ -31,7 +32,7 @@ print(myString)
 `;
 
 test.beforeEach(async ({ page, browserName }, testInfo) => {
-    await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 240000, skipPyodide: true});
+    await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 240000, skipPyodide: false});
 });
 
 test.describe("Add Match statement", () => {
@@ -403,4 +404,42 @@ print(myString)
 
 test("Round trip", async ({page}) => {
     await testPlaywrightRoundTripImportAndDownload(page, "tests/cypress/fixtures/project-match-statement.spy");
+});
+
+test.describe("Execute match statement", () => {
+    // Check match statement is matched when using the default case
+    // (see previous bug https://github.com/k-pet-group/Strype/issues/978 )
+    test("Use default case", async ({page}) => {
+        await page.keyboard.press("m");
+        await waitForEditorSettled(page);
+        await page.keyboard.type("\"1\"");
+        await waitForEditorSettled(page);
+        // Two arrow right should get us into the default case:
+        await pressN("ArrowRight", 2, true)(page);
+        // Then we must delete the backspace which is there by default:
+        await page.keyboard.press("Delete");
+        await waitForEditorSettled(page);
+        await page.keyboard.type("\"1\"");
+        await waitForEditorSettled(page);
+        // One more arrow right takes us to the body:
+        await page.keyboard.press("ArrowRight");
+        await waitForEditorSettled(page);
+        // Add a print("Matched"):
+        await page.keyboard.type("p\"Matched!\"");
+        // Run it:
+        await runToFinish(page);
+        await checkConsoleContent(page, "Matched!\nHello from Strype\n");
+        // Also check it saves to right form:
+        expect(readFileSync(await save(page, true), "utf-8")).toEqual(`#(=> Strype:1:std
+${defaultStandardStrypeProjectDocLiteral}#(=> Section:Imports
+${defaultStrypeProjectImportsLiteral}#(=> Section:Definitions
+#(=> Section:Main
+match "1"  :
+    case "1"  :
+        print("Matched!") 
+myString  = "Hello from Strype" 
+print(myString) 
+#(=> Section:End
+`);
+    });
 });


### PR DESCRIPTION
This fixes the two bugs @mkolling reported today:
 - The match statement's default case had an error.  The AI pinpointed this as being an issue with having a value for slot index 1 for the default case frame even though there's only one case slot (index 0).  Added a test and a fix for this.
 - The console input bug was already filed as #927 and there was a suggestion in there on how to fix, so that's not been done.  If you stop the program during console input, it's now cleared up properly so that if you re-run you can enter input on the second run.