### PR TITLE
Allow GitHub pages per branch

### DIFF
--- a/.github/workflows/build-pages-test-site.yml
+++ b/.github/workflows/build-pages-test-site.yml
@@ -14,6 +14,8 @@ on:
 #     of the main branch to the root of the site, via GitHub's official Pages deployment.
 #   - true (opt-in, e.g. on a fork): every branch gets its own preview at /<branch>/ within
 #     a shared gh-pages branch, with an index page and pruning of deleted branches' previews.
+# When opting in, also switch Settings > Pages > Source to "Deploy from a branch" and select
+# gh-pages / (root) — that branch doesn't exist until the first run of this workflow creates it.
 permissions:
     contents: write
     pages: write

--- a/.github/workflows/build-pages-test-site.yml
+++ b/.github/workflows/build-pages-test-site.yml
@@ -1,26 +1,28 @@
 name: Deploy to GitHub Pages
 on:
-    # Runs on pushes targeting the default branch
+    # Runs on pushes to any branch except gh-pages (which the branch-preview scheme below
+    # writes to, so triggering on it would cause an infinite loop). Which jobs actually run
+    # is then gated per-job below.
     push:
-        branches: ["main"]    
+        branches-ignore: ["gh-pages"]
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Two schemes are supported, selected by the repository variable PAGES_BRANCH_PREVIEWS
+# (Settings > Secrets and variables > Actions > Variables):
+#   - unset/false (the default, used by the upstream repo): original scheme, one deployment
+#     of the main branch to the root of the site, via GitHub's official Pages deployment.
+#   - true (opt-in, e.g. on a fork): every branch gets its own preview at /<branch>/ within
+#     a shared gh-pages branch, with an index page and pruning of deleted branches' previews.
 permissions:
-    contents: read
+    contents: write
     pages: write
     id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-    group: "pages"
-    cancel-in-progress: false
-
 jobs:
-    # Build job
-    build:
+    # --- Single-deployment scheme (default): main only, replaces the whole site each time ---
+    build-single:
+        if: vars.PAGES_BRANCH_PREVIEWS != 'true' && github.ref_name == 'main'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -46,15 +48,138 @@ jobs:
               uses: actions/upload-pages-artifact@v3
               with:
                   path: dist/
-    
-    # Deployment job
-    deploy:
+
+    deploy-single:
+        if: vars.PAGES_BRANCH_PREVIEWS != 'true' && github.ref_name == 'main'
         environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}
         runs-on: ubuntu-latest
-        needs: build
+        needs: build-single
+        concurrency:
+            group: pages
+            cancel-in-progress: false
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
               uses: actions/deploy-pages@v4
+
+    # --- Branch-preview scheme (opt-in via PAGES_BRANCH_PREVIEWS repo variable) ---
+    # Branch names become URL path segments (Strype/<branch>/), so skip any branch whose name
+    # wouldn't be safe as one (this repo's convention is words and dashes only, so this should
+    # only ever exclude bot branches such as dependabot/renovate).
+    check-branch-name:
+        if: vars.PAGES_BRANCH_PREVIEWS == 'true'
+        runs-on: ubuntu-latest
+        outputs:
+            valid: ${{ steps.check.outputs.valid }}
+        steps:
+            - name: Validate branch name is safe for a URL path segment
+              id: check
+              run: |
+                  if [[ "${{ github.ref_name }}" =~ ^[A-Za-z0-9._-]+$ ]] && [[ "${{ github.ref_name }}" != "gh-pages" ]]; then
+                      echo "valid=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "valid=false" >> "$GITHUB_OUTPUT"
+                      echo "Skipping deploy: branch name '${{ github.ref_name }}' is not a safe URL path segment."
+                  fi
+
+    build:
+        needs: check-branch-name
+        if: vars.PAGES_BRANCH_PREVIEWS == 'true' && needs.check-branch-name.outputs.valid == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+            - name: Install Node.js and NPM
+              uses: volta-cli/action@v4
+            - name: NPM Install
+              run: npm install
+            - name: Cache Pyodide
+              id: cache-pyodide
+              uses: actions/cache@v4
+              with:
+                path: public/pyodide
+                key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json') }}
+            - name: Install Pyodide
+              if: steps.cache-pyodide.outputs.cache-hit != 'true'
+              run: npm run build:download-pyodide-libs
+            - name: NPM Build
+              run: npm run build:github-pages
+              env:
+                  VITE_GITHUB_PAGE_BRANCH: ${{ github.ref_name }}
+            - name: Upload build output
+              uses: actions/upload-artifact@v4
+              with:
+                  name: dist
+                  path: dist/
+
+    deploy:
+        needs: [check-branch-name, build]
+        if: vars.PAGES_BRANCH_PREVIEWS == 'true'
+        runs-on: ubuntu-latest
+        concurrency:
+            group: gh-pages-deploy
+            cancel-in-progress: false
+        steps:
+            - name: Download build output
+              uses: actions/download-artifact@v4
+              with:
+                  name: dist
+                  path: dist
+            - name: Publish branch preview to gh-pages
+              uses: peaceiris/actions-gh-pages@v4
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ./dist
+                  destination_dir: ${{ github.ref_name }}
+                  keep_files: true
+                  user_name: "github-actions[bot]"
+                  user_email: "github-actions[bot]@users.noreply.github.com"
+
+    cleanup:
+        needs: deploy
+        if: vars.PAGES_BRANCH_PREVIEWS == 'true'
+        runs-on: ubuntu-latest
+        concurrency:
+            group: gh-pages-deploy
+            cancel-in-progress: false
+        steps:
+            - name: Checkout gh-pages
+              uses: actions/checkout@v6
+              with:
+                  ref: gh-pages
+            - name: Remove previews for deleted branches and refresh index
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  existing_branches=$(gh api "repos/${{ github.repository }}/branches" --paginate --jq '.[].name')
+
+                  for dir in */; do
+                      name="${dir%/}"
+                      if ! grep -qxF "$name" <<< "$existing_branches"; then
+                          echo "Removing preview for deleted branch: $name"
+                          git rm -rq "$name"
+                      fi
+                  done
+
+                  {
+                      echo "<!doctype html><html><head><title>Strype branch previews</title></head><body>"
+                      echo "<h1>Strype branch previews</h1><ul>"
+                      for dir in */; do
+                          name="${dir%/}"
+                          echo "  <li><a href=\"./${name}/\">${name}</a></li>"
+                      done
+                      echo "</ul></body></html>"
+                  } > index.html
+
+                  git add -A
+                  if git diff --cached --quiet; then
+                      echo "Nothing to clean up."
+                  else
+                      git config user.name "github-actions[bot]"
+                      git config user.email "github-actions[bot]@users.noreply.github.com"
+                      git commit -m "Update branch preview index / remove deleted branches"
+                      git push
+                  fi

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -140,7 +140,7 @@ export default defineConfig(({mode}) => {
         },
 
         base: (process.env.VITE_GITHUB_PAGE)
-            ? "/Strype/"
+            ? (process.env.VITE_GITHUB_PAGE_BRANCH ? `/Strype/${process.env.VITE_GITHUB_PAGE_BRANCH}/` : "/Strype/")
             : ((isStandardPython)
                 ? "/editor/"
                 : "/microbit/"),


### PR DESCRIPTION
Sometimes we want test servers to be able to show something, but before this work, there was only one page per repo (e.g. https://k-pet-group.github.io/Strype/) that came from main, so we couldn't easily have two test servers at once.  This PR allows us to have https://neilccbrown.github.io/Strype/branch1 and https://neilccbrown.github.io/Strype/branch2 both running test sites, for different branches.  You can see already for this work that https://neilccbrown.github.io/Strype/ shows a list of branches for which test sites are available (currently only this branch, but in future would be several.)

It is an opt-in per repository (by changing settings described in the workflow file) so we can leave https://k-pet-group.github.io/Strype/ like it was if we want to, and just enable it on our own repos where we are more likely to have branches we want to test or demonstrate.

If you delete a branch, the next workflow run (which will be on another branch) should then remove it from consideration.  There is a GitHub branch setting that helps with this, in Settings > General: 
<img width="1170" height="232" alt="image" src="https://github.com/user-attachments/assets/41482d7a-01fd-4adb-933e-66626dad07b9" />
If you tick that, merged branches will be auto-deleted, and thus their test sites will also be deleted once you've merged them into main.  (You can also manually delete old branches through GitHub, there's a branches view with all https://github.com/neilccbrown/Strype/branches/all where you can delete them; in general branches which are 0 commits ahead (the number on the right) can usually be deleted because they've been merged in, but obviously decide for yourself!)