### PR TITLE
Copy and download console 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -449,6 +449,17 @@ export default defineComponent({
                 return;
             }
 
+            // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
+            // Handle the keyboard shortcuts for the PEA console copy (when the PEA console is visible).
+            if((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() == "c" && vueComponentsAPIHandler.peaComponentAPI?.getIsConsoleAreaShowing()){
+                vueComponentsAPIHandler.peaComponentAPI?.copyConsoleText(new Event(CustomEventTypes.copyPEAConsoleText));
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                event.stopPropagation();
+                return;            
+            }
+            // #v-endif
+
             // Close the rename identifiers popup on most keys:
             // to simplify the event registration on when we close the popup, we close it on almost all key hits except navigation keys:
             // they will be handled in watch() via the change of frame and we do allow navigation when the popup is showing.

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -36,6 +36,9 @@
                             @wheel.stop
                             @keydown.self.stop="handleKeyEvent"
                             @keyup.self="handleKeyEvent"
+                            @dragstart.prevent
+                            @dragover.prevent
+                            @drop.prevent
                             disabled
                             spellcheck="false"
                         >    

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -26,8 +26,10 @@
                             <canvas id="pythonGraphicsCanvas" ref="pythonGraphicsCanvas" @mousedown.stop="graphicsCanvasMouseDown" @mouseup.stop="graphicsCanvasMouseUp" @mousemove="graphicsCanvasMouseMove" @mouseleave="graphicsCanvasMouseExit"></canvas>
                         </div>
                     </pane>
-                    <pane key="2" v-show="isConsoleAreaShowing" :size="(isTabsLayout) ? 100 : (100 - currentSplitterPane1Size)" min-size="5">
-                        <textarea 
+                    <pane key="2" v-show="isConsoleAreaShowing" :size="(isTabsLayout) ? 100 : (100 - currentSplitterPane1Size)" min-size="5" style="position: relative;">
+                    <div v-if="isConsoleAreaShowing" :class="{'console-copy-btn far fa-copy': true, 'flash-background': copyConsoleTextBtnClicked, hidden: !isTabContentHovered}" 
+                        @click="copyConsoleText" @animationend="copyConsoleTextBtnClicked=false"></div> 
+                    <textarea 
                             :id="pythonConsoleId"
                             ref="pythonConsole"
                             class="pea-console"
@@ -41,6 +43,7 @@
                             @drop.prevent
                             disabled
                             spellcheck="false"
+                            @contextmenu="handleContextMenu"
                         ></textarea>
                     </pane>
                 </Splitpanes>
@@ -72,10 +75,10 @@ import { CoordPosition, defaultEmptyStrypeLayoutDividerSettings, PythonExecRunni
 import { WORLD_HEIGHT, WORLD_WIDTH } from "@/stryperuntime/image_and_collisions";
 import SVGIcon from "@/components/SVGIcon.vue";
 import { Splitpanes, Pane } from "splitpanes";
-import { debounce } from "lodash";
+import { debounce, escape } from "lodash";
 import scssVars from "@/assets/style/_export.module.scss";
 import {getAvailableFilesFromLibrary, getLibraryName, getRawFileFromLibraries} from "@/helpers/libraryManager";
-import { getDateTimeFormatted } from "@/helpers/common";
+import { getDateTimeFormatted, isMacOSPlatform } from "@/helpers/common";
 import { bufferToBase64 } from "@/helpers/media";
 import turtleImgURL from "@/assets/images/turtle.png" ;
 import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
@@ -90,7 +93,7 @@ import {getPythonClient, isPythonWorkerReady, renderer, terminateAndRestartPyodi
 import { TurtlePixiHandler } from "@/stryperuntime/turtle_pixi_handler";
 import {createOrGetAudioContext} from "@/helpers/audioContext";
 import {clearAllRuntimeErrors, computeFrameSnapshot} from "@/helpers/storeMethods";
-
+import html2canvas from "html2canvas";
 
 // Helper to keep indexed tabs (for maintenance if we add some tabs etc)
 const enum PEATabIndexes {graphics, console}
@@ -188,6 +191,7 @@ export default defineComponent({
             downloadWAV: this.downloadWAV,
             overrideGraphics: this.overrideGraphics,
             redrawCanvas: this.redrawCanvas,
+            copyConsoleText: this.copyConsoleText,            
         };
 
         // Expose the Components API handler object on window for Strype.graphics and Strype.sounds 
@@ -221,6 +225,7 @@ export default defineComponent({
             frameContextMenuItems: [] as StrypeContextMenuItem[],
             showContextMenuAtCoordPos: {x: 0, y: 0} as CoordPosition,
             mouseCoordsToShow: undefined as string | undefined,
+            copyConsoleTextBtnClicked: false, // flag used for UI
             graphicsOverride: null as {background: OffscreenCanvas | HTMLImageElement, imageToShowCentered: OffscreenCanvas | HTMLImageElement} | null,
         };
     },
@@ -785,6 +790,26 @@ export default defineComponent({
             const consoleTextarea = this.$refs.pythonConsole as HTMLTextAreaElement;
             consoleTextarea.scrollTop = consoleTextarea.scrollHeight;
         },
+       
+        copyConsoleText(event?: Event): string | undefined {
+            // Show an animation on the copy button, if that was what triggered this action (either clicked on it or via keyboard shortcut)
+            if(event && ( event.type == CustomEventTypes.copyPEAConsoleText || (event.target as HTMLElement).classList.contains("console-copy-btn"))){
+                this.copyConsoleTextBtnClicked = true;
+            }
+
+            // Copy the console text to the clipboard depends on the console context: if the console contains a text selection that's what is copied,
+            // otherwise, the full console content is copied.
+            // The copied content is returned.
+            const pythonConsole = this.$refs.pythonConsole as HTMLTextAreaElement;
+            if(pythonConsole){
+                const isConsoleTextSelected = (pythonConsole.selectionStart != pythonConsole.selectionEnd);
+                const textToCopy = (isConsoleTextSelected) ? pythonConsole.value.substring(pythonConsole.selectionStart, pythonConsole.selectionEnd) : pythonConsole.value;
+                navigator.clipboard.writeText(textToCopy);
+                return textToCopy;
+            }
+
+            return undefined;
+        },
 
         handleKeyEvent(event: KeyboardEvent) {
             // Key events are captured by the UI to navigate the blue cursor and add frames -- for the console, we don't want to propagate the event
@@ -1116,8 +1141,10 @@ export default defineComponent({
         },
 
         handleContextMenu(event: MouseEvent): void {
-            // Do not show any menu if the user's code is being executed
-            if(this.isPythonExecuting){
+            const isContextMenuForGraphics = ((event.target as HTMLElement)?.id ?? "") == "pythonGraphicsCanvas";
+
+            // Do not show any menu if the user's code is being executed and we are using Graphics 
+            if(this.isPythonExecuting && isContextMenuForGraphics){
                 return;
             }
             
@@ -1130,8 +1157,11 @@ export default defineComponent({
             // Overwrite readonly properties clientX and clientY (to position the menu if needed)
             setContextMenuEventClientXY(event);
            
-            // Create the menu content here and open it
-            this.frameContextMenuItems = [{label: this.$t("contextMenu.screenshotGraphics"), onClick: this.screenshotGraphicsArea}];
+            // Create the menu content here and open it (for Graphis: "download screenshot", for the console: "Copy" and "Download")
+            this.frameContextMenuItems = (isContextMenuForGraphics) 
+                ? [{label: this.$t("contextMenu.screenshotPEA"), onClick: this.screenshotGraphicsArea}]
+                : [{label: this.$t("contextMenu.copy"), onClick: this.copyConsoleText, shortcut: `${(isMacOSPlatform()) ? "⌘" : this.$t("contextMenu.ctrl")}+⇧+C`},
+                    {label: this.$t("contextMenu.screenshotPEA") + "...", onClick: this.screenshotConsole}];
             this.showContextMenuAtCoordPos.x = event.x;
             this.showContextMenuAtCoordPos.y = event.y;
             this.showContextMenu = true;
@@ -1159,6 +1189,86 @@ export default defineComponent({
             document.body.removeChild(link);
             // Clean up
             URL.revokeObjectURL(url);
+        },
+
+        async screenshotConsole(): Promise<void> {
+            // The screenshot of the console cannot be directly invoked on the textarea element like we do on the Graphics' canvas.
+            // So instead, we use HTML2Canvas to draw a representation of our textarea, then follow the same logic than Graphics' canvas.
+            // The small tweak is HTML2Canvas can take forever to generate its canvas, because of internal work issues and DOM parsing.
+            // When the textarea content is big, the canvas generation is significantly slow. So to having hanging, we always do the generation
+            // operation outside our editor window (in a separate iframe). We also show the progess bar so it is clear the UI is busy.
+            vueComponentsAPIHandler.appComponentAPI?.applyShowAppProgress({requestAttention: true, message: this.$t("appMessage.downloadPEAConsole")});    
+            const textarea = this.$refs.pythonConsole as HTMLTextAreaElement;
+            const textareaStyle = getComputedStyle(textarea);
+
+            const html2canvasIframe = document.createElement("iframe");
+
+            html2canvasIframe.style.position = "fixed";
+            html2canvasIframe.style.right = `-${textarea.clientWidth + 20}px`; // We offset the iframe by at least it's own width + extra for safety
+            html2canvasIframe.style.top = "0";
+            html2canvasIframe.style.width = `${textarea.clientWidth + 20}px`; // Adapt the iframe to the console size, with extra 20px both dimensions
+            html2canvasIframe.style.height = `${textarea.clientHeight + 20}px`; // Adapt the iframe to the console size, with extra 20px both dimensions
+            html2canvasIframe.style.border = "0";
+
+            document.body.appendChild(html2canvasIframe);
+            const html2canvasIframeDoc = html2canvasIframe.contentDocument;
+            if(html2canvasIframeDoc){
+                // Prepare the content. We need to set the div width in a way we replicate as much as possible the textarea console.
+                // That is, we need to consider the original console width, bar its internal scrollbar.
+                const style = html2canvasIframeDoc.createElement("style");
+                style.textContent = `
+.pea-mirror {
+    color: ${textareaStyle.color};
+    background-color: ${textareaStyle.backgroundColor};
+    width: ${textarea.scrollWidth/* - (textarea.offsetWidth - textarea.clientWidth - parseFloat(textareaStyle.borderLeftWidth.replace("px","")) - parseFloat(textareaStyle.borderLeftWidth.replace("px", "")))*/}px;
+    height: ${textarea.clientHeight}px;
+    padding: ${textareaStyle.padding};
+    margin: ${textareaStyle.margin};
+    overflow-y: hidden;
+    font-family: ${textareaStyle.fontFamily};
+    font-size: ${textareaStyle.fontSize};
+    font-weight: ${textareaStyle.fontWeight};
+    font-style: ${textareaStyle.fontStyle};
+    tab-size: ${textareaStyle.tabSize};
+    line-height: ${textareaStyle.lineHeight};
+    letter-spacing: ${textareaStyle.letterSpacing};
+    letter-spacing: ${textareaStyle.letterSpacing};
+    word-spacing: ${textareaStyle.wordSpacing};
+    white-space: ${textareaStyle.whiteSpace};
+    white-space-collapse: ${textareaStyle.whiteSpaceCollapse};
+    overflow-wrap: ${textareaStyle.overflowWrap};
+    word-break: ${textareaStyle.wordBreak};
+    box-sizing: ${textareaStyle.boxSizing};
+}`;
+
+                html2canvasIframeDoc.head.appendChild(style);
+                // Create the mirror with its text directly within body as a literal HTML string addition,
+                // because using standard Document API (createElement(), appendChild(), etc.) is significantly slower,
+                // even with the necessary HTML-escaping characters transformation.
+                html2canvasIframeDoc.body.innerHTML += `<div id=\"PEAMirror\" class=\"pea-mirror\">${escape(textarea.value)}</div>`;
+                const peaConsoleMirror = html2canvasIframeDoc.querySelector("#PEAMirror") as HTMLDivElement;
+                if(peaConsoleMirror){
+                    peaConsoleMirror.scrollTop = textarea.scrollTop;
+                    const canvas = await html2canvas(peaConsoleMirror as HTMLDivElement);
+                    canvas.toBlob((blob) => {
+                        if(blob){
+                            // Download here
+                            const url = URL.createObjectURL(blob);
+                            const link = document.createElement("a");
+                            link.href = url;
+                            link.download = `strype-${getDateTimeFormatted(new Date(Date.now()))}.png`;
+                            link.click();
+                            
+                            // Clean after ourselves 
+                            URL.revokeObjectURL(url);
+                            document.body.removeChild(html2canvasIframe);
+                           
+                            // Stop the progress bar
+                            vueComponentsAPIHandler.appComponentAPI?.applyShowAppProgress({requestAttention: false});
+                        }    
+                    });
+                }
+            }
         },
         
         downloadWAV(src: AudioBuffer, filenameStem: string) {
@@ -1269,6 +1379,27 @@ export default defineComponent({
 
     .pea-toggle-layout-button.pea-toggle-layout-button-selected {
         color: yellow;
+    }
+
+    .console-copy-btn {
+        position: absolute;
+        color: white;
+        top: $strype-python-exec-area-layout-buttons-pos-offset;
+        right: $strype-python-exec-area-layout-buttons-pos-offset;
+        padding: 3px 3px;
+        border-radius: 5px;
+        background: rgba(69, 68, 68, 0.8);
+    }
+
+    
+    .flash-background {
+        animation: flash-bg-anim 300ms ease-out;
+    }   
+
+    @keyframes flash-bg-anim {
+        0%   { background-color: init; color: init; }
+        50%   { background-color: #c3beae; color: black; }
+        100% { background-color: init; color: init; }
     }
     
     .show-error-icon {

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -41,8 +41,7 @@
                             @drop.prevent
                             disabled
                             spellcheck="false"
-                        >    
-                        </textarea>
+                        ></textarea>
                     </pane>
                 </Splitpanes>
             </div>

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -86,7 +86,8 @@ export enum CustomEventTypes {
     pythonConsoleAfterInput = "pythonConsoleAfterInput",
     notifyGraphicsUsage = "graphicsUsage",
     pythonExecAreaSizeChanged = "peaSizeChanged",
-    highlightPythonRunningState = "highlightPythonRunningState"
+    highlightPythonRunningState = "highlightPythonRunningState",
+    copyPEAConsoleText = "copyPEAConsoleText"
     // #v-endif
 }
 

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -189,7 +189,8 @@
     "renameIdentifiers": "Rename all uses of {thisIdentifierType}?",
     "thisVariable": "this variable",
     "thisFunction": "this function",
-    "thisClass": "this class"
+    "thisClass": "this class",
+    "downloadPEAConsole":"Preparing the console screenshot (this may take time)..."
   },
   "contextMenu": {
     "ctrl": "Ctrl",
@@ -211,7 +212,7 @@
     "delete": "Delete",
     "deleteOuter": "Delete Outer",
     "insert": "Insert",
-    "screenshotGraphics": "Download screenshot",
+    "screenshotPEA": "Download screenshot",
     "collapseHeader": "Collapsed View",
     "collapseDocumentation": "Interface View",
     "collapseFull": "Expanded View",

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -189,7 +189,8 @@
     "thisVariable": "cette variable",
     "thisFunction": "cette fonction",
     "thisClass": "cette classe",
-    "clearAllRecent": "Supprimer tout"
+    "clearAllRecent": "Supprimer tout",
+    "downloadPEAConsole":"Préparation de la capture du terminal (cela peut prendre du temps)..."
   },
   "contextMenu": {
     "ctrl": "Ctrl",
@@ -211,14 +212,15 @@
     "delete": "Supprimer",
     "deleteOuter": "Supprimer externe(s)",
     "insert": "Insérer",
-    "screenshotGraphics": "Télécharger une capture d'écran",
+    "screenshotPEA": "Télécharger une capture d'écran",
     "collapseHeader": "Vue Réduite",
     "collapseDocumentation": "Vue Interface",
     "collapseFull": "Vue Dévelopée",
     "cannotCollapseErrors": "Réduction impossible avec des erreurs",
     "freeze": "Verrouiller",
     "unfreeze": "Déverrouiller",
-    "cannotFreezeErrors": "Verrouillage impossible avec des erreurs"
+    "cannotFreezeErrors": "Verrouillage impossible avec des erreurs",
+    "download": "Télécharger"
   },
   "appMenu": {
     "downloadHex": "Convertir vers Hex",
@@ -267,7 +269,7 @@
     "stopping": "Arrêt...",
     "loading": "Initialisation...",
     "runtimeErrorConsole": "Erreur d'exécution",
-    "console": "Console",
+    "console": "Terminal",
     "Graphics": "Graphics",
     "importTurtleOrGraphics": "Importez 'strype.graphics' ou 'turtle' pour utiliser Graphics",
     "PEA-layout-tabs-collapsed": "Disposition en onglets reduite",
@@ -324,7 +326,7 @@
     "libraryAddrPlaceholder": "Adresse de la bibliothèque",
     "add": "Ajouter",
     "builtinGraphics": "Graphics",
-    "builtinConsole": "Console",
+    "builtinConsole": "Terminal",
     "builtinTurtle": "Turtle",
     "builtinMicrobit": "micro:bit"
   },

--- a/src/types/vue-component-api-types.ts
+++ b/src/types/vue-component-api-types.ts
@@ -162,6 +162,7 @@ export type PEAComponentAPI = {
   downloadWAV: (src: AudioBuffer, filenameStem: string) => void,
   redrawCanvas: () => void,
   overrideGraphics: (background: OffscreenCanvas | HTMLImageElement | null, imageToShowCentered: OffscreenCanvas | HTMLImageElement | null) => void,
+  copyConsoleText: (event?: Event) =>void,
 };
 
 export type MediaPreviewPopupComponentAPI = {


### PR DESCRIPTION
This PR deals with the PEA console, fixing a few issues we had with it's initial state and restricting the drag and drop, and mainly adding some features for copying and downloading the PEA console.

- Copying the console fixes #930: via the context menu on the console or via the small icon-button located at the top-right corner of the console as per the image below. If the a text selection in the console extists, that selection is copied - otherwise the console's full content is copied.
<img width="423" height="392" alt="image" src="https://github.com/user-attachments/assets/605ee4fc-adfa-4a34-8e71-3f21fb22e4bf" /><img width="424" height="392" alt="image" src="https://github.com/user-attachments/assets/9140213d-08db-4aa8-b8a8-bd64d3734286" />

- Downloading the console screenshot: via a context menu (see image above). Note that the download action triggers a progress bar. In most cases, the textarea contains text of a decent length, but when it doesn't, the mechanism to generate the image for the screenshot can be slow (because we need to make a mirror div then a canvas element). 