### PR TITLE
Changes related to "open"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -638,21 +638,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-            "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+            "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
+                "@emnapi/wasi-threads": "1.2.3",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-            "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -661,9 +661,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+            "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1088,9 +1088,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1139,9 +1139,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1189,9 +1189,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1201,7 +1201,7 @@
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.3.0",
                 "minimatch": "^3.1.5",
                 "strip-json-comments": "^3.1.1"
             },
@@ -1220,9 +1220,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1267,9 +1267,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+            "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1480,23 +1480,23 @@
             "license": "MIT"
         },
         "node_modules/@imengyu/vue3-context-menu": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@imengyu/vue3-context-menu/-/vue3-context-menu-1.5.4.tgz",
-            "integrity": "sha512-/a6Quyn3V320/Mi6UoH+6wSTBYrln70RovT3iyfoXQQpIHpC7ZPWObzS0BXQTRlWtyJB92XmGDT703UxSO8Tvg==",
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/@imengyu/vue3-context-menu/-/vue3-context-menu-1.5.6.tgz",
+            "integrity": "sha512-rMsaQZHM3JJP2wKpX4lhmOtWL29h1BjLAv6UcbMU6rc2Lm+t/xtK2eMj3WpC02DroNlWYZr7Dtk1uAS+iwUxPw==",
             "license": "MIT",
             "dependencies": {
                 "@imengyu/vue-scroll-rect": "^0.1.4"
             }
         },
         "node_modules/@intlify/core-base": {
-            "version": "11.4.5",
-            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.5.tgz",
-            "integrity": "sha512-lja3F/iKVIvTa48mIwmrIeDcQUFZ0F0drvFvT8AwINOvbwnAzl/S/p8p2DxILZpWEUHRi1qewfWNIkMvhD3kKA==",
+            "version": "11.4.8",
+            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.4.8.tgz",
+            "integrity": "sha512-A+Q7SKm5oEcy1E/cghqd7n/St4XjTqLhiiyDuieNcMrJcrHlkY5n0jp7Q9dD3txvVHzvsmBVV5M9wD5/s1zfzw==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/devtools-types": "11.4.5",
-                "@intlify/message-compiler": "11.4.5",
-                "@intlify/shared": "11.4.5"
+                "@intlify/devtools-types": "11.4.8",
+                "@intlify/message-compiler": "11.4.8",
+                "@intlify/shared": "11.4.8"
             },
             "engines": {
                 "node": ">= 22"
@@ -1506,13 +1506,13 @@
             }
         },
         "node_modules/@intlify/devtools-types": {
-            "version": "11.4.5",
-            "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.5.tgz",
-            "integrity": "sha512-W5vydP9Yq3t82IyWqCM6aR0BTWCZrN5RAwjZEPpH8I2OQWp2RLy03Evh2ANZlSMhcvGAoyDg25k0so85Kwncpw==",
+            "version": "11.4.8",
+            "resolved": "https://registry.npmjs.org/@intlify/devtools-types/-/devtools-types-11.4.8.tgz",
+            "integrity": "sha512-MGpID+rlfzGUbNcnC20bm5NMSBHPrvx0atLTfv9dftn3kjXw1hGKDcIcwrO99tSrZEc2i+hczRL7ks8qXsHPkQ==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "11.4.5",
-                "@intlify/shared": "11.4.5"
+                "@intlify/core-base": "11.4.8",
+                "@intlify/shared": "11.4.8"
             },
             "engines": {
                 "node": ">= 22"
@@ -1522,12 +1522,12 @@
             }
         },
         "node_modules/@intlify/message-compiler": {
-            "version": "11.4.5",
-            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.5.tgz",
-            "integrity": "sha512-IEOZiHtbQopyPc/Dz2M869lOlZYX1SdcniNJwphATDYHhovvIneEKf1EFF37DE7NAABZtza1FNtnwwqZWInfpw==",
+            "version": "11.4.8",
+            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.4.8.tgz",
+            "integrity": "sha512-vbzk17dYwduYiv52EK61+FDCyhfVg1uPUtPmiD/d45W99uJIcXywrweOBcHv7n9/iEqmXiMGT52bgJbZDQqK3w==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/shared": "11.4.5",
+                "@intlify/shared": "11.4.8",
                 "source-map-js": "^1.0.2"
             },
             "engines": {
@@ -1538,9 +1538,9 @@
             }
         },
         "node_modules/@intlify/shared": {
-            "version": "11.4.5",
-            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.5.tgz",
-            "integrity": "sha512-g/i5mtdUa9ia/8BaJ4w6ZRHgAXYQd9XyCaQPRMvsd8d5qmZwkjoTmHrNsI28Q/7I8h+2ijUkI4uEnnMCziKupQ==",
+            "version": "11.4.8",
+            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.4.8.tgz",
+            "integrity": "sha512-XbRgrv+XEuvDr7UCY55oibVrh+o4u+A0VB6nSL0F5Z8LcZxE/8j573LYG6bCrOigIcHdGpSNI7Rh5UpC5/B/eg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 22"
@@ -1708,9 +1708,9 @@
             }
         },
         "node_modules/@maxim_mazurok/gapi.client.drive-v3": {
-            "version": "0.2.20260602",
-            "resolved": "https://registry.npmjs.org/@maxim_mazurok/gapi.client.drive-v3/-/gapi.client.drive-v3-0.2.20260602.tgz",
-            "integrity": "sha512-BNDVj7gVop5Q4rx0hvAfHxjhACShaQrYB1Zmd8fJeNAszGpLK3zRoggqPGtehdYW3O72fmsHmEsWV89QObuAgw==",
+            "version": "0.3.20260720",
+            "resolved": "https://registry.npmjs.org/@maxim_mazurok/gapi.client.drive-v3/-/gapi.client.drive-v3-0.3.20260720.tgz",
+            "integrity": "sha512-PexiExzULSlZPQSOjIdZByocQMFcGTQg5/AfyQvCgl6MZCtnw6qdBUqzuegvMsKhLgNbOzgJ5Xbtc0W3Tnj56Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1810,9 +1810,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.133.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-            "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
@@ -2021,17 +2021,10 @@
                 "win32"
             ]
         },
-        "node_modules/@package-json/types": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
-            "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@parcel/watcher": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+            "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -2039,7 +2032,7 @@
                 "detect-libc": "^2.0.3",
                 "is-glob": "^4.0.3",
                 "node-addon-api": "^7.0.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -2049,25 +2042,24 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "@parcel/watcher-android-arm64": "2.5.6",
-                "@parcel/watcher-darwin-arm64": "2.5.6",
-                "@parcel/watcher-darwin-x64": "2.5.6",
-                "@parcel/watcher-freebsd-x64": "2.5.6",
-                "@parcel/watcher-linux-arm-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm-musl": "2.5.6",
-                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm64-musl": "2.5.6",
-                "@parcel/watcher-linux-x64-glibc": "2.5.6",
-                "@parcel/watcher-linux-x64-musl": "2.5.6",
-                "@parcel/watcher-win32-arm64": "2.5.6",
-                "@parcel/watcher-win32-ia32": "2.5.6",
-                "@parcel/watcher-win32-x64": "2.5.6"
+                "@parcel/watcher-android-arm64": "2.6.0",
+                "@parcel/watcher-darwin-arm64": "2.6.0",
+                "@parcel/watcher-darwin-x64": "2.6.0",
+                "@parcel/watcher-freebsd-x64": "2.6.0",
+                "@parcel/watcher-linux-arm-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm-musl": "2.6.0",
+                "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm64-musl": "2.6.0",
+                "@parcel/watcher-linux-x64-glibc": "2.6.0",
+                "@parcel/watcher-linux-x64-musl": "2.6.0",
+                "@parcel/watcher-win32-arm64": "2.6.0",
+                "@parcel/watcher-win32-x64": "2.6.0"
             }
         },
         "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+            "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
             "cpu": [
                 "arm64"
             ],
@@ -2085,9 +2077,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+            "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
             "cpu": [
                 "arm64"
             ],
@@ -2105,9 +2097,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+            "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
             "cpu": [
                 "x64"
             ],
@@ -2125,9 +2117,9 @@
             }
         },
         "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+            "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
             "cpu": [
                 "x64"
             ],
@@ -2145,9 +2137,9 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+            "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
             "cpu": [
                 "arm"
             ],
@@ -2168,9 +2160,9 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+            "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
             "cpu": [
                 "arm"
             ],
@@ -2191,9 +2183,9 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+            "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
             "cpu": [
                 "arm64"
             ],
@@ -2214,9 +2206,9 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+            "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
             "cpu": [
                 "arm64"
             ],
@@ -2237,9 +2229,9 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+            "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
             "cpu": [
                 "x64"
             ],
@@ -2260,9 +2252,9 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+            "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
             "cpu": [
                 "x64"
             ],
@@ -2283,9 +2275,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+            "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2302,30 +2294,10 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
         "node_modules/@parcel/watcher-win32-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+            "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
             "cpu": [
                 "x64"
             ],
@@ -2888,19 +2860,19 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+            "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.60.0"
+                "playwright": "1.62.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/@popperjs/core": {
@@ -2914,9 +2886,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-            "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2930,9 +2902,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-            "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
@@ -2946,9 +2918,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-            "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
@@ -2962,9 +2934,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-            "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
@@ -2978,9 +2950,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-            "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
@@ -2994,9 +2966,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-            "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3013,9 +2985,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-            "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
             ],
@@ -3032,9 +3004,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-            "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
             ],
@@ -3051,9 +3023,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-            "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
             ],
@@ -3070,9 +3042,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-            "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
             ],
@@ -3089,9 +3061,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-            "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
             ],
@@ -3108,9 +3080,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-            "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -3124,38 +3096,38 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-            "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
+                "@emnapi/core": "1.11.1",
+                "@emnapi/runtime": "1.11.1",
+                "@napi-rs/wasm-runtime": "^1.1.6"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
+                "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3163,9 +3135,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3173,13 +3145,13 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-            "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tybys/wasm-util": "^0.10.2"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
@@ -3191,9 +3163,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-            "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
@@ -3207,9 +3179,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-            "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
@@ -3406,9 +3378,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3599,9 +3571,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.19.21",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-            "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
@@ -3894,17 +3866,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
-            "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.61.0",
-                "@typescript-eslint/type-utils": "8.61.0",
-                "@typescript-eslint/utils": "8.61.0",
-                "@typescript-eslint/visitor-keys": "8.61.0",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/type-utils": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -3917,22 +3889,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.61.0",
+                "@typescript-eslint/parser": "^8.65.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
-            "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.61.0",
-                "@typescript-eslint/types": "8.61.0",
-                "@typescript-eslint/typescript-estree": "8.61.0",
-                "@typescript-eslint/visitor-keys": "8.61.0",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3948,14 +3920,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-            "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.61.0",
-                "@typescript-eslint/types": "^8.61.0",
+                "@typescript-eslint/tsconfig-utils": "^8.65.0",
+                "@typescript-eslint/types": "^8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3970,14 +3942,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-            "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.61.0",
-                "@typescript-eslint/visitor-keys": "8.61.0"
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3988,9 +3960,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-            "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4005,15 +3977,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
-            "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.61.0",
-                "@typescript-eslint/typescript-estree": "8.61.0",
-                "@typescript-eslint/utils": "8.61.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -4030,9 +4002,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-            "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4044,16 +4016,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-            "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.61.0",
-                "@typescript-eslint/tsconfig-utils": "8.61.0",
-                "@typescript-eslint/types": "8.61.0",
-                "@typescript-eslint/visitor-keys": "8.61.0",
+                "@typescript-eslint/project-service": "8.65.0",
+                "@typescript-eslint/tsconfig-utils": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -4072,16 +4044,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
-            "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.61.0",
-                "@typescript-eslint/types": "8.61.0",
-                "@typescript-eslint/typescript-estree": "8.61.0"
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4096,13 +4068,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-            "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.61.0",
+                "@typescript-eslint/types": "8.65.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -4462,14 +4434,14 @@
             }
         },
         "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-            "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+            "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tybys/wasm-util": "^0.10.2"
+                "@tybys/wasm-util": "^0.10.3"
             },
             "funding": {
                 "type": "github",
@@ -4523,9 +4495,9 @@
             ]
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "6.0.7",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
-            "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
+            "version": "6.0.8",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+            "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
             "license": "MIT",
             "dependencies": {
                 "@rolldown/pluginutils": "^1.0.1"
@@ -4568,9 +4540,9 @@
             }
         },
         "node_modules/@vue/compat": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/compat/-/compat-3.5.38.tgz",
-            "integrity": "sha512-MiV5OPkT2Qgorfs5BkvVZmvk6y7SMlYkycOGqElMQ8KsWVuSW0CTgTPdGJW53rnKo7JBoyDZcZRraDscqmUXnA==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compat/-/compat-3.5.40.tgz",
+            "integrity": "sha512-VajKNXf4Z6KdeGcuhKzoZmIsji/kZTt675yZlo7vY+sc82G16nSXYyN4uGfexsV5UOvTpHnHSfaLjBpT4++MFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4580,75 +4552,75 @@
                 "source-map-js": "^1.2.1"
             },
             "peerDependencies": {
-                "vue": "3.5.38"
+                "vue": "3.5.40"
             }
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
-            "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.40.tgz",
+            "integrity": "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.7",
-                "@vue/shared": "3.5.38",
+                "@vue/shared": "3.5.40",
                 "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
-            "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.40.tgz",
+            "integrity": "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.38",
-                "@vue/shared": "3.5.38"
+                "@vue/compiler-core": "3.5.40",
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
-            "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
+            "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.7",
-                "@vue/compiler-core": "3.5.38",
-                "@vue/compiler-dom": "3.5.38",
-                "@vue/compiler-ssr": "3.5.38",
-                "@vue/shared": "3.5.38",
+                "@vue/compiler-core": "3.5.40",
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/compiler-ssr": "3.5.40",
+                "@vue/shared": "3.5.40",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
-                "postcss": "^8.5.15",
+                "postcss": "^8.5.19",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
-            "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.40.tgz",
+            "integrity": "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.38",
-                "@vue/shared": "3.5.38"
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/devtools-api": {
-            "version": "7.7.9",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
-            "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+            "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^7.7.9"
+                "@vue/devtools-kit": "^7.7.10"
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "7.7.9",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
-            "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+            "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-shared": "^7.7.9",
+                "@vue/devtools-shared": "^7.7.10",
                 "birpc": "^2.3.0",
                 "hookable": "^5.5.3",
                 "mitt": "^3.0.1",
@@ -4658,9 +4630,9 @@
             }
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "7.7.9",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
-            "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+            "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
             "license": "MIT",
             "dependencies": {
                 "rfdc": "^1.4.1"
@@ -4686,69 +4658,67 @@
             }
         },
         "node_modules/@vue/language-core": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.4.tgz",
-            "integrity": "sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.8.tgz",
+            "integrity": "sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.28",
                 "@vue/compiler-dom": "^3.5.0",
                 "@vue/shared": "^3.5.0",
-                "alien-signals": "^3.2.0",
+                "alien-signals": "^3.2.1",
                 "muggle-string": "^0.4.1",
                 "path-browserify": "^1.0.1",
                 "picomatch": "^4.0.4"
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
-            "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+            "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.38"
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
-            "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.40.tgz",
+            "integrity": "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.38",
-                "@vue/shared": "3.5.38"
+                "@vue/reactivity": "3.5.40",
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
-            "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.40.tgz",
+            "integrity": "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.38",
-                "@vue/runtime-core": "3.5.38",
-                "@vue/shared": "3.5.38",
+                "@vue/reactivity": "3.5.40",
+                "@vue/runtime-core": "3.5.40",
+                "@vue/shared": "3.5.40",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
-            "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+            "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.38",
-                "@vue/shared": "3.5.38"
-            },
-            "peerDependencies": {
-                "vue": "3.5.38"
+                "@vue/compiler-ssr": "3.5.40",
+                "@vue/runtime-dom": "3.5.40",
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
-            "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+            "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
             "license": "MIT"
         },
         "node_modules/@wsfe/vue-tree": {
@@ -5469,9 +5439,9 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-            "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+            "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5493,25 +5463,12 @@
                 }
             }
         },
-        "node_modules/bare-os": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "bare": ">=1.14.0"
-            }
-        },
         "node_modules/bare-path": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-            "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+            "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
             "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "bare-os": "^3.0.1"
-            }
+            "license": "Apache-2.0"
         },
         "node_modules/bare-stream": {
             "version": "2.13.3",
@@ -5542,9 +5499,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.4.5",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
-            "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+            "version": "2.4.6",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+            "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5614,9 +5571,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.36",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
-            "integrity": "sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==",
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
+            "integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -5841,16 +5798,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -5866,9 +5823,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
             "dev": true,
             "funding": [
                 {
@@ -5887,10 +5844,10 @@
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -6051,9 +6008,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001799",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "dev": true,
             "funding": [
                 {
@@ -6220,9 +6177,9 @@
             }
         },
         "node_modules/cheerio/node_modules/undici": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-            "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
@@ -6693,15 +6650,15 @@
             "license": "MIT"
         },
         "node_modules/concurrently": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-            "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+            "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+            "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "4.1.2",
                 "rxjs": "7.8.2",
-                "shell-quote": "1.8.3",
+                "shell-quote": "1.9.0",
                 "supports-color": "8.1.1",
                 "tree-kill": "1.2.2",
                 "yargs": "17.7.2"
@@ -7116,9 +7073,9 @@
             }
         },
         "node_modules/cypress-split": {
-            "version": "1.24.31",
-            "resolved": "https://registry.npmjs.org/cypress-split/-/cypress-split-1.24.31.tgz",
-            "integrity": "sha512-hDXoIQSFmpa+0hPEgRE22k027vlwd5aJlrPoB1owqWwsvoR2ab4GspPtvlTA2FwA4YbHMbhC6vbkiJC6DId4aQ==",
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/cypress-split/-/cypress-split-1.25.0.tgz",
+            "integrity": "sha512-/K8qQz3yeSc5GyHFyqJC6ipz3S47kwtFu7WfuZ+uSAjtfNlCxTBlPV5CTTn0v39zjWEVqrfpu2arZuzZegu/9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7827,9 +7784,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.372",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
-            "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+            "version": "1.5.396",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+            "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
             "dev": true,
             "license": "ISC",
             "peer": true
@@ -7865,9 +7822,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-            "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+            "version": "5.24.3",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+            "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8079,9 +8036,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+            "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8090,8 +8047,8 @@
                 "@eslint/config-array": "^0.21.2",
                 "@eslint/config-helpers": "^0.4.2",
                 "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.5",
-                "@eslint/js": "9.39.4",
+                "@eslint/eslintrc": "^3.3.6",
+                "@eslint/js": "9.39.5",
                 "@eslint/plugin-kit": "^0.4.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -8218,13 +8175,12 @@
             }
         },
         "node_modules/eslint-plugin-import-x": {
-            "version": "4.16.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
-            "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
+            "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@package-json/types": "^0.0.12",
                 "@typescript-eslint/types": "^8.56.0",
                 "comment-parser": "^1.4.1",
                 "debug": "^4.4.1",
@@ -8335,18 +8291,18 @@
             }
         },
         "node_modules/eslint-plugin-vue": {
-            "version": "10.9.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.2.tgz",
-            "integrity": "sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==",
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.10.0.tgz",
+            "integrity": "sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
+                "@eslint-community/eslint-utils": "^4.9.1",
                 "natural-compare": "^1.4.0",
                 "nth-check": "^2.1.1",
-                "postcss-selector-parser": "^7.1.0",
-                "semver": "^7.6.3",
-                "xml-name-validator": "^4.0.0"
+                "postcss-selector-parser": "^7.1.4",
+                "semver": "^7.8.5",
+                "xml-name-validator": "^5.0.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8404,9 +8360,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8628,9 +8584,9 @@
             }
         },
         "node_modules/exsolve": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-            "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+            "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
             "dev": true,
             "license": "MIT"
         },
@@ -8762,9 +8718,9 @@
             "license": "MIT"
         },
         "node_modules/fast-shuffle": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/fast-shuffle/-/fast-shuffle-6.2.0.tgz",
-            "integrity": "sha512-Y7MexltTgkdI2UzeRx7zVIWiHSuQ41dD+2PPwukkIZW2b1wCSaciISyKNSKFVW6ImkH+QQivlDsmY552EO22Ig==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/fast-shuffle/-/fast-shuffle-6.2.1.tgz",
+            "integrity": "sha512-a5xCB8x4LI0VhqRf6nFYO4H4tdalIywqzVU8xc3CoZ0xF8exohNIz12ugArWF2Zm9juXHWTbwt7t4fZgRk/TkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8775,9 +8731,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "dev": true,
             "funding": [
                 {
@@ -9061,9 +9017,9 @@
             "license": "MIT"
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -9154,16 +9110,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -9428,9 +9384,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9773,9 +9729,9 @@
             }
         },
         "node_modules/humanize-duration": {
-            "version": "3.33.2",
-            "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.33.2.tgz",
-            "integrity": "sha512-K7Ny/ULO1hDm2nnhvAY+SJV1skxFb61fd073SG1IWJl+D44ULrruCuTyjHKjBVVcSuTlnY99DKtgEG39CM5QOQ==",
+            "version": "3.34.0",
+            "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.34.0.tgz",
+            "integrity": "sha512-NDxhYxiiRzsST6xULIHuYWRvsCtviJXRdjarhyWyh78S4Ou+MWhM2k4HQ+y7iegdrzreXe11isd0au1N2PB/pQ==",
             "dev": true,
             "license": "Unlicense",
             "funding": {
@@ -9832,9 +9788,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9842,9 +9798,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-            "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -10602,9 +10558,9 @@
             }
         },
         "node_modules/joi": {
-            "version": "18.2.1",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
-            "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+            "version": "18.2.3",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+            "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -10637,9 +10593,9 @@
             "license": "MIT"
         },
         "node_modules/js-base64": {
-            "version": "3.7.8",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-            "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
+            "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/js-tokens": {
@@ -10650,9 +10606,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {
@@ -10885,9 +10841,9 @@
             }
         },
         "node_modules/lightningcss": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
             "license": "MPL-2.0",
             "dependencies": {
                 "detect-libc": "^2.0.3"
@@ -10900,23 +10856,23 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "lightningcss-android-arm64": "1.32.0",
-                "lightningcss-darwin-arm64": "1.32.0",
-                "lightningcss-darwin-x64": "1.32.0",
-                "lightningcss-freebsd-x64": "1.32.0",
-                "lightningcss-linux-arm-gnueabihf": "1.32.0",
-                "lightningcss-linux-arm64-gnu": "1.32.0",
-                "lightningcss-linux-arm64-musl": "1.32.0",
-                "lightningcss-linux-x64-gnu": "1.32.0",
-                "lightningcss-linux-x64-musl": "1.32.0",
-                "lightningcss-win32-arm64-msvc": "1.32.0",
-                "lightningcss-win32-x64-msvc": "1.32.0"
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
             }
         },
         "node_modules/lightningcss-android-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
             "cpu": [
                 "arm64"
             ],
@@ -10934,9 +10890,9 @@
             }
         },
         "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
             "cpu": [
                 "arm64"
             ],
@@ -10954,9 +10910,9 @@
             }
         },
         "node_modules/lightningcss-darwin-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
             "cpu": [
                 "x64"
             ],
@@ -10974,9 +10930,9 @@
             }
         },
         "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
             "cpu": [
                 "x64"
             ],
@@ -10994,9 +10950,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
             "cpu": [
                 "arm"
             ],
@@ -11014,9 +10970,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
             "cpu": [
                 "arm64"
             ],
@@ -11037,9 +10993,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
                 "arm64"
             ],
@@ -11060,9 +11016,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
             "cpu": [
                 "x64"
             ],
@@ -11083,9 +11039,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
             "cpu": [
                 "x64"
             ],
@@ -11106,9 +11062,9 @@
             }
         },
         "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
             "cpu": [
                 "arm64"
             ],
@@ -11126,9 +11082,9 @@
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
             "cpu": [
                 "x64"
             ],
@@ -11789,9 +11745,9 @@
             "license": "MIT"
         },
         "node_modules/multimatch/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11823,9 +11779,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -11904,9 +11860,9 @@
             "optional": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.47",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -12130,9 +12086,9 @@
             }
         },
         "node_modules/obug": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
-            "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
@@ -12310,9 +12266,19 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/pako": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+            "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "(MIT AND Zlib)"
         },
         "node_modules/parent-module": {
@@ -12561,9 +12527,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -12835,35 +12801,35 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+            "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.60.0"
+                "playwright-core": "1.62.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "optionalDependencies": {
                 "fsevents": "2.3.2"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+            "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/please-upgrade-node": {
@@ -12913,9 +12879,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -12932,7 +12898,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -13345,9 +13311,9 @@
             "license": "MIT"
         },
         "node_modules/readdir-glob/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13669,12 +13635,12 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-            "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.133.0",
+                "@oxc-project/types": "=0.139.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -13684,21 +13650,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.3",
-                "@rolldown/binding-darwin-arm64": "1.0.3",
-                "@rolldown/binding-darwin-x64": "1.0.3",
-                "@rolldown/binding-freebsd-x64": "1.0.3",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-                "@rolldown/binding-linux-arm64-musl": "1.0.3",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-                "@rolldown/binding-linux-x64-gnu": "1.0.3",
-                "@rolldown/binding-linux-x64-musl": "1.0.3",
-                "@rolldown/binding-openharmony-arm64": "1.0.3",
-                "@rolldown/binding-wasm32-wasi": "1.0.3",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-                "@rolldown/binding-win32-x64-msvc": "1.0.3"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/run-parallel": {
@@ -13791,9 +13757,9 @@
             "license": "MIT"
         },
         "node_modules/sass": {
-            "version": "1.101.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
-            "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
+            "version": "1.102.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
+            "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -13852,9 +13818,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -13921,9 +13887,9 @@
             "license": "MIT"
         },
         "node_modules/serve-handler/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14118,9 +14084,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+            "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -14765,9 +14731,9 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.27.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
-            "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+            "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14988,9 +14954,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -15372,9 +15338,9 @@
             "license": "MIT"
         },
         "node_modules/ts-node-dev/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -15568,9 +15534,9 @@
             "license": "0BSD"
         },
         "node_modules/tsx": {
-            "version": "4.22.4",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-            "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+            "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -15724,9 +15690,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-            "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -15853,14 +15819,14 @@
             }
         },
         "node_modules/unplugin-utils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
-            "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+            "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "pathe": "^2.0.3",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -16158,15 +16124,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.16",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.15",
-                "rolldown": "1.0.3",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -16183,7 +16149,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
+                "@vitejs/devtools": "^0.3.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -16431,9 +16397,9 @@
             }
         },
         "node_modules/vite-plugin-static-copy/node_modules/p-map": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+            "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -16491,16 +16457,16 @@
             "license": "MIT"
         },
         "node_modules/vue": {
-            "version": "3.5.38",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
-            "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
+            "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.38",
-                "@vue/compiler-sfc": "3.5.38",
-                "@vue/runtime-dom": "3.5.38",
-                "@vue/server-renderer": "3.5.38",
-                "@vue/shared": "3.5.38"
+                "@vue/compiler-dom": "3.5.40",
+                "@vue/compiler-sfc": "3.5.40",
+                "@vue/runtime-dom": "3.5.40",
+                "@vue/server-renderer": "3.5.40",
+                "@vue/shared": "3.5.40"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -16567,14 +16533,14 @@
             }
         },
         "node_modules/vue-i18n": {
-            "version": "11.4.5",
-            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.5.tgz",
-            "integrity": "sha512-rm8YJ6RpjOrkcgS2GLrZwLvs/VbhxbTSuEspbyXDo233+fPK0OMFNLOj3fdQYVKdOgcpSfLW91JhbqgpkkcBWA==",
+            "version": "11.4.8",
+            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.4.8.tgz",
+            "integrity": "sha512-0ULeHP6Z9CGvAm67S77ZEp41cfGXIREGL8qfhos2BMgcQQewtQcDKuojt6jjasAD/S8GwfTp2ySPmDSpwvrCMQ==",
             "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "11.4.5",
-                "@intlify/devtools-types": "11.4.5",
-                "@intlify/shared": "11.4.5",
+                "@intlify/core-base": "11.4.8",
+                "@intlify/devtools-types": "11.4.8",
+                "@intlify/shared": "11.4.8",
                 "@vue/devtools-api": "^6.5.0"
             },
             "engines": {
@@ -16594,14 +16560,14 @@
             "license": "MIT"
         },
         "node_modules/vue-tsc": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.4.tgz",
-            "integrity": "sha512-XA/JqmQwS2GZmfgpjOEGdrKwaTSEuPwxpHa7/t6f4yiGrJb3gVHTPb9wBfByMNZwQ+xDXs41b8gaS2DKsOozUw==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.8.tgz",
+            "integrity": "sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/typescript": "2.4.28",
-                "@vue/language-core": "3.3.4"
+                "@vue/language-core": "3.3.8"
             },
             "bin": {
                 "vue-tsc": "bin/vue-tsc.js"
@@ -16649,9 +16615,9 @@
             }
         },
         "node_modules/wait-on/node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17032,9 +16998,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -17053,13 +17019,13 @@
             }
         },
         "node_modules/xml-name-validator": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-            "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/xtend": {
@@ -17085,6 +17051,22 @@
             "dev": true,
             "license": "ISC",
             "peer": true
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "extraneous": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
         },
         "node_modules/yargs": {
             "version": "15.4.1",

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -37,6 +37,7 @@
                             <span>{{ $t("appMessage.targetFS") }}</span>
                         </div>
                     </div>
+                    <div><a class="open-menu-embedded-proj-link" @click="onOpenMenuLinkClick('examples')">{{$t("appMenu.loadDemoProject")}}</a><a class="open-menu-embedded-proj-link" @click="onOpenMenuLinkClick('book')">{{$t("appMenu.book")}}</a></div>
                     <div class="recent-states-pane" v-if="recentLoadableStates && recentLoadableStates.length > 0">
                         <div class="d-flex justify-content-between align-items-baseline">
                             <span class="load-save-label">{{ $t("appMessage.loadRecentState") }}</span>
@@ -876,6 +877,18 @@ export default defineComponent({
             // The new UI (changing combobox to buttons) means we can't directly check the HTML component to get the selection (unless using CSS).
             // Instead, we use the temp flag we've added in this Menu component, or the value for Google Drive (default) is no changed has been made.
             return (this.tempSyncTarget != StrypeSyncTarget.none) ? this.tempSyncTarget : StrypeSyncTarget.gd;
+        },
+
+        onOpenMenuLinkClick(target: "examples" | "book"): void {
+            // When a link from the menu is clicked, we need to close the "Open" dialog (as cancelled), 
+            // and open the selected link target's dialog.
+            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "cancel", componentId: this.loadProjectModalDlgId});
+            if(target === "examples"){
+                this.openLoadDemoProjectModal();
+            }
+            else{
+                this.openBookModal();
+            };
         },
 
         onSaveTargetChanged(){
@@ -1758,6 +1771,16 @@ export default defineComponent({
     cursor: pointer;
 }
 
+.open-menu-embedded-proj-link{
+    font-size: smaller;
+    cursor: pointer;
+}
+
+div:has(> a.open-menu-embedded-proj-link) {
+    display: flex;
+    gap: 8px;
+}
+
 .save-project-modal-dlg-container {
     display: table;
     border-spacing: 10px 10px;
@@ -2016,5 +2039,4 @@ export default defineComponent({
     color: #aaa;
     padding-left: 3rem;
 }
-
 </style>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -531,7 +531,8 @@ export default defineComponent({
         },
 
         loadProjectKBShortcut(): string {
-            return `${(isMacOSPlatform()) ? "⌘" : (this.$t("contextMenu.ctrl")+"+")}O`;
+            const {isSafari} = useBrowserDetect();
+            return `${(isMacOSPlatform() ? "⌘" : this.$t("contextMenu.ctrl"))+"+"+(isSafari ? "⇧+ " : "")}O`;
         },
         
         loadProjectModalDlgId(): string {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -532,7 +532,7 @@ export default defineComponent({
 
         loadProjectKBShortcut(): string {
             const {isSafari} = useBrowserDetect();
-            return `${(isMacOSPlatform() ? "⌘" : this.$t("contextMenu.ctrl"))+"+"+(isSafari ? "⇧+ " : "")}O`;
+            return `${(isMacOSPlatform() ? "⌘" : this.$t("contextMenu.ctrl")+"+")+(isSafari ? "⇧" : "")}O`;
         },
         
         loadProjectModalDlgId(): string {
@@ -592,7 +592,8 @@ export default defineComponent({
         },
 
         shareProjectKBShortcut(): string {
-            return `${(isMacOSPlatform()) ? "⌘" : (this.$t("contextMenu.ctrl")+"+")}⇧+L`;
+            const isMacos = isMacOSPlatform();
+            return `${(isMacos) ? "⌘" : (this.$t("contextMenu.ctrl")+"+")}⇧${isMacos ? "" : "+"}L`;
         },
 
         shareProjectModalDlgId(): string {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -269,6 +269,7 @@ import { eventBus, getLocaleBuildDate } from "@/helpers/appContext";
 import {checkForRecentSaveStates, deleteStates} from "@/store/store-db-storage";
 import OpenBookDlg from "@/components/OpenBookDlg.vue";
 import {trackUsedBookProject} from "@/store/analytics";
+import { useBrowserDetect } from "vue3-detect-browser";
 
 //////////////////////
 //     Component    //
@@ -390,8 +391,20 @@ export default defineComponent({
         window.addEventListener(
             "keydown",
             (event: KeyboardEvent) => {
-                // Loading/saving project shortcuts
-                if((event.key.toLowerCase() === "s" || event.key.toLowerCase() === "o") && (event.metaKey || event.ctrlKey) && (!event.shiftKey)){
+                // Loading/saving project shortcuts.
+                // The control for the shortcuts is a bit awkward to preserve a tight check on the browsers: for Safari, ⌘+O is interecepted
+                // by the browser so we cannot rely on this shortcut to open a Strype project. However, ctrl+O works, but is not trivial for macOS.
+                // Therefore for Safari, we use ⌘+⇧+O to open a project (while still supportting ctrl+O), ⌘+S to save a project (but silently supports
+                // ⌘+⇧+S too for muscle memory).
+                // For other browsers: we are restricting to ctrl+O and ctrl+S as expected (explicitly discarding ⇧ to keep not override existing browser shortcuts).
+                const {isSafari} = useBrowserDetect();
+                const lowCaseEventKey = event.key.toLowerCase();
+                const isOpeningOrSavingShortcut = (lowCaseEventKey === "s" || lowCaseEventKey === "o") 
+                    && ((isSafari)
+                        ? event.metaKey && (lowCaseEventKey === "s" || (lowCaseEventKey === "o" && event.shiftKey))
+                        : (event.metaKey || event.ctrlKey) && !event.shiftKey
+                    );
+                if(isOpeningOrSavingShortcut){
                     event.stopImmediatePropagation();
                     event.preventDefault();
                     if(this.isPythonRunning){

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -1195,7 +1195,7 @@ export default defineComponent({
             // Create the menu content here and open it (for Graphis: "download screenshot", for the console: "Copy" and "Download")
             this.frameContextMenuItems = (isContextMenuForGraphics) 
                 ? [{label: this.$t("contextMenu.screenshotPEA"), onClick: this.screenshotGraphicsArea}]
-                : [{label: this.$t("contextMenu.copy"), onClick: this.copyConsoleText, shortcut: `${(isMacOSPlatform()) ? "⌘" : this.$t("contextMenu.ctrl")}+⇧+C`},
+                : [{label: this.$t("contextMenu.copy"), onClick: this.copyConsoleText, shortcut: `${(isMacOSPlatform()) ? "⌘" : (this.$t("contextMenu.ctrl")+"+")}⇧${isMacOSPlatform() ? "" : "+"}C`},
                     {label: this.$t("contextMenu.screenshotPEA") + "...", onClick: this.screenshotConsole}];
             this.showContextMenuAtCoordPos.x = event.x;
             this.showContextMenuAtCoordPos.y = event.y;


### PR DESCRIPTION
This PR contains 2 parts related to "Open"
- added links to the books and examples dialogs within the Open dialog (this was mainly to facilitate their discovery by new Strype users)
- added support for ⌘+⇧+O for opening projects with Safari (#975) - now for Safari, we want to explicitly support that shortcut for opening projects, explicitly keep ⌘+S to save project but implicitly support ⌘+⇧+S to save projects as well. For other browsers, the previous behaviour should be the same as before.