### PR TITLE
Fix CI hangs: cache browser detection instead of recomputing on every keystroke

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -275,6 +275,9 @@ import { useBrowserDetect } from "vue3-detect-browser";
 //     Component    //
 //////////////////////
 const defaultSharingProjectMode = ShareProjectMode.public;
+// The browser doesn't change during a session, so we detect it once here rather than calling
+// useBrowserDetect() (which allocates a new reactive object) on every keydown event.
+const { isSafari } = useBrowserDetect();
 export default defineComponent({
     name: "Menu",
     
@@ -397,7 +400,6 @@ export default defineComponent({
                 // Therefore for Safari, we use ⌘+⇧+O to open a project (while still supportting ctrl+O), ⌘+S to save a project (but silently supports
                 // ⌘+⇧+S too for muscle memory).
                 // For other browsers: we are restricting to ctrl+O and ctrl+S as expected (explicitly discarding ⇧ to keep not override existing browser shortcuts).
-                const {isSafari} = useBrowserDetect();
                 const lowCaseEventKey = event.key.toLowerCase();
                 const isOpeningOrSavingShortcut = (lowCaseEventKey === "s" || lowCaseEventKey === "o") 
                     && ((isSafari)
@@ -531,7 +533,6 @@ export default defineComponent({
         },
 
         loadProjectKBShortcut(): string {
-            const {isSafari} = useBrowserDetect();
             return `${(isMacOSPlatform() ? "⌘" : this.$t("contextMenu.ctrl")+"+")+(isSafari ? "⇧" : "")}O`;
         },
         


### PR DESCRIPTION
## Summary

PR #987 (open-additions) added a global `window` keydown handler in `Menu.vue` that calls `useBrowserDetect()` from the new `vue3-detect-browser` dependency on every keystroke, anywhere in the app. That composable allocates a fresh Vue `reactive()` object and re-parses `navigator.userAgent` on every single call.

Since Strype is a code editor, this is an extremely hot path — every character typed in any test now pays that cost. In CI this was enough to blow the 2-hour hard timeout across the whole Playwright browser/OS matrix (all jobs failing/cancelled, with essentially every single test individually timing out through its retries), and to substantially slow down the Cypress suite too.

This shows up on every recent PR/push run since the merge (`2a45cca7` onward), because they're all built on top of a `main` that already carries the regression — not because those PRs introduced anything new.

## Fix

The detected browser can't change during a page session, so compute it once at module load and reuse that value, instead of calling `useBrowserDetect()` inside the keydown handler and in the `loadProjectKBShortcut` computed getter.

## Test plan

- [x] `npm run type:check` passes
- [x] `npm run lint:check` passes
- [x] Manually verified in a running dev server: app loads with no new console errors/warnings, typing works, and Ctrl+O still correctly triggers the "unsaved changes" / load-project flow in Chrome
- [ ] CI should show the Playwright matrix completing within its normal time budget again

🤖 Generated with [Claude Code](https://claude.com/claude-code)