### PR TITLE
UI improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strype-editor",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strype-editor",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "dependencies": {
         "@azure/msal-browser": "^4.15.0",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "strype-editor",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "private": true,
     "scripts": {
         "serve:microbit": "cross-env STRYPE_PLATFORM=microbit vite --port 8081",

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -76,9 +76,9 @@
                                                         class="frame-cmd-container text-editing-command"
                                                     >
                                                         <span class="text-editing-command-keys">
-                                                            <template v-for="(key, keyIndex) in mediaRecordingCommand.keys" :key="key">
+                                                            <template v-for="(key, keyIndex) in mediaRecordingCommand.keys" :key="key.label">
                                                                 <span v-if="keyIndex > 0" class="text-editing-command-keys-plus">+</span>
-                                                                <button class="frame-cmd-btn frame-cmd-btn-large">{{ key }}</button>
+                                                                <button class="frame-cmd-btn frame-cmd-btn-large" :title="key.title">{{ key.label }}</button>
                                                             </template>
                                                         </span>
                                                         <span>{{ mediaRecordingCommand.description }}</span>
@@ -364,7 +364,7 @@ export default defineComponent({
         // Ctrl-Shift-I/U opens a dialog to record a new image/sound literal from the webcam/
         // microphone. We show those shortcuts here as a hint, mirroring the same gating
         // LabelSlot.vue's onKeyDown uses for the shortcut itself.
-        mediaRecordingCommands(): {keys: string[]; description: string}[] {
+        mediaRecordingCommands(): {keys: ({label: string, title?: string})[]; description: string}[] {
             const focusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
             if(!this.appStore.isEditing || !focusSlotCursorInfos){
                 return [];
@@ -376,11 +376,11 @@ export default defineComponent({
                 return [];
             }
 
-            const ctrl = this.$t("contextMenu.ctrl");
-            const shift = this.$t("autoCompletion.shiftKey");
+            const ctrl = {label: this.$t("contextMenu.ctrl")};
+            const shift = {label: "⇧", title: this.$t("autoCompletion.shiftKey")};
             return [
-                {keys: [ctrl, shift, "I"], description: this.$t("autoCompletion.recordImageShortcut")},
-                {keys: [ctrl, shift, "U"], description: this.$t("autoCompletion.recordSoundShortcut")},
+                {keys: [ctrl, shift, {label: "I"}], description: this.$t("autoCompletion.recordImageShortcut")},
+                {keys: [ctrl, shift, {label: "U"}], description: this.$t("autoCompletion.recordSoundShortcut")},
             ];
         },
 

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1328,10 +1328,15 @@ export default defineComponent({
                 else if (dlgId == this.loadBookProjectModalDlgId) {
                     const selectedProject = (this.$refs.openBookDlg  as InstanceType<typeof OpenBookDlg>).getSelectedProject();
                     if (selectedProject) {
+                        // We always show the book menu entry and dialog. However, the projects do not run on the micro:bit version.
+                        // Therefore, if we are on the micro:bit version, instead of loading the selected project inside the current editor,
+                        // we open a new tab pointing at the standard version with the project as if we shared it.
+                        const projectName = selectedProject.name ?? "Book";
+                        trackUsedBookProject(projectName, selectedProject.chapter);
+                        // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
                         selectedProject.projectFile.then((content) => {
                             if (content) {
-                                trackUsedBookProject(selectedProject.name ?? "Book", selectedProject.chapter);
-                                this.afterSaveDialog = {spy: content, name: selectedProject.name ?? "Book"};
+                                this.afterSaveDialog = {spy: content, name: projectName};
                                 if (this.appStore.isEditorContentModified) {
                                     eventBus.emit(CustomEventTypes.showStrypeModal, this.saveOnLoadModalDlgId);
                                 }
@@ -1340,6 +1345,12 @@ export default defineComponent({
                                 }
                             }
                         });
+                        // #v-else
+                        // For micro:bit, we can simply open a shared the project as an exteral resource since it exists in our public repository.
+                        // Of course, this rely on how we expose the projects, and that we have the correct project name set.
+                        const normalisedChapterNumber = selectedProject.chapter.replace(/chapter\s+(\d+)/i, (_, n) => n.padStart(2, "0"));
+                        window.open(`https://strype.org/editor/?${sharedStrypeProjectIdKey}=${encodeURI(`https://strype.org/editor/book_projects/chapter${normalisedChapterNumber}/${projectName}.spy`)}`, "_blank");
+                        // #v-endif
                     }
                 }
             }

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -256,7 +256,7 @@
     "wrapCurlyBrackets": "Entourer de {'{}'}",
     "wrapDoubleQuotes": "Entourer de \"",
     "wrapSingleQuotes": "Entourer de '",
-    "shiftKey": "Shift",
+    "shiftKey": "Maj",
     "recordImageShortcut": "Enregistrer une image",
     "recordSoundShortcut": "Enregistrer un son"
   },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -808,8 +808,10 @@ export const useStore = defineStore("app", {
                     removeFrameInFrameList(payload.frameToDeleteId);
                 }
                 else{
-                    //we "replace" the frame to delete by its content in its parent's location
-                    //note: the content is its children and the children of its potential joint frames
+                    // We "replace" the frame to delete by its content in its parent's location
+                    // Note: the content is its children and the children of its potential joint frames
+                    // For the special case of match frames, we bring up the content of all cases 
+                    // to the level of the match frame (match and case frames will be deleted)
                     const frameToDelete = this.frameObjects[payload.frameToDeleteId];
                     const isFrameToDeleteJointFrame = (frameToDelete.jointParentId > 0);
                     const isFrameToDeleteRootJointFrame = (frameToDelete.jointParentId === 0 && frameToDelete.frameType.jointFrameTypes.length > 0);
@@ -822,7 +824,18 @@ export const useStore = defineStore("app", {
                             this.frameObjects[payload.frameToDeleteId].jointParentId;     
                     }
 
-                    const listOfChildrenToMove = this.frameObjects[payload.frameToDeleteId].childrenIds;
+                    const listOfChildrenToMove = (frameToDelete.frameType.type != AllFrameTypesIdentifier.match) 
+                        ? this.frameObjects[payload.frameToDeleteId].childrenIds
+                        : this.frameObjects[payload.frameToDeleteId].childrenIds.flatMap((matchChildId) => {
+                            // When we delete from the body of a match or of a case, we bring back all the bodies' content 
+                            // to the current level (which is above match).
+                            if(this.frameObjects[matchChildId].frameType.type == AllFrameTypesIdentifier.case){
+                                return this.frameObjects[matchChildId].childrenIds;
+                            }
+                            else{
+                                return  matchChildId;
+                            }
+                        });
                     //if the frame to remove is the root of a joint frames structure, we include all the joint frames' children in the list of children to remove
                     if(isFrameToDeleteRootJointFrame){
                         this.frameObjects[payload.frameToDeleteId]
@@ -850,7 +863,14 @@ export const useStore = defineStore("app", {
                             1
                         );
                     }
-                    //and finally, delete the frame
+                    //and finally, delete the frame, and in the case of a match frame we delete the case frames left dangling too
+                    if(frameToDelete.frameType.type == AllFrameTypesIdentifier.match){
+                        this.frameObjects[payload.frameToDeleteId].childrenIds.forEach((matchChildId) => {
+                            if(this.frameObjects[matchChildId].frameType.type == AllFrameTypesIdentifier.case) {
+                                delete this.frameObjects[matchChildId];
+                            }
+                        });
+                    }
                     delete this.frameObjects[payload.frameToDeleteId];
                 }
             }
@@ -2021,10 +2041,10 @@ export const useStore = defineStore("app", {
         // Note: this will not always do the delete, for example if frozen frames are involved
         // Returns true if the deletion ocurred or false if it did not.
         deleteFrames(key: string, ignoreBackState?: boolean) : boolean {
-            // If we are trying to delete a match or case frame from its body, the action is cancelled if this body isn't empty-like (i.e. if not empty, or only containing comments/blanks): 
+            // If we are trying to delete a case frame from its body, the action is cancelled if this body isn't empty-like (i.e. if not empty, or only containing comments/blanks): 
             // catch statements cannot live outside a match statement and match statements cannot contain anything but cases or comments/blanks
             if(this.selectedFrames.length == 0 && key == "Backspace" && this.currentFrame.caretPosition == CaretPosition.body 
-                && (this.frameObjects[this.currentFrame.id].frameType.type == AllFrameTypesIdentifier.match || this.frameObjects[this.currentFrame.id].frameType.type == AllFrameTypesIdentifier.case) 
+                && this.frameObjects[this.currentFrame.id].frameType.type == AllFrameTypesIdentifier.case
                 && this.frameObjects[this.currentFrame.id].childrenIds.length > 0 
                     && this.frameObjects[this.currentFrame.id].childrenIds.map((childFrameId) => this.frameObjects[childFrameId].frameType.type).some((frameType) => frameType != AllFrameTypesIdentifier.comment && frameType != AllFrameTypesIdentifier.blank)){
                 return false;
@@ -2081,7 +2101,7 @@ export const useStore = defineStore("app", {
                 // we need to delete the next joint frame that is visually below us.
                 //if backspace is pressed
                 //  case current frame is Container --> do nothing, a container cannot be deleted
-                //  case cursor is body: cursor needs to move one level up, and the current frame's children + all siblings replace its parent (except for function definitions frames)
+                //  case cursor is body: cursor needs to move one level up, and the current frame's children + all siblings replace its parent (except for function definitions frames) - match frames are a bit specific (see below)
                 //  case cursor is below: cursor needs to move to bottom of previous sibling (or body of parent if first child) and the current frame (*) is deleted
                 //(*) with all sub levels children
 

--- a/tests/playwright/e2e/match-statement.spec.ts
+++ b/tests/playwright/e2e/match-statement.spec.ts
@@ -2,7 +2,7 @@ import {test, expect} from "@playwright/test";
 import {readFileSync} from "node:fs";
 import {save, testPlaywrightRoundTripImportAndDownload} from "../support/loading-saving";
 import {setupStrypeTest} from "../support/general";
-import {getDefaultStrypeProjectDocumentationFullLine, getDefaultStrypeProjectImportsFullLine, pressN, waitForEditorSettled} from "../support/editor";
+import {doPagePaste, getDefaultStrypeProjectDocumentationFullLine, getDefaultStrypeProjectImportsFullLine, pressN, waitForEditorSettled} from "../support/editor";
 import {checkConsoleContent, runToFinish} from "../support/execution";
 
 const defaultStandardStrypeProjectDocLiteral = getDefaultStrypeProjectDocumentationFullLine();
@@ -30,6 +30,29 @@ myString  = "Hello from Strype"
 print(myString) 
 #(=> Section:End
 `;
+
+const complexMatchCodeLiteral = `
+match a  :
+    #match comment
+    case _  :
+        a1() 
+    case f  :
+        a2() 
+        print("2") 
+    case "f"  :
+        a3() 
+        while True  :
+            print("3") 
+`;
+
+const scrappedMatchWithDefaultCode = defaultProjectCodeLiteral.replace("#(=> Section:Main",`#(=> Section:Main
+#match comment
+a1() 
+a2() 
+print("2") 
+a3() 
+while True  :
+    print("3") `);
 
 test.beforeEach(async ({ page, browserName }, testInfo) => {
     await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 240000, skipPyodide: false});
@@ -338,14 +361,23 @@ test.describe("Delete Match statement", () => {
         await waitForEditorSettled(page);
         await page.keyboard.press("Backspace");
         await waitForEditorSettled(page);
-        // This backspace should not delete anything
-        expect(readFileSync(await save(page), "utf-8")).toEqual(basicMatchLiteral.trimStart());
-        // Now delete the case, and see that backspace delete the match frame
-        await page.keyboard.press("Delete");
+        // This backspace should delete the match and its content
+        expect(readFileSync(await save(page), "utf-8")).toEqual(defaultProjectCodeLiteral.trimStart());    
+    });
+    
+    test("Backspace inside complex Match", async ({page}) => {
+        // Paste some small complex match case code
+        await doPagePaste(page, complexMatchCodeLiteral);
+        await waitForEditorSettled(page);
+        // Go back to the top of the main section, then inside main
+        await page.keyboard.press("Home");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("ArrowDown");
         await waitForEditorSettled(page);
         await page.keyboard.press("Backspace");
         await waitForEditorSettled(page);
-        expect(readFileSync(await save(page, false), "utf-8")).toEqual(defaultProjectCodeLiteral.trimStart());
+        // This backspace should delete the match and the cases, bringing up the body contents.
+        expect(readFileSync(await save(page), "utf-8")).toEqual(scrappedMatchWithDefaultCode.trimStart());    
     });
     
     test("Backspace inside Case", async ({page}) => {


### PR DESCRIPTION
This PR contains 3 small UI related changes and the version bump for 2.3.0.
Changes:
- allow using backspace to delete match+case frames, even if the match contains some not "empty-like" content. It brings all the content of the match bar the case frame proper (but their content is indeed brought up) to the match frame's parent level (#992)
- for the micro:bit version, open the Book's project within a new tab, in the standard Strype version - this relies on these projects to be publicly exposed in strype.org, so it's a simple shared project opening (#994)
- show the "⇧" symbol in the text-slot commands rather than the textual key name (which is then shown as a title) (#995 - I initially thought there was no localisation, which isn't true, the localisation was already totally fine)