### PR TITLE
A couple of small fixes to the open dialog

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1806,11 +1806,25 @@ export default defineComponent({
 .open-menu-embedded-proj-link{
     font-size: smaller;
     cursor: pointer;
+    color: inherit;
+    text-decoration: none;
+    border: #c5c4c1 2px solid;
+    border-radius: 6px;
+    padding: 4px 10px;
+}
+
+.open-menu-embedded-proj-link:hover,
+.open-menu-embedded-proj-link:focus {
+    border-color: #007bff;
+    box-shadow: 2px 2px 5px rgb(141, 140, 140);
+    outline: none;
 }
 
 div:has(> a.open-menu-embedded-proj-link) {
     display: flex;
-    gap: 8px;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 5px;
 }
 
 .save-project-modal-dlg-container {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -38,7 +38,7 @@
                         </div>
                     </div>
                     <div><a class="open-menu-embedded-proj-link" @click="onOpenMenuLinkClick('examples')">{{$t("appMenu.loadDemoProject")}}</a><a class="open-menu-embedded-proj-link" @click="onOpenMenuLinkClick('book')">{{$t("appMenu.book")}}</a></div>
-                    <div class="recent-states-pane" v-if="recentLoadableStates && recentLoadableStates.length > 0">
+                    <div class="recent-states-pane" v-if="showRecentUnsaved && recentLoadableStates && recentLoadableStates.length > 0">
                         <div class="d-flex justify-content-between align-items-baseline">
                             <span class="load-save-label">{{ $t("appMessage.loadRecentState") }}</span>
                             <span class="clear-all-label" @click="clearAllRecent">{{ $t("appMessage.clearAllRecent") }}</span>
@@ -386,6 +386,8 @@ export default defineComponent({
 
             // States that could be loaded from the load menu:
             recentLoadableStates: [] as {label: string, sublabel: string, data: string, tabId: string}[],
+            // Whether the "recent unsaved projects" pane is revealed in the load dialog (hidden by default, toggled by Ctrl+U while the dialog is open)
+            showRecentUnsaved: false,
         };
     },
 
@@ -433,6 +435,15 @@ export default defineComponent({
                     event.preventDefault();
                     event.stopImmediatePropagation();
                     event.stopPropagation();
+                }
+                // Secret shortcut to reveal the "recent unsaved projects" pane in the load dialog.
+                // Ctrl+U is normally "view page source" in the browser, so we only intercept it (and
+                // therefore only override that browser shortcut) while the load dialog is open.
+                else if(lowCaseEventKey === "u" && (event.metaKey || event.ctrlKey) && this.appStore.currentModalDlgId === this.loadProjectModalDlgId) {
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                    event.stopPropagation();
+                    this.showRecentUnsaved = !this.showRecentUnsaved;
                 }
             }
         );
@@ -766,6 +777,8 @@ export default defineComponent({
 
         async openLoadProjectModal(): Promise<void> {
             this.appStore.trackMenuAction("load_project");
+            // The recent unsaved projects pane is hidden by default each time the dialog is opened; Ctrl+U reveals it.
+            this.showRecentUnsaved = false;
             // We prepare the recent states now, even if the user might need to deal with the save dialog in a moment:
             this.recentLoadableStates = (await checkForRecentSaveStates(settingsStore().locale ?? "en", "load_menu"))
                 .map((s) => {

--- a/tests/playwright/e2e/storage-model.spec.ts
+++ b/tests/playwright/e2e/storage-model.spec.ts
@@ -377,9 +377,25 @@ async function assertRecentStatesShowing(page: Page, expectedProjectNames: RegEx
     await expect(page.locator("." + scssVars.projectRecentStateLabel)).toHaveText(expectedProjectNames);
 }
 
+// The "recent unsaved projects" pane is hidden by default in the load dialog; Ctrl+U reveals it.
+// The shortcut is only armed once the dialog has fully finished its "shown" transition (a Bootstrap
+// event that fires a little after the dialog becomes visible to Playwright), so a single press right
+// after opening the dialog can race that transition. Presses before the dialog is armed are harmless
+// no-ops, so we just retry the press until the pane shows up:
+async function revealRecentUnsavedPane(page: Page) : Promise<void> {
+    const scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
+    await expect(async () => {
+        await page.keyboard.press("Control+u");
+        await expect(page.locator("." + scssVars.projectRecentStateLabel).first()).toBeVisible({timeout: 300});
+    }).toPass({timeout: 5000});
+}
+
 async function assertOpenRecentMenu(page: Page, expectedProjectNames: RegExp[]) : Promise<void> {
     await page.click("#" + await strypeElIds(page).getEditorMenuUID());
     await page.click("#" + await strypeElIds(page).getLoadProjectLinkId());
+    if (expectedProjectNames.length > 0) {
+        await revealRecentUnsavedPane(page);
+    }
     await assertRecentStatesShowing(page, expectedProjectNames);
 }
 
@@ -477,6 +493,47 @@ test.describe("Offer to reload unsaved backups", () => {
         await assertOpenRecentMenu(page, [/^My project \(/]);
     });
 
+    // Regression test for the Ctrl+U secret-shortcut behaviour: the recent-unsaved-projects pane
+    // (and its divider) must be hidden by default, only appear once Ctrl+U is pressed, toggle off
+    // again on a second press, and reset back to hidden the next time the dialog is opened:
+    test("The recent unsaved projects pane is hidden until Ctrl+U is pressed", async ({page}) => {
+        await loadAndWaitForEditor(page);
+        const str = "Modifying before starting a new project";
+        await appendContent(page, str);
+
+        await page.click("#" + await strypeElIds(page).getEditorMenuUID());
+        await page.click("#" + await strypeElIds(page).getNewProjectLinkId());
+        await page.locator("*[id='confirmNewProjectModalDlg'] button", {hasText: "Continue"}).click();
+        await waitForNewProjectReload(page);
+        await assertStartingProject(page);
+
+        // Open the load dialog directly (not via assertOpenRecentMenu, which presses Ctrl+U itself):
+        await page.click("#" + await strypeElIds(page).getEditorMenuUID());
+        await page.click("#" + await strypeElIds(page).getLoadProjectLinkId());
+        await page.locator("#load-strype-project-modal-dlg").waitFor({state: "visible"});
+        const scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
+        const recentPane = page.locator("." + scssVars.projectRecentStateLabel);
+
+        // Hidden by default, even though there is a recent unsaved project to show:
+        await expect(recentPane).not.toBeVisible();
+
+        // Ctrl+U reveals it:
+        await revealRecentUnsavedPane(page);
+        await assertRecentStatesShowing(page, [/^My project \(/]);
+
+        // Pressing it again hides it:
+        await page.keyboard.press("Control+u");
+        await expect(recentPane).not.toBeVisible();
+
+        // Reveal it once more, then close and reopen the dialog -- it should reset to hidden:
+        await page.keyboard.press("Control+u");
+        await assertRecentStatesShowing(page, [/^My project \(/]);
+        await page.locator("#load-strype-project-modal-dlg .btn-close").click();
+        await page.click("#" + await strypeElIds(page).getEditorMenuUID());
+        await page.click("#" + await strypeElIds(page).getLoadProjectLinkId());
+        await expect(recentPane).not.toBeVisible();
+    });
+
     // Regression test: discarding changes via the "save changes before loading?" dialog (shown
     // when opening a different project, a demo, or a book chapter while the current one is
     // modified) used to never back up the outgoing project at all -- unlike the "Save changes"
@@ -514,7 +571,9 @@ test.describe("Offer to reload unsaved backups", () => {
         await page.click("#" + await strypeElIds(page).getLoadProjectLinkId());
         await page.locator("button", {hasText: "Discard changes"}).filter({visible: true}).click();
 
-        // The discarded project should still be recoverable:
+        // The discarded project should still be recoverable. This dialog was opened directly rather
+        // than via assertOpenRecentMenu(), so we need to reveal the recent-unsaved-projects pane ourselves:
+        await revealRecentUnsavedPane(page);
         await assertRecentStatesShowing(page, [/^My project \(/]);
     });
 

--- a/tests/playwright/e2e/storage-model.spec.ts
+++ b/tests/playwright/e2e/storage-model.spec.ts
@@ -385,7 +385,7 @@ async function assertRecentStatesShowing(page: Page, expectedProjectNames: RegEx
 async function revealRecentUnsavedPane(page: Page) : Promise<void> {
     const scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
     await expect(async () => {
-        await page.keyboard.press("Control+u");
+        await page.keyboard.press("ControlOrMeta+u");
         await expect(page.locator("." + scssVars.projectRecentStateLabel).first()).toBeVisible({timeout: 300});
     }).toPass({timeout: 5000});
 }
@@ -522,11 +522,11 @@ test.describe("Offer to reload unsaved backups", () => {
         await assertRecentStatesShowing(page, [/^My project \(/]);
 
         // Pressing it again hides it:
-        await page.keyboard.press("Control+u");
+        await page.keyboard.press("ControlOrMeta+u");
         await expect(recentPane).not.toBeVisible();
 
         // Reveal it once more, then close and reopen the dialog -- it should reset to hidden:
-        await page.keyboard.press("Control+u");
+        await page.keyboard.press("ControlOrMeta+u");
         await assertRecentStatesShowing(page, [/^My project \(/]);
         await page.locator("#load-strype-project-modal-dlg .btn-close").click();
         await page.click("#" + await strypeElIds(page).getEditorMenuUID());


### PR DESCRIPTION
Two small fixes to the open dialog, requested by Michael:
 - Restyle the examples/book items
 - Remove the open recent projects menu as it was cluttering up the dialog.  I decided to actually put it on a hidden shortcut (Ctrl-U).  We get emails to BlueJ support saying "my project is lost, help" so it seems like maybe it might be useful to have this menu available if it's needed by someone who gets in touch.