### PR TITLE
Improve overtyping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,19 @@ London. See [README.md](README.md) for build/run basics.
 - Single Cypress file: open the Cypress runner (`npx cypress open`) against
   the already-running dev server, or filter via `cypress-split` env vars.
 
+When running `npm run test:cypress` / `start-server-and-test ... cy:run:*`
+(or the Playwright equivalent) in the background: this has repeatedly either
+sat producing no output at all (the dev server/browser never actually
+started, confirmed via `ps`/`lsof` showing nothing listening), or crashed
+with Cypress's Electron renderer ("Page.screencastFrameAck ... CRI connection
+has crashed") partway through a larger spec. Both have been seen across
+multiple machines running Claude Code on this project, so don't just wait
+indefinitely on a background run — if there's no output after ~60s, check
+`ps aux` / `lsof -i :8081 -i :8089` for the actual server/browser process
+before assuming it's still working, and don't treat an Electron-renderer
+crash as a real test failure (rerun, or narrow to a smaller spec) — it's an
+environment issue, not a code regression.
+
 ## Test layout
 
 - `tests/cypress/e2e/*.cy.ts` + `tests/cypress/support/*.ts` — Cypress specs

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1200,11 +1200,11 @@ export default defineComponent({
             else if(inputString === " " && this.frameType !== AllFrameTypesIdentifier.comment && this.slotType != SlotType.string && cursorPos == 0){
                 this.removeLastInput(inputString);
             }
-            // If we type ":" as the very first character of a function definition's docs field, we discard it:
-            // the user has just overtyped the closing bracket of the parameter list (which moves the cursor
-            // past the "):" and into the docs field), so this ":" is almost certainly a leftover keystroke
-            // from habitually typing "def foo():" rather than text intended for the docs.
-            else if(inputString === ":" && cursorPos == 0 && this.frameType === AllFrameTypesIdentifier.funcdef && this.allowedSlotContent == AllowedSlotContent.FREE_TEXT_DOCUMENTATION){
+            // If we type ":" as the very first character of a function/class definition's docs field, we
+            // discard it: the user has just overtyped the closing bracket/name (which moves the cursor past
+            // the frame's own " :" label and into the docs field), so this ":" is almost certainly a leftover
+            // keystroke from habitually typing "def foo():"/"class Foo:" rather than text intended for the docs.
+            else if(inputString === ":" && cursorPos == 0 && (this.frameType === AllFrameTypesIdentifier.funcdef || this.frameType === AllFrameTypesIdentifier.classdef) && this.allowedSlotContent == AllowedSlotContent.FREE_TEXT_DOCUMENTATION){
                 this.removeLastInput(inputString);
             }
             // On comments, we do not need multislots and parsing any code, we just let any key go through
@@ -1260,9 +1260,15 @@ export default defineComponent({
                 else{
                     // It's not a string, check for bracket
                     const parentBracketSlot = (parentSlot && isFieldBracketedSlot(parentSlot)) ? parentSlot as SlotsStructure : undefined;
+                    // A function definition's parameter list isn't stored as a bracketed field slot like a normal
+                    // "(...)" expression -- its surrounding brackets are just the frame label's own static text
+                    // (labels "(" and ") :"), so there is no bracketed parent slot to find via parentBracketSlot
+                    // above. We special-case it here so overtyping its closing ")" still moves to the next slot:
+                    const isFuncDefParamsRoot = !this.coreSlotInfo.slotId.includes(",") && this.allowedSlotContent == AllowedSlotContent.ONLY_FORMAL_PARAMS;
                     shouldMoveToNextSlot = inputSpanFieldContent.substring(cursorPos).replace(/\u200B/g, "").trim() == inputString
                         // make sure we are inside a bracketed structure and that the opening bracket is the counterpart of the key value (closing bracket)
-                        && parentBracketSlot != undefined && parentBracketSlot.openingBracketValue == getMatchingBracket(inputString, false)
+                        && ((parentBracketSlot != undefined && parentBracketSlot.openingBracketValue == getMatchingBracket(inputString, false))
+                            || (isFuncDefParamsRoot && inputString == ")"))
                         && !hasTextSelection;
                     checkMultidimBrackets = !shouldMoveToNextSlot && !hasTextSelection;
                 }

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1155,6 +1155,18 @@ export default defineComponent({
                 }
                 return;
             }
+            // If the frame is a "for" or "with" frame and we are in the first top-level slot (the loop target
+            // for "for", the expression for "with"), pressing space at the end of that slot moves to the
+            // second slot (the iterable for "for", the "as" target for "with"), just like it does for the
+            // LHS of a variable assignment frame above.
+            else if(this.labelSlotsIndex === 0 && this.slotId.indexOf(",") == -1 && !hasTextSelection &&
+                inputString === " " && (this.frameType === AllFrameTypesIdentifier.for || this.frameType === AllFrameTypesIdentifier.with)){
+                this.removeLastInput(inputString);
+                if (isAtEndOfLastSlot) {
+                    this.doArrowRightNextTick();
+                }
+                return;
+            }
             // If the frame is an import frame, pressing space will automatically add the "as" operator when it makes sense to do so (see details below),
             // when we press space and we are just before  an "as", we go to the next slot.
             // In other cases and anywhere for "from... import" frames, pressing space will result in no action.
@@ -1186,6 +1198,13 @@ export default defineComponent({
             }
             // We also prevent start trailing spaces on all slots except comments and string content, to avoid indentation errors
             else if(inputString === " " && this.frameType !== AllFrameTypesIdentifier.comment && this.slotType != SlotType.string && cursorPos == 0){
+                this.removeLastInput(inputString);
+            }
+            // If we type ":" as the very first character of a function definition's docs field, we discard it:
+            // the user has just overtyped the closing bracket of the parameter list (which moves the cursor
+            // past the "):" and into the docs field), so this ":" is almost certainly a leftover keystroke
+            // from habitually typing "def foo():" rather than text intended for the docs.
+            else if(inputString === ":" && cursorPos == 0 && this.frameType === AllFrameTypesIdentifier.funcdef && this.allowedSlotContent == AllowedSlotContent.FREE_TEXT_DOCUMENTATION){
                 this.removeLastInput(inputString);
             }
             // On comments, we do not need multislots and parsing any code, we just let any key go through

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1068,6 +1068,14 @@ export default defineComponent({
             }
         },
 
+        // Checks whether the label immediately following this one is a plain ":" label with no slot of its own
+        // (e.g. the " :" label of if/elif/for/while/except/class frames), which is the case we want to treat
+        // a trailing ":" keypress as overtyping rather than insertion.
+        isNextLabelColon() : boolean {
+            const nextLabel = this.appStore.frameObjects[this.frameId].frameType.labels[this.labelSlotsIndex + 1];
+            return nextLabel != undefined && nextLabel.showSlots === false && nextLabel.label.replace(/&nbsp;/g, "").trim() === ":";
+        },
+
         doArrowRightNextTick() {
             this.$nextTick(() => {
                 document.getElementById(getFrameLabelSlotsStructureUID(this.frameId, this.labelSlotsIndex))?.dispatchEvent(
@@ -1183,6 +1191,23 @@ export default defineComponent({
             // On comments, we do not need multislots and parsing any code, we just let any key go through
             else if(this.allowedSlotContent == AllowedSlotContent.LIBRARY_ADDRESS || this.allowedSlotContent == AllowedSlotContent.FREE_TEXT_DOCUMENTATION){
                 // Do nothing
+            }
+            // If we type ":" at the very end of a top-level slot structure (not inside a bracket or quote), and the
+            // next label of this frame is just a colon label (e.g. "if <cond>:", "while <cond>:"...), we treat this
+            // as overtyping that colon label rather than inserting a new one:
+            else if(inputString === ":" && isAtEndOfLastSlot && !isFieldStringSlot(currentSlot) && !this.coreSlotInfo.slotId.includes(",") && this.isNextLabelColon()){
+                this.removeLastInput(inputString);
+                // There is no further slot to move the focus to within this frame's own label slots (the
+                // ":" label that follows has no slot of its own), so unlike the other overtyping cases in
+                // this method we can't just dispatch a synthetic ArrowRight to the label-slots-structure
+                // element -- we need to actually leave the frame's header, so we call the store action
+                // that performs this navigation directly instead:
+                this.$nextTick(() => {
+                    this.$nextTick(() => {
+                        this.appStore.leftRightKey({key: "ArrowRight"});
+                    });
+                });
+                return;
             }
             // Finally, we check the case an operator, bracket or quote has been typed and the slots within this frame need update
             // First we check closing brackets or quote as they have a specifc behaviour, then keep working out the other things

--- a/tests/cypress/e2e/basics.cy.ts
+++ b/tests/cypress/e2e/basics.cy.ts
@@ -355,6 +355,30 @@ describe("Classes", () => {
             ]},
         ]).concat(defaultMyCode));
     });
+
+    it("Lets you use space to move to the next slot in a for frame", () => {
+        checkCodeEquals(defaultImports.concat(defaultMyCode));
+        // Go to the top of "my code" (just below the first default statement), where "for" is
+        // offered directly via its own shortcut rather than falling back to def's legacy "f" shortcut:
+        cy.get("#" + strypeElIds.getFrameUID(-3), {timeout: 15 * 1000}).focus();
+        cy.get("body").type("{downarrow}");
+        pressFrameShortcutThenType("f", "x range(5)");
+        checkCodeEquals(defaultImports.concat([
+            defaultMyCode[0],
+            {h: /for\s+x\s+in\s+range\(5\)\s*:/, b: []},
+        ]).concat(defaultMyCode.slice(1)));
+    });
+
+    it("Lets you use space to move to the next slot in a with frame", () => {
+        checkCodeEquals(defaultImports.concat(defaultMyCode));
+        cy.get("#" + strypeElIds.getFrameUID(-3), {timeout: 15 * 1000}).focus();
+        cy.get("body").type("{downarrow}");
+        pressFrameShortcutThenType("h", "f g");
+        checkCodeEquals(defaultImports.concat([
+            defaultMyCode[0],
+            {h: /with\s+f\s+as\s+g\s*:/, b: []},
+        ]).concat(defaultMyCode.slice(1)));
+    });
 });
 
 // Test that selecting and deleting frames using keyboard works properly:

--- a/tests/cypress/e2e/colon-overtyping.cy.ts
+++ b/tests/cypress/e2e/colon-overtyping.cy.ts
@@ -1,4 +1,4 @@
-import { standardBeforeEach } from "../support/standard-setup";
+import { standardBeforeEach, strypeElIds } from "../support/standard-setup";
 
 require("cypress-terminal-report/src/installLogsCollector")();
 import failOnConsoleError from "cypress-fail-on-console-error";
@@ -27,5 +27,22 @@ describe("Test colon overtyping", () => {
         assertState("{$}");
         cy.get("body").type("(x:");
         assertState("{}_({x}:{$})_{}");
+    });
+
+    // Typing ")" to overtype the closing bracket of a function definition's parameter list moves the
+    // cursor into the docs field (following the "):" label). Since the user has therefore effectively
+    // already "typed" the colon that ends the def line, a ":" typed as the very first character of the
+    // docs field is discarded rather than inserted:
+    it("Discards a colon typed at the start of a function definition's docs field", () => {
+        focusEditor();
+        pressFrameShortcut("d");
+        // "(x)" : the "(" auto-inserts the closing ")", "x" is the parameter name, and the final ")"
+        // overtypes the auto-inserted one, moving the cursor into the docs field:
+        cy.get("body").type("foo(x)");
+        cy.get("body").type(":Explanation");
+        cy.get("#" + strypeElIds.getEditorID()).then((eds) => {
+            const focusId = eds.get()[0].getAttribute("data-slot-focus-id") || "";
+            cy.get("#" + focusId.replaceAll(",", "\\,")).should("have.text", "Explanation");
+        });
     });
 });

--- a/tests/cypress/e2e/colon-overtyping.cy.ts
+++ b/tests/cypress/e2e/colon-overtyping.cy.ts
@@ -45,4 +45,16 @@ describe("Test colon overtyping", () => {
             cy.get("#" + focusId.replaceAll(",", "\\,")).should("have.text", "Explanation");
         });
     });
+
+    // Same as above, but for a class definition's docs field:
+    it("Discards a colon typed at the start of a class definition's docs field", () => {
+        focusEditor();
+        pressFrameShortcut("c");
+        cy.get("body").type("Foo{rightarrow}");
+        cy.get("body").type(":Explanation");
+        cy.get("#" + strypeElIds.getEditorID()).then((eds) => {
+            const focusId = eds.get()[0].getAttribute("data-slot-focus-id") || "";
+            cy.get("#" + focusId.replaceAll(",", "\\,")).should("have.text", "Explanation");
+        });
+    });
 });

--- a/tests/cypress/e2e/colon-overtyping.cy.ts
+++ b/tests/cypress/e2e/colon-overtyping.cy.ts
@@ -1,0 +1,31 @@
+import { standardBeforeEach } from "../support/standard-setup";
+
+require("cypress-terminal-report/src/installLogsCollector")();
+import failOnConsoleError from "cypress-fail-on-console-error";
+failOnConsoleError();
+
+import {testInsert, testInsertExisting, focusEditor, assertState} from "../support/expression-test-support";
+import {pressFrameShortcut} from "../support/test-support";
+
+// Must clear all local storage between tests to reset the state, and set the 'paste' command:
+beforeEach(standardBeforeEach);
+
+describe("Test colon overtyping", () => {
+    // Typing ":" at the very end of the (only, top-level) slot of an if-frame's condition should be treated
+    // as overtyping the frame's own " :" label, i.e. it should not be inserted and the cursor should leave
+    // the slot instead (so there is no "$" left inside the condition's content):
+    testInsert("x:", "{x}", false);
+
+    // Typing ":" part-way through a slot (not at the end) should just insert a literal ":" character:
+    testInsertExisting("ab$c", ":", "{ab}:{$c}");
+
+    // Typing ":" at the end of a slot that is nested inside brackets (i.e. not at the top level) should
+    // just insert a literal ":" character, even though it is the last slot within those brackets:
+    it("Does not overtype the colon inside brackets", () => {
+        focusEditor();
+        pressFrameShortcut("i");
+        assertState("{$}");
+        cy.get("body").type("(x:");
+        assertState("{}_({x}:{$})_{}");
+    });
+});

--- a/tests/cypress/support/param-prompt-support.ts
+++ b/tests/cypress/support/param-prompt-support.ts
@@ -123,7 +123,7 @@ export function testRawFuncs(rawFuncs: [string | [string, string] | {class?: str
                     ? ` c${(rawFunc[0] as any)?.class}{rightarrow}{rightarrow}`
                     : "";
                 funcs.push({
-                    keyboardTypingToImport: "{uparrow}" + classTypePreamble + " f" + (rawFunc[0] as any)?.udf + "{downarrow}{downarrow}",
+                    keyboardTypingToImport: "{uparrow}" + classTypePreamble + " f" + (rawFunc[0] as any)?.udf + (isTestingFunctionInClass ? "{downarrow}" : "{downarrow}{downarrow}"),
                     funcName: rawFunc[1],
                     params: params,
                     acSection: (isTestingFunctionInClass) ? "self" : "My functions",


### PR DESCRIPTION
Now that we're encouraging more keyboard typing of constructs, we want to make sure that we can overtype elements to continue with the keyboard typing approach, so this small PR:
 - Makes sure that if you type a colon at the end of the top level of a slot before a ":" label, focus moves past it (as if right arrow was pressed)
 - Similar for close-bracket in funcdef parameters
 - If you then try to type a colon at the start of the funcdef docs (e.g. you typed "foo():", the close bracket takes you into the docs, then you'd type a colon in the docs) it's discarded.  Can't think you'd want to start the docs with a colon...
 - Pressing space in the first slot of "for" or "with" moves to the second slot, like it already did for assignment frames.
 - Add tests for some of this