### PR TITLE
Small fixes

### DIFF
--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1193,8 +1193,14 @@ export default defineComponent({
                 }
                 return;
             }
+            // For "from ... import ...", pressing space at the end of the first slot (the module name) moves
+            // to the second slot (the imported part), just like it does for "for"/"with" above. Elsewhere in
+            // a from-import frame, pressing space does nothing.
             else if (inputString === " " && this.frameType === AllFrameTypesIdentifier.fromimport){
                 this.removeLastInput(inputString);
+                if (this.labelSlotsIndex === 0 && this.slotId.indexOf(",") == -1 && !hasTextSelection && isAtEndOfLastSlot) {
+                    this.doArrowRightNextTick();
+                }
             }
             // We also prevent start trailing spaces on all slots except comments and string content, to avoid indentation errors
             else if(inputString === " " && this.frameType !== AllFrameTypesIdentifier.comment && this.slotType != SlotType.string && cursorPos == 0){

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -751,7 +751,12 @@ export default defineComponent({
                     // We always restart Pyodide for a clean state, regardless of whether we still
                     // need to wait below for sounds to finish -- the worker itself is done either way:
                     void terminateAndRestartPyodide();
-                    if (wasStoppedByUser || possibleError != null) {
+                    // strype.graphics.stop() raises SystemExit to end the program early -- handleErrorTrace()
+                    // (above) already treats that as a deliberate, silent exit rather than a real runtime
+                    // error, and we do the same here: it's not "wasStoppedByUser" (the Stop button), so it
+                    // should still wait for sounds below, just like a normal fall-off-the-end completion:
+                    const hadRealError = possibleError != null && !possibleError.text.startsWith("SystemExit");
+                    if (wasStoppedByUser || hadRealError) {
                         // Either the user already clicked Stop (which already stopped the sounds
                         // and set NotRunning), or the code ended with an uncaught error, in which
                         // case we stop any sounds immediately rather than waiting for them:

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -111,6 +111,12 @@ let sendNextKey : ((s: string) => void) = () => {};
 const keyMapping = new Map<string, string>([["ArrowUp", "up"], ["ArrowDown", "down"], ["ArrowLeft", "left"], ["ArrowRight", "right"], [" ", "space"]]);
 let switchedToGraphicsTabAlreadyThisExecute = false;
 let switchedToConsoleTabAlreadyThisExecute = false;
+// True once the user's Python code has finished executing normally (no uncaught error, not
+// stopped by the user) but we are still waiting for any still-playing sounds to finish, as if
+// there were an invisible wait_for_all_sounds_to_finish() at the very end of the program. The
+// run button still shows "Stop" during this time; clicking it goes through runClicked()'s
+// "Running" case, which stops the sounds (resolving the wait below) and finalises the run.
+let waitingForSoundsAfterNormalCompletion = false;
 
 let soundManager : SoundManager | null = null; // Can't initialise this here as we need permissions for audio context
 const turtleCanvas = new OffscreenCanvas(800, 600);
@@ -516,7 +522,13 @@ export default defineComponent({
                 return;
             case PythonExecRunningState.Running:
                 soundManager?.stopAllSounds();
-                void terminateAndRestartPyodide();
+                // If we're only here waiting for sounds to finish after the code itself already
+                // completed normally, Pyodide has already been restarted (see execPythonCode())
+                // and there is nothing left to interrupt:
+                if (!waitingForSoundsAfterNormalCompletion) {
+                    void terminateAndRestartPyodide();
+                }
+                waitingForSoundsAfterNormalCompletion = false;
                 useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
                 return;
             case PythonExecRunningState.RunningAwaitingStop:
@@ -732,14 +744,35 @@ export default defineComponent({
                             }
                         }, parser.getFramePositionMap());
                     }
-                    useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
                     setPythonExecAreaLayoutButtonPos();
                     // A runtime error may happen whenever the user code failed, therefore we should check if an error
                     // when Skulpt indicates the code execution has finished.
                     this.checkNonePrecompiledErrors();
-                    soundManager?.stopAllSounds();
-                    // We always restart Pyodide for a clean state:
+                    // We always restart Pyodide for a clean state, regardless of whether we still
+                    // need to wait below for sounds to finish -- the worker itself is done either way:
                     void terminateAndRestartPyodide();
+                    if (wasStoppedByUser || possibleError != null) {
+                        // Either the user already clicked Stop (which already stopped the sounds
+                        // and set NotRunning), or the code ended with an uncaught error, in which
+                        // case we stop any sounds immediately rather than waiting for them:
+                        soundManager?.stopAllSounds();
+                        useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
+                    }
+                    else {
+                        // Normal completion with no error: keep showing "Stop" and wait for any
+                        // still-playing sounds to finish naturally, as if there were an invisible
+                        // wait_for_all_sounds_to_finish() at the end of the program. This must not
+                        // block the main thread, and clicking Stop during this time (handled in
+                        // runClicked()) will stop the sounds and resolve this early.
+                        waitingForSoundsAfterNormalCompletion = true;
+                        soundManager?.waitForAllSoundsToFinish().then(() => {
+                            if (waitingForSoundsAfterNormalCompletion) {
+                                waitingForSoundsAfterNormalCompletion = false;
+                                useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
+                                setPythonExecAreaLayoutButtonPos();
+                            }
+                        });
+                    }
                 });
                 
                 // We make sure the number of errors shown in the interface is in line with the current state of the code

--- a/src/stryperuntime/sound_manager.ts
+++ b/src/stryperuntime/sound_manager.ts
@@ -219,4 +219,24 @@ export class SoundManager {
             }
         });
     }
+
+    // Resolves once every sound that is currently playing has finished (naturally, or because
+    // stopAllSounds()/stopAudioBuffer() was called on it). Sounds started after this is called
+    // are not waited for, matching the "invisible wait_for_all_sounds_to_finish() at the very
+    // end of the program" semantics this is used for.
+    waitForAllSoundsToFinish() : Promise<void> {
+        const stillPlaying = [...this.bufferToSource.values()];
+        return Promise.all(stillPlaying.map((source) => new Promise<void>((resolve) => {
+            // stopAudioBuffer()/stopAllSounds() calling source.stop() also fires "ended",
+            // so this resolves either way; if it already ended, onended has already run
+            // and been cleared, but the buffer would then no longer be in bufferToSource above.
+            const prevOnEnded = source.onended;
+            source.onended = (ev) => {
+                if (typeof prevOnEnded === "function") {
+                    prevOnEnded.call(source, ev);
+                }
+                resolve();
+            };
+        }))).then(() => undefined);
+    }
 }

--- a/tests/cypress/e2e/autocomplete-graphics-libs.cy.ts
+++ b/tests/cypress/e2e/autocomplete-graphics-libs.cy.ts
@@ -1,5 +1,5 @@
 import { scssVars } from "../support/standard-setup";
-import { clearDefaultImports, pressFrameShortcut, pressFrameShortcutThenType } from "../support/test-support";
+import {clearDefaultImports, pressFrameShortcut, pressFrameShortcutThenType, waitForEditorSettled} from "../support/test-support";
 
 require("cypress-terminal-report/src/installLogsCollector")();
 import "@testing-library/cypress/add-commands";
@@ -201,14 +201,17 @@ describe("Graphics library", () => {
         focusEditorAC();
         // Add graphics import:
         clearDefaultImports();
-        cy.get("body").type("fstrype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
+        cy.get("body").type("from strype.graphics{rightarrow}*{rightarrow}{downarrow}{downarrow}");
         // Make an actor, then fetch the list of all actors:
-        cy.get("body").type("=a=Actor('cat-test.jpg'){rightarrow}");
-        cy.get("body").type("=all_actors=get_actors(){rightarrow}");
-        // Add a function frame and trigger auto-complete after popping an item off the list:
-        cy.get("body").type(" ");
-        cy.wait(500);
-        cy.get("body").type("all_actors.pop().{ctrl} ");
+        cy.get("body").type(" =a=Actor('cat-test.jpg')");
+        cy.get("body").type("{rightarrow}");
+        waitForEditorSettled();
+        cy.get("body").type(" =all_actors=get_actors()");
+        cy.get("body").type("{rightarrow}");
+        waitForEditorSettled();
+        cy.get("body").type("all_actors.pop().");
+        waitForEditorSettled();
+        cy.get("body").type("{ctrl} ");
         withAC((acIDSel, frameId) => {
             cy.get(acIDSel).should("be.visible");
             checkExactlyOneItem(acIDSel, null, "is_at_edge(distance)");

--- a/tests/cypress/e2e/basics.cy.ts
+++ b/tests/cypress/e2e/basics.cy.ts
@@ -387,9 +387,9 @@ describe("Classes", () => {
         // "from...import" here (unlike in "my code", where it needs disambiguating from "for"):
         clearDefaultImports();
         pressFrameShortcutThenType("f", "microbit Foo");
-        checkCodeEquals([
+        checkCodeEquals(([
             /from\s+microbit\s+import\s+Foo/,
-        ].concat(defaultMyCode));
+        ] as CodeMatch[]).concat(defaultMyCode));
     });
 });
 

--- a/tests/cypress/e2e/basics.cy.ts
+++ b/tests/cypress/e2e/basics.cy.ts
@@ -4,7 +4,7 @@ import {expect} from "chai";
 import en from "@/localisation/en/en_main.json";
 
 import failOnConsoleError from "cypress-fail-on-console-error";
-import {cleanFromHTML, getDefaultStrypeProjectDocumentationFullLine, pressFrameShortcut, pressFrameShortcutThenType} from "../support/test-support";
+import {cleanFromHTML, clearDefaultImports, getDefaultStrypeProjectDocumentationFullLine, pressFrameShortcut, pressFrameShortcutThenType} from "../support/test-support";
 import { scssVars, standardBeforeEach, strypeElIds } from "../support/standard-setup";
 failOnConsoleError();
 require("cypress-terminal-report/src/installLogsCollector")();
@@ -378,6 +378,18 @@ describe("Classes", () => {
             defaultMyCode[0],
             {h: /with\s+f\s+as\s+g\s*:/, b: []},
         ]).concat(defaultMyCode.slice(1)));
+    });
+
+    it("Lets you use space to move to the next slot in a from...import frame", () => {
+        checkCodeEquals(defaultImports.concat(defaultMyCode));
+        // Clear the default imports and add our own "from...import" there instead -- "for" isn't a
+        // valid command in the imports section, so the bare "f" shortcut resolves directly to
+        // "from...import" here (unlike in "my code", where it needs disambiguating from "for"):
+        clearDefaultImports();
+        pressFrameShortcutThenType("f", "microbit Foo");
+        checkCodeEquals([
+            /from\s+microbit\s+import\s+Foo/,
+        ].concat(defaultMyCode));
     });
 });
 

--- a/tests/playwright/e2e/sound-wait-after-run.spec.ts
+++ b/tests/playwright/e2e/sound-wait-after-run.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import { enterCode } from "../support/editor";
+import { checkConsoleContent, checkFrameErrorCount, startRunning } from "../support/execution";
+import { setupStrypeTest } from "../support/general";
+
+// Covers the behaviour added to PythonExecutionArea.vue/sound_manager.ts: when the user's code
+// finishes normally (no uncaught error, not stopped by the user) while a sound started with
+// play() is still going, execution should behave as if there were an invisible
+// wait_for_all_sounds_to_finish() at the very end of the program -- the run button keeps showing
+// "Stop" until the sound finishes on its own, and clicking Stop during that wait immediately stops
+// the sound and ends the run, rather than waiting for the timeout below.
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    if (browserName === "firefox") {
+        // Same headless-sound limitation noted in console-execution.spec.ts's sound tests.
+        testInfo.skip(true, "Playing sound headless doesn't work in Firefox");
+    }
+    await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 120000});
+});
+
+test.describe("Waiting for sounds after normal completion", () => {
+    test("Keeps showing Stop until a still-playing sound finishes, then returns to Run", async ({page}) => {
+        // ~0.5s of silence at the default 44100 sample rate; the code finishes almost immediately
+        // after starting it, well before the sound itself is done:
+        await enterCode(page, ["from strype.sound import *", "", `
+s = Sound([0] * 22050)
+s.play()
+print("done")`]);
+        const button = await startRunning(page);
+        await checkConsoleContent(page, "done\n");
+
+        // The code has finished, but the sound is still playing, so the button must still say
+        // Stop rather than having already flipped back to Run:
+        await expect(button).toHaveText(/Stop/);
+
+        // Once the sound finishes on its own, the run should end without any further user action:
+        await expect(button).toHaveText("Run", {timeout: 5000});
+        await checkFrameErrorCount(page, 0);
+    });
+
+    test("Clicking Stop while waiting for a sound stops it immediately", async ({page}) => {
+        // A much longer sound (~10s) than we're willing to wait for in the test, so the run only
+        // ending quickly demonstrates that Stop interrupted the wait rather than the sound just
+        // happening to finish on its own:
+        await enterCode(page, ["from strype.sound import *", "", `
+s = Sound([0] * (44100 * 10))
+s.play()
+print("done")`]);
+        const button = await startRunning(page);
+        await checkConsoleContent(page, "done\n");
+        await expect(button).toHaveText(/Stop/);
+
+        // Click Stop while we're still in the "waiting for sound" phase:
+        await button.click();
+
+        // Should return to Run promptly, not after anything like the sound's 10s duration:
+        await expect(button).toHaveText("Run", {timeout: 5000});
+        await checkFrameErrorCount(page, 0);
+    });
+});

--- a/tests/playwright/e2e/sound-wait-after-run.spec.ts
+++ b/tests/playwright/e2e/sound-wait-after-run.spec.ts
@@ -56,4 +56,30 @@ print("done")`]);
         await expect(button).toHaveText("Run", {timeout: 5000});
         await checkFrameErrorCount(page, 0);
     });
+
+    test("strype.graphics.stop() still waits for a still-playing sound to finish", async ({page}) => {
+        // stop() ends the program early by raising SystemExit -- this must be treated like a normal
+        // completion for sound-waiting purposes (not like an uncaught error, and not like the user's
+        // own Stop button click), so the run should still wait for the ~0.5s sound below rather than
+        // cutting it off immediately:
+        await enterCode(page, ["from strype.sound import *\nfrom strype.graphics import stop", "", `
+s = Sound([0] * 22050)
+s.play()
+print("done")
+stop()
+print("never printed")`]);
+        const button = await startRunning(page);
+        await checkConsoleContent(page, "done\n");
+
+        // The program has ended via stop(), but the sound is still playing, so the button must
+        // still say Stop rather than having already flipped back to Run:
+        await expect(button).toHaveText(/Stop/);
+
+        // Once the sound finishes on its own, the run should end without any further user action:
+        await expect(button).toHaveText("Run", {timeout: 5000});
+        // stop() must not be reported as a runtime error:
+        await checkFrameErrorCount(page, 0);
+        // Nothing after stop() should have run:
+        await checkConsoleContent(page, "done\n");
+    });
 });


### PR DESCRIPTION
This has a few different small fixes:
 - Fix a test which was failing because the keypresses needed adjusting to the latest version
 - Make space move to the next slot from the first slot of "from...import...", like we recently did for "for..in.." and "with..as.."
 - Change the program completion to wait for pending sounds to finish before changing from Stop->Run, unless it ended with an uncaught exception.  Clicking stop while waiting for the sounds to finish will kill them and allow running again.