### PR TITLE
Fix Run button getting stuck showing Stop with nothing executing

### DIFF
--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -644,6 +644,10 @@ export default defineComponent({
                 // const reference to it for the duration of a Python run: 
                 const client = getPythonClient();
                 if (client == null) {
+                    // Shouldn't normally happen (the Run button is disabled while
+                    // isPythonWorkerReady is false), but if it does, don't leave the
+                    // button stuck showing "Stop" with nothing actually running:
+                    useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
                     return;
                 }
                 

--- a/src/stryperuntime/main_thread_python_handler.ts
+++ b/src/stryperuntime/main_thread_python_handler.ts
@@ -126,6 +126,12 @@ export async function terminateAndRestartPyodide() : Promise<void> {
     // point, regardless of what kind of request it was waiting on -- so the worker actually stops
     // instead of continuing. We cap how long we wait for that (it should be near-instant) so a
     // slow/stuck write can never stop us from terminating below:
+    // Mark the worker as not-ready immediately: activeSlot is about to be terminated and
+    // swapped out below, and until activateSlot() runs again at the end of this function,
+    // any Run click that slips through (isPythonWorkerReady was previously left stale/true
+    // during this whole window) could pick up a client that's mid-termination or briefly
+    // null, get no response, and leave the UI stuck showing "Stop" with nothing running:
+    isPythonWorkerReady.value = false;
     const client = activeSlot?.client;
     if (client?.state === "awaitingMessage" || client?.state === "sleeping") {
         try {


### PR DESCRIPTION
This is an attempted fix for the issue Michael saw with the Run button not doing anything.

Further explanation: terminateAndRestartPyodide() left isPythonWorkerReady stale at true for its whole async duration (interrupt wait, worker.terminate(), slot swap), even though the Run button's disabled state is gated on that flag. A click landing in that window could pick up a client mid-termination (or briefly null), get no response, and leave the button stuck on "Stop" with nothing running until the user clicked Stop then Run again.

Clear isPythonWorkerReady immediately at the start of the restart so the button is disabled for that window instead of accepting a doomed click, and reset the running state defensively if getPythonClient() ever does return null.