### PR TITLE
Fix Google Drive Strype folder ID incorrectly cleared on unrelated errors

### DIFF
--- a/src/components/GoogleDriveComponent.vue
+++ b/src/components/GoogleDriveComponent.vue
@@ -456,7 +456,10 @@ export default defineComponent({
                 }
                 else{
                     // If we were looking for the Strype folder, then we also need to reset our internal flag
-                    this.strypeFolderId = "";
+                    // (if we were checking another folder instead, the Strype folder lookup is unaffected, so leave it alone)
+                    if(checkStrypeFolder){
+                        this.strypeFolderId = "";
+                    }
                     return checkFolderDoneCallBack(strypeFolderId);
                 }
             });


### PR DESCRIPTION
## Summary
- `checkDriveStrypeOrOtherFolder()` in `GoogleDriveComponent.vue` unconditionally reset the cached `strypeFolderId` to `""` on any non-auth request failure, even when the failed request was checking an unrelated folder (the current project's location, via `checkStrypeFolder === false`) rather than the Strype root folder itself.
- This meant a transient error (network blip, rate limit, etc.) while checking the current project folder could wipe out an already-valid Strype folder ID, causing the "Strype" shortcut view to disappear from the Google Drive file picker (`GoogleDriveFilePicker.vue`) even though the Strype folder was never queried in that request.
- Fix: only clear `strypeFolderId` when the failed request was actually looking up the Strype folder (`checkStrypeFolder === true`), matching the existing code comment's stated intent.

## Test plan
- [ ] Manually reproduce: trigger a failed Drive request while `checkStrypeFolder` is `false` (e.g. simulate an error looking up the current project folder) and confirm the "Strype" shortcut still appears in the file picker afterwards.