### PR TITLE
Fix Run/Stop button getting stuck when the service worker drops out; editor typing performance

### DIFF
--- a/src/autocompletion/acManager.ts
+++ b/src/autocompletion/acManager.ts
@@ -6,7 +6,7 @@ import {getAllEnabledUserDefinedClasses, getAllEnabledUserDefinedFunctions} from
 import i18n from "@/i18n";
 import {Signature, TPyParser} from "@tigerpython/tpparser";
 import {getAvailablePyPyiFromLibrary, getPossibleImports, getTextFileFromLibraries} from "@/helpers/libraryManager";
-import Parser, { AC_PROBE_MARKER } from "@/parser/parser";
+import Parser, { AC_PROBE_MARKER, getCachedCodeWithoutErrors } from "@/parser/parser";
 import {extractPYI} from "@/helpers/python-pyi";
 import {AcResultsWithCategorySchema} from "@/types/ac-types-zod";
 import builtinsMod from "@/../pysrc/pyi/builtins.pyi?raw";
@@ -751,9 +751,43 @@ export function buildProbeCodeAndOffset(baseCode: string, context: string): {cod
     return {code, offset: markerIndex + probePrefix.length};
 }
 
+// calculateParamPrompt (below) recomputes on every keystroke in a function call's argument list
+// (it's driven by a Vue computed over the label's slots), but its result only actually depends on
+// which parameter position we're at (context/token/paramIndex/lastParam/prevKeywordNames/isFocused)
+// -- none of which change from typing into an argument's own value, only from editing the call's
+// function-name chain, or adding/removing brackets/commas/equals signs there (all of which already
+// produce a fresh placeholderSource tuple via checkSlotRefactoring's reparse, so a cache keyed on
+// that tuple naturally misses exactly when needed for those). For calls to a locally-defined
+// function/class (blank context), the signature is also read fresh from that definition's own
+// frame data every time regardless of context/token changing at the call site -- so editing a
+// function's formal parameters (rename/add/remove/default value) needs to invalidate every cached
+// prompt too, done coarsely via invalidateParamPromptCache() (called from checkSlotRefactoring
+// whenever the edited label is a funcdef's parameter list) rather than tracked per-function, since
+// formal-param edits are rare compared to normal typing. Calls resolved via TigerPython's
+// whole-document evidence inference (the dotted/context branch below, e.g. "ax.plot(...)") aren't
+// specially invalidated when their evidence changes elsewhere (e.g. the assignment that establishes
+// what "ax" is) -- accepted as a rare staleness tradeoff versus recomputing every keystroke.
+const paramPromptCache = new Map<string, Promise<string>>();
+
+export function invalidateParamPromptCache(): void {
+    paramPromptCache.clear();
+}
+
+export async function calculateParamPrompt(frameId: number, placeholderSource : {context: string, token: string, paramIndex: number, lastParam: boolean, prevKeywordNames: string[]}, isFocused: boolean) : Promise<string> {
+    const {context, token, paramIndex, lastParam, prevKeywordNames} = placeholderSource;
+    const cacheKey = `${context}|${token}|${paramIndex}|${lastParam}|${prevKeywordNames.join(",")}|${isFocused}`;
+    const cached = paramPromptCache.get(cacheKey);
+    if (cached !== undefined) {
+        return cached;
+    }
+    const promise = calculateParamPromptUncached(frameId, placeholderSource, isFocused);
+    paramPromptCache.set(cacheKey, promise);
+    return promise;
+}
+
 // Gets the parameter name prompt for the given autocomplete details (context+token)
 // for the given parameter. Note that for the UI to display spans properly, empty placeholders are returned as \u200b (0-width space)
-export async function calculateParamPrompt(frameId: number, {context, token, paramIndex, lastParam, prevKeywordNames} : {context: string, token: string, paramIndex: number, lastParam: boolean, prevKeywordNames: string[]}, isFocused: boolean) : Promise<string> {
+async function calculateParamPromptUncached(frameId: number, {context, token, paramIndex, lastParam, prevKeywordNames} : {context: string, token: string, paramIndex: number, lastParam: boolean, prevKeywordNames: string[]}, isFocused: boolean) : Promise<string> {
     if (!context) {
         // If context is blank, we know that the function must be one of:
         // - A user-defined function (of the section definitions only )
@@ -814,7 +848,7 @@ export async function calculateParamPrompt(frameId: number, {context, token, par
     if (context) {
         // See if TigerPython can infer the type of the content before the dot (".")
         const parser = new Parser(false, "py", true);
-        const userCode = parser.getCodeWithoutErrors(frameId);
+        const userCode = getCachedCodeWithoutErrors(parser, frameId);
         await tpyDefineLibraries(parser);
         // getCodeWithoutErrors() leaves AC_PROBE_MARKER exactly where the frame we're editing sits, so
         // the probe below ends up correctly nested there, however much other code (e.g. evidence for a

--- a/src/components/AutoCompletion.vue
+++ b/src/components/AutoCompletion.vue
@@ -81,7 +81,7 @@ import _ from "lodash";
 import { mapStores } from "pinia";
 import {getAllEnabledUserDefinedClasses, getAllEnabledUserDefinedFunctions} from "@/helpers/storeMethods";
 import {buildProbeCodeAndOffset, getAllExplicitlyImportedItems, getAllUserDefinedVariablesUpTo, getAvailableItemsForImportFromModule, getAvailableModulesForImport, getBuiltins, tpyDefineLibraries, getUserDefinedSignature} from "@/autocompletion/acManager";
-import Parser from "@/parser/parser";
+import Parser, { getCachedCodeWithoutErrors } from "@/parser/parser";
 import { CustomEventTypes, parseLabelSlotUID } from "@/helpers/editor";
 import {Completion, Signature, SignatureArg, TPyParser} from "@tigerpython/tpparser";
 import scssVars from "@/assets/style/_export.module.scss";
@@ -300,7 +300,7 @@ export default defineComponent({
         async updateAC(frameId: number, token : string | null, context: string, kind: "code" | "string"): Promise<void> {
             const tokenStartsWithUnderscore = (token ?? "").startsWith("_");
             const parser = new Parser(false, "py", true);
-            const userCode = parser.getCodeWithoutErrors(frameId);
+            const userCode = getCachedCodeWithoutErrors(parser, frameId);
             
             await tpyDefineLibraries(parser);
             

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -182,6 +182,12 @@ export default defineComponent({
 
     beforeUnmount() {
         this.appStore.removePreCompileErrors(this.UID);
+        // Cancel any pending debounced updateAC() call -- otherwise it can fire after this slot
+        // (and potentially its whole frame) no longer exists, reading stale/gone state. Concretely
+        // hit as a CI regression: updateACForModuleImport() ran against an import frame that had
+        // since been torn down, ending up with a garbage/empty library address and throwing
+        // "Failed to construct 'URL': Invalid base URL" as an unhandled rejection.
+        (this.updateAC as unknown as DebouncedFunc<() => void>).cancel();
     },
 
     data: function() {
@@ -723,6 +729,11 @@ export default defineComponent({
         // Event callback equivalent to what would happen for a blur event callback 
         // (the spans don't get focus anymore because the containg editable div grab it)
         onLoseCaret(event: CustomEvent<{keepIgnoreKeyEventFlagOn?: boolean, keepEditingModeOn?: boolean}>): void {
+            // A pending debounced updateAC() call is for whatever was focused before -- once we've
+            // lost the caret, that's no longer relevant (and firing it later, e.g. against a slot
+            // whose frame has since been removed, is a source of stale-state bugs; see the
+            // matching cancel() in beforeUnmount()):
+            (this.updateAC as unknown as DebouncedFunc<() => void>).cancel();
             const {keepIgnoreKeyEventFlagOn, keepEditingModeOn} = event.detail??{};
             this.$nextTick(() => vueComponentsAPIHandler.labelSlotsStructureComponentAPI?.forInstance[getFrameLabelSlotsStructureUID(this.frameId, this.labelSlotsIndex)].updatePrependTextAndCheckErrors());
             // Before anything, we make sure that the current frame still exists,

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -172,7 +172,7 @@ export default defineComponent({
         }
     },
 
-    beforeUnmounts() {
+    beforeUnmount() {
         this.appStore.removePreCompileErrors(this.UID);
     },
 
@@ -1108,8 +1108,12 @@ export default defineComponent({
             //   with operators and brackets which can create new slots.
             // - Delete and backspace are not input events so they happen elsewhere.
             
-            const stateBeforeChanges = cloneDeep(this.appStore.$state);
-            
+            // Scoped to this frame only: ordinary character input only ever mutates this.frameId's own slots
+            // (see checkSlotRefactoring()/performKeywordFrameConversion() in LabelSlotsStructure.vue -- the
+            // keyword-frame-conversion path re-widens this to a full clone itself before it reparents/attaches
+            // any other frame, since that's the one case here that can reach beyond this.frameId).
+            const stateBeforeChanges = this.appStore.cloneStateForUndo([this.frameId]);
+
             const inputSpanField = document.getElementById(this.UID) as HTMLSpanElement;
             const inputSpanFieldContent = inputSpanField.textContent ?? "";
             const currentSlot = retrieveSlotFromSlotInfos(this.coreSlotInfo) as BaseSlot;

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -84,7 +84,7 @@ import { getCandidatesForAC } from "@/autocompletion/acManager";
 import { mapStores } from "pinia";
 import {evaluateSlotType, getFlatNeighbourFieldSlotInfos, getOutmostDisabledAncestorFrameId, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isFrameLabelSlotStructWithCodeContent, retrieveParentSlotFromSlotInfos, retrieveSlotFromSlotInfos} from "@/helpers/storeMethods";
 import Parser from "@/parser/parser";
-import { cloneDeep } from "lodash";
+import { cloneDeep, debounce, DebouncedFunc } from "lodash";
 import { BPopover, useToggle } from "bootstrap-vue-next";
 import scssVars from "@/assets/style/_export.module.scss";
 import {drawSoundOnCanvas} from "@/helpers/media";
@@ -127,6 +127,14 @@ export default defineComponent({
         else{
             vueComponentsAPIHandler.labelSlotComponentAPI.forInstance[this.UID] = apiMethods;
         }
+
+        // updateAC() triggers a full-document TigerPython parse (via AutoCompletion.vue's
+        // updateAC()) on essentially every keystroke while a slot is focused, which is expensive
+        // on large documents (profiled separately). Debounce it so a burst of typing only pays
+        // that cost once it pauses, rather than on every character. Callers that need results
+        // immediately (explicit Ctrl+Space request, or gaining focus on a slot) call updateAC()
+        // and then flush() it straight after -- see onKeyDown()/onGetCaret().
+        this.updateAC = debounce(this.updateAC, 150);
     },
 
     components: {
@@ -621,6 +629,16 @@ export default defineComponent({
                 document.getElementById(getLabelSlotUID(this.coreSlotInfo))?.scrollIntoView({block: "nearest"});
 
                 this.updateAC();
+                // onGetCaret() is also invoked on essentially every keystroke -- not just real
+                // focus changes -- via checkSlotRefactoring's cursor-repositioning dispatch of
+                // "slotGotCaret" after each reparse (see LabelSlotsStructure.vue), so flushing
+                // unconditionally here would defeat updateAC()'s debounce for normal typing.
+                // fromNaturalClick is only true for an actual mouse click into the slot -- a
+                // one-off event, not a rapid-fire burst -- so it's safe (and desirable, for
+                // responsiveness) to flush immediately in that case only:
+                if (fromNaturalClick) {
+                    (this.updateAC as unknown as DebouncedFunc<() => void>).flush();
+                }
 
                 // As we receive focus, we show the error popover if required. Note that we do it programmatically as it seems the focus trigger on popover isn't working in our configuration
                 if(this.erroneous()){
@@ -927,6 +945,11 @@ export default defineComponent({
 
             // We capture the key shortcut for opening the a/c
             if((event.metaKey || event.ctrlKey) && event.key == " "){
+                // updateAC() is debounced (see created()) so a paused-but-not-yet-fired debounce
+                // could otherwise show stale results here -- force it to run immediately, since
+                // the user explicitly asked for completions right now:
+                this.updateAC();
+                (this.updateAC as unknown as DebouncedFunc<() => void>).flush();
                 this.showAC = true;
                 event.preventDefault();
                 event.stopPropagation();

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -63,7 +63,7 @@ import { bumpCaretRequestSeq, CustomEventTypes, getEditableSelectionText, getFra
 import { checkCodeErrors, evaluateSlotType, filterAllowedJointChildrenAfter, generateFlatSlotBases, getFlatNeighbourFieldSlotInfos, getFrameParentSlotsLength, getParentOrJointParent, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, retrieveSlotByPredicate, retrieveSlotFromSlotInfos, getParentId, areSlotStructuresIsomorphic, getAncestorFrameOfTypeId, findSlotsWithIndentifierName, isAncestorGatedFrameTypeAllowed } from "@/helpers/storeMethods";
 import { cloneDeep } from "lodash";
 import Parser from "@/parser/parser";
-import { calculateParamPrompt } from "@/autocompletion/acManager";
+import { calculateParamPrompt, invalidateParamPromptCache } from "@/autocompletion/acManager";
 import scssVars from "@/assets/style/_export.module.scss";
 import { isMacOSPlatform, splitByRegexMatches } from "@/helpers/common";
 import { detectBrowser } from "@/helpers/browser";
@@ -547,6 +547,15 @@ export default defineComponent({
                     this.partialIgnoreRefocus = true;
                 }
                 this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures = parsedCodeRes.slots;
+                // If this label is a funcdef's formal parameter list, any edit here (renaming a
+                // param, adding/removing one, adding/removing a default value) can change what
+                // calculateParamPrompt() should show at call sites elsewhere in the document --
+                // invalidate its cache so those pick up the change next time they're computed
+                // (see the comment on invalidateParamPromptCache() for why this is coarse rather
+                // than tracking which specific call sites are affected).
+                if (allowed === AllowedSlotContent.ONLY_FORMAL_PARAMS) {
+                    invalidateParamPromptCache();
+                }
                 // The parser can be return a different size "code" of the slots than the code literal
                 // (that is for example the case with textual operators which requires spacing in typing, not in the UI)
                 focusCursorAbsPos += parsedCodeRes.cursorOffset;

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -630,6 +630,14 @@ export default defineComponent({
                                         // characters) -- buffering keystrokes during the conversion's own brief async
                                         // gap replaces it, so there's no reason left to delay the conversion itself.
                                         this.startPendingConversion();
+                                        // A keyword-frame conversion (if/elif/for/while/etc.) can reparent this frame and/or
+                                        // attach/detach joint frames on its parent, reaching beyond this.frameId -- so if
+                                        // stateBeforeChanges was captured scoped to just this frame (see LabelSlot.vue's
+                                        // onInput()), widen it to a full clone here, before any such mutation has happened,
+                                        // so undo/redo still captures every frame this conversion actually touches.
+                                        if((stateBeforeChanges as any).__touchedFrameIds !== undefined) {
+                                            stateBeforeChanges = this.appStore.cloneStateForUndo();
+                                        }
                                         this.performKeywordFrameConversion(keywordFrameConversionDef, candidateKeyword[1].length, uiLiteralCode, stateBeforeChanges, options?.triggeredByEnter ? 0 : 1, {...options, isColonTrigger});
                                     }
                                     else if(isVarAssignSlotStructure && this.labelIndex == 0 && !((currentFocusSlotCursorInfos?.slotInfos.slotId??",").includes(",")) && this.appStore.frameObjects[this.frameId].frameType.type == AllFrameTypesIdentifier.funccall && uiLiteralCode.match(/(?<!=)=(?!=)/) != null){

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -782,8 +782,21 @@ export default defineComponent({
                             }
                         });
                     }
+                }).catch((err) => {
+                    // client.call() itself can reject -- not just resolve with a possibleError --
+                    // e.g. if a sync request from the worker (see bridgeSync/makeRawRequest) couldn't
+                    // reach the main thread because the service worker sync-message channel was briefly
+                    // down (ServiceWorkerError). Without this handler that rejection went unhandled and
+                    // the .then() above never ran, leaving the Run button stuck showing "Stop" with
+                    // nothing running until the user clicked Stop then Run again to force a reset:
+                    console.error("Python execution failed to complete: ", err);
+                    setPythonExecAreaLayoutButtonPos();
+                    // The worker may be left in a broken/uncertain state, so get a clean one for next time:
+                    void terminateAndRestartPyodide();
+                    soundManager?.stopAllSounds();
+                    useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
                 });
-                
+
                 // We make sure the number of errors shown in the interface is in line with the current state of the code
                 // Note that a run time error can still occur later.                
                 this.checkNonePrecompiledErrors();

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -85,11 +85,11 @@ import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
 import { BTab, BTabs } from "bootstrap-vue-next";
 import * as Comlink from "comlink";
 import {handleErrorTrace, setSInputConsole} from "@/helpers/execPythonCode";
-import {PyodideErrorDetails, serviceWorkerReadyAndInControl} from "@/workers/shared_helpers";
+import {isServiceWorkerChannelResponsive, PyodideErrorDetails, serviceWorkerReadyAndInControl} from "@/workers/shared_helpers";
 import {SpriteHandle, SyncOrAsyncStrypePyodideWorkerRequest} from "@/stryperuntime/worker_bridge_type";
 import {SoundManager} from "@/stryperuntime/sound_manager";
 import {handleAsyncRequests, handleSyncRequests} from "@/stryperuntime/main_bridge_handler";
-import {getPythonClient, isPythonWorkerReady, renderer, terminateAndRestartPyodide} from "@/stryperuntime/main_thread_python_handler";
+import {getPythonClient, isPythonWorkerReady, renderer, serviceWorkerChannel, terminateAndRestartPyodide} from "@/stryperuntime/main_thread_python_handler";
 import { TurtlePixiHandler } from "@/stryperuntime/turtle_pixi_handler";
 import {createOrGetAudioContext} from "@/helpers/audioContext";
 import {clearAllRuntimeErrors, computeFrameSnapshot} from "@/helpers/storeMethods";
@@ -641,7 +641,7 @@ export default defineComponent({
                 setSInputConsole(pythonConsole);
                 
                 // getPythonClient() can change value if restarted so important we take one
-                // const reference to it for the duration of a Python run: 
+                // const reference to it for the duration of a Python run:
                 const client = getPythonClient();
                 if (client == null) {
                     // Shouldn't normally happen (the Run button is disabled while
@@ -650,7 +650,30 @@ export default defineComponent({
                     useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
                     return;
                 }
-                
+
+                // The run depends on the sync-message service worker channel throughout (input(),
+                // cloud file I/O, output catch-up), but nothing normally confirms it's actually
+                // being intercepted before we commit to running -- a controller can be present yet
+                // not truly answering (Safari is known to silently lose a backgrounded tab's service
+                // worker), in which case the run would only fail ~5s in, deep inside the worker.
+                // Check fast, and if it's not responding try to get the service worker to reclaim
+                // us before proceeding; if that doesn't help either, we still go ahead -- the
+                // .then()/.catch() below will reset the Run button cleanly rather than leaving it
+                // stuck, so this is a best-effort speed-up, not a hard gate:
+                if (!(await isServiceWorkerChannelResponsive(serviceWorkerChannel.baseUrl))) {
+                    console.error("Service worker sync channel not responding; attempting to reclaim control before running");
+                    const registration = await navigator.serviceWorker.getRegistration();
+                    await registration?.update();
+                    await new Promise<void>((resolve) => {
+                        const timeout = setTimeout(resolve, 1500);
+                        navigator.serviceWorker.addEventListener("controllerchange", () => {
+                            clearTimeout(timeout);
+                            resolve();
+                        }, {once: true});
+                        registration?.active?.postMessage("claim");
+                    });
+                }
+
                 const syncBridgePromise = handleSyncRequests(renderer, soundManager as SoundManager, turtlePixiHandler, {
                     getPressedKeys: () => pressedKeys,
                     waitForNextKey: () => {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -942,6 +942,32 @@ export default class Parser {
             code = STRYPE_EXPRESSION_BLANK;
         }
         
-        return {code: code, slotLengths: slotLengths, slotStarts: slotStarts, slotIds: slotIds, slotTypes: slotTypes}; 
+        return {code: code, slotLengths: slotLengths, slotStarts: slotStarts, slotIds: slotIds, slotTypes: slotTypes};
     }
+}
+
+// getCodeWithoutErrors() re-parses and re-type-checks the *whole* document from scratch, which is
+// expensive on large documents -- and it's called from two independent places (AutoCompletion.vue's
+// updateAC(), and acManager.ts's calculateParamPrompt() for dotted-context calls like "ax.plot(...)")
+// that can both run for the same frameId around the same "settle" moment after a keystroke, doing
+// the same work twice. Both callers construct their Parser with identical arguments
+// (new Parser(false, "py", true)), and the method is a pure function of (frameId, document state),
+// so the result can safely be shared between them.
+//
+// Cached against editorLastModificationAt rather than a purpose-built counter: it's already the
+// store's existing "content was modified" signal, bumped by saveStateChanges() *and*
+// applyStateUndoRedoChanges() (undo/redo doesn't go through saveStateChanges, so a cache keyed only
+// on the latter would miss it) and a couple of other content/state-modifying actions -- so this
+// self-invalidates on any edit without needing new invalidation call sites scattered around.
+const codeWithoutErrorsCache = new Map<number, {modifiedAt: number; result: string}>();
+
+export function getCachedCodeWithoutErrors(parser: Parser, frameId: number): string {
+    const modifiedAt = useStore().editorLastModificationAt;
+    const cached = codeWithoutErrorsCache.get(frameId);
+    if (cached !== undefined && cached.modifiedAt === modifiedAt) {
+        return cached.result;
+    }
+    const result = parser.getCodeWithoutErrors(frameId);
+    codeWithoutErrorsCache.set(frameId, {modifiedAt, result});
+    return result;
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1343,20 +1343,53 @@ export const useStore = defineStore("app", {
             }); 
         },
 
+        // Clones state for later use with saveStateChanges(), to compute the undo/redo diff against.
+        // Cloning (and later diffing) the entire state on every single keystroke is expensive on large files,
+        // since it's proportional to the whole document's frame/slot count rather than to the size of the edit.
+        // When a caller can be sure the edit it's about to make will only ever touch specific frames (e.g. typing
+        // inside one frame's slot), it can pass those frame ids here so only those frames' subtrees are cloned/diffed,
+        // instead of the whole frameObjects tree. Leave touchedFrameIds undefined (the safe default) whenever the
+        // edit might reach beyond a known, fixed set of frames (e.g. drag and drop, keyword-frame conversion which
+        // can reparent/attach joint frames, or a rename that can touch arbitrarily many frames) -- an incomplete
+        // touchedFrameIds list would silently drop those other frames' changes from the undo/redo history.
+        cloneStateForUndo(touchedFrameIds?: number[]): (typeof this.$state) {
+            if(touchedFrameIds === undefined) {
+                return cloneDeep(this.$state);
+            }
+            const {frameObjects, ...restState} = this.$state;
+            const clonedState = cloneDeep(restState) as (typeof this.$state);
+            clonedState.frameObjects = {} as (typeof this.$state)["frameObjects"];
+            for(const frameId of touchedFrameIds) {
+                if(frameObjects[frameId] !== undefined) {
+                    clonedState.frameObjects[frameId] = cloneDeep(frameObjects[frameId]);
+                }
+            }
+            // Tag the clone with the scope it was taken at, so saveStateChanges() can scope its own clone/diff
+            // to match -- deleted again before the object is actually used as part of the state comparison.
+            (clonedState as any).__touchedFrameIds = touchedFrameIds;
+            return clonedState;
+        },
+
         saveStateChanges(previousState: (typeof this.$state)) {
             // If have an explicit request to igore the undo/redo save state preps, we don't do anything
             if(this.ignoreStateSavingActionsForUndoRedo){
                 return;
             }
-            
+
             this.isEditorContentModified = true;
             this.editorLastModificationAt = Date.now();
+            // If previousState was captured via cloneStateForUndo(touchedFrameIds), scope our own clone of the
+            // current state to the same frames, so the diff below only has to walk those frames' subtrees rather
+            // than the whole document -- see cloneStateForUndo()'s comment for why this must only be done when
+            // we're sure no other frame could have changed.
+            const touchedFrameIds: number[] | undefined = (previousState as any).__touchedFrameIds;
+            delete (previousState as any).__touchedFrameIds;
             // Saves the state changes in diffPreviousState.
-            // We do not simply save the differences between the state and the previous state, because when undo/redo will be invoked, we cannot know what will be 
+            // We do not simply save the differences between the state and the previous state, because when undo/redo will be invoked, we cannot know what will be
             // the navigation status in the editor (i.e. are we editing? what blue caret or text cursor is currenty displayed), and there might not be any difference right now.
             // So to make sure that we will ALWAYS see a difference of positioning no matter the situation, we simlate a mock change with dummy positioning,
             // in order to get the previous state saved correctly regarding navigation.
-            const stateCopy = cloneDeep(this.$state);
+            const stateCopy = this.cloneStateForUndo(touchedFrameIds);
             stateCopy.currentFrame = {id: 0, caretPosition: CaretPosition.none};
             previousState.lastCriticalActionPositioning = {lastCriticalCaretPosition: previousState.currentFrame, lastCriticalSlotCursorInfos: previousState.focusSlotCursorInfos};
             this.lastCriticalActionPositioning = {

--- a/src/stryperuntime/main_thread_python_handler.ts
+++ b/src/stryperuntime/main_thread_python_handler.ts
@@ -18,8 +18,11 @@ import * as Comlink from "comlink";
 import {makeServiceWorkerChannel} from "sync-message";
 import {ref} from "vue";
 
-// Can be re-used:
-const serviceWorkerChannel = makeServiceWorkerChannel({scope: import.meta.env.BASE_URL});
+// Can be re-used. Exported so PythonExecutionArea can health-check it before a run (see
+// isServiceWorkerChannelResponsive in shared_helpers.ts) -- Safari in particular is known to
+// silently drop a page's service worker controller (e.g. after backgrounding the tab), which
+// otherwise only surfaces ~5s into a run as a ServiceWorkerError from deep inside Pyodide:
+export const serviceWorkerChannel = makeServiceWorkerChannel({scope: import.meta.env.BASE_URL});
 
 export const renderer = new Renderer();
 export const isPythonWorkerReady = ref(false);

--- a/src/workers/shared_helpers.ts
+++ b/src/workers/shared_helpers.ts
@@ -19,3 +19,20 @@ export async function serviceWorkerReadyAndInControl() : Promise<void> {
     });
 }
 
+// Unlike serviceWorkerReadyAndInControl() above (which only checks that *some* controller is
+// present), this actually round-trips through the sync-message channel to confirm the service
+// worker is currently intercepting requests for it. A controller can be present yet not truly
+// answering (e.g. Safari silently losing a backgrounded tab's service worker), in which case a
+// Pyodide run that depends on the channel (input(), cloud file I/O, output catch-up) would only
+// discover the problem ~5s in, via a ServiceWorkerError from deep inside the worker. Kept to a
+// short timeout so a genuinely dead channel is detected fast rather than stalling the Run click:
+export async function isServiceWorkerChannelResponsive(channelBaseUrl: string, timeoutMs = 800) : Promise<boolean> {
+    try {
+        const response = await fetch(channelBaseUrl + "/version", {signal: AbortSignal.timeout(timeoutMs)});
+        return response.ok;
+    }
+    catch {
+        return false;
+    }
+}
+

--- a/src/workers/shared_helpers.ts
+++ b/src/workers/shared_helpers.ts
@@ -28,7 +28,13 @@ export async function serviceWorkerReadyAndInControl() : Promise<void> {
 // short timeout so a genuinely dead channel is detected fast rather than stalling the Run click:
 export async function isServiceWorkerChannelResponsive(channelBaseUrl: string, timeoutMs = 800) : Promise<boolean> {
     try {
-        const response = await fetch(channelBaseUrl + "/version", {signal: AbortSignal.timeout(timeoutMs)});
+        // Must be POST, not the fetch() default of GET: sync-message's own fetch listener
+        // doesn't care about method for /version, but if the service worker *isn't*
+        // intercepting, a GET to an unmatched path is commonly rewritten to a 200 (e.g. an SPA's
+        // own index.html fallback, in dev and in many production static hosts) -- so a GET here
+        // could report "healthy" when the channel is actually dead. POST to the same unmatched
+        // path correctly falls through to a real 404 instead:
+        const response = await fetch(channelBaseUrl + "/version", {method: "POST", signal: AbortSignal.timeout(timeoutMs)});
         return response.ok;
     }
     catch {

--- a/tests/playwright/e2e/undo-redo.spec.ts
+++ b/tests/playwright/e2e/undo-redo.spec.ts
@@ -1,0 +1,208 @@
+import {Page, test, expect} from "@playwright/test";
+import {setupStrypeTest} from "../support/general";
+import {clearDefaultProject, waitForEditorSettled} from "../support/editor";
+import {AllFrameTypesIdentifier} from "../../cypress/support/frame-types";
+import {
+    assertFrameType,
+    assertConversionDidNotHappen,
+    getFirstSlotText,
+    getFocusedFrameId,
+    typeKeywordConversionTrigger,
+} from "../support/keyword-conversion";
+
+// These tests target the undo/redo scoping introduced to avoid diffing/cloning the WHOLE
+// document's frame/slot tree on every keystroke (see cloneStateForUndo/saveStateChanges,
+// src/store/store.ts, and its use in LabelSlot.vue's onInput()): plain character edits within one
+// frame's slot are now cloned/diffed scoped to just that frame, rather than the whole state.
+//
+// "Scoped path" below means the new, narrower path (a single frame's own slot edits). "Full-scope
+// path" means edits that still (deliberately) clone/diff the whole state, either because they were
+// never scoped to begin with (e.g. paste, delete), or because LabelSlotsStructure.vue's
+// checkSlotRefactoring explicitly re-widens a scoped clone back to a full one right before a
+// keyword-frame conversion, since that can reparent/attach joint frames beyond the one frame that
+// was typed into (see the comment at its call to performKeywordFrameConversion).
+//
+// The two "sibling frames" tests specifically guard against the scoped path corrupting frames it
+// didn't declare as touched: if the scoping ever silently dropped another frame's data from a
+// diff (e.g. treating it as deleted because it's simply absent from the scoped clone), undoing
+// edits to one frame would wrongly affect a sibling's content -- exactly what this checks for.
+
+test.beforeEach(async ({page, browserName}, testInfo) => {
+    await setupStrypeTest(page, browserName, testInfo, {skipPyodide: true});
+    await clearDefaultProject(page);
+    // clearDefaultProject() leaves the caret at the top of (now-empty) Imports; every test here
+    // needs Main instead, which offers a plain func-call fallback for bare typed text.
+    await page.keyboard.press("ArrowDown"); // Imports -> Definitions
+    await waitForEditorSettled(page);
+    await page.keyboard.press("ArrowDown"); // Definitions -> Main
+    await waitForEditorSettled(page);
+});
+
+// Both Ctrl+Z/Ctrl+Y and Cmd+Z/Cmd+Y trigger undo/redo (Commands.vue checks event.ctrlKey ||
+// event.metaKey), so Control+z/Control+y work identically on every platform Playwright runs on.
+async function undo(page: Page, times = 1): Promise<void> {
+    for (let i = 0; i < times; i++) {
+        await page.keyboard.press("Control+z");
+        await waitForEditorSettled(page);
+    }
+}
+
+async function redo(page: Page, times = 1): Promise<void> {
+    for (let i = 0; i < times; i++) {
+        await page.keyboard.press("Control+y");
+        await waitForEditorSettled(page);
+    }
+}
+
+// Types a bare character at the current blank-line caret in Main, creating a func-call frame with
+// that single character as its content, and returns the new frame's id.
+async function createFuncCallFrame(page: Page, firstChar: string): Promise<number> {
+    await page.keyboard.type(firstChar);
+    await waitForEditorSettled(page);
+    return await getFocusedFrameId(page);
+}
+
+test.describe("Undo/redo -- scoped path (plain typing within a single frame)", () => {
+    test("undo/redo restores plain typed characters one keystroke at a time", async ({page}) => {
+        const frameId = await createFuncCallFrame(page, "a");
+        await page.keyboard.type("bc");
+        await waitForEditorSettled(page);
+        expect(await getFirstSlotText(page, frameId)).toEqual("abc");
+
+        await undo(page, 1);
+        expect(await getFirstSlotText(page, frameId)).toEqual("ab");
+
+        await undo(page, 1);
+        expect(await getFirstSlotText(page, frameId)).toEqual("a");
+
+        await redo(page, 1);
+        expect(await getFirstSlotText(page, frameId)).toEqual("ab");
+
+        await redo(page, 1);
+        expect(await getFirstSlotText(page, frameId)).toEqual("abc");
+    });
+
+    test("undoing/redoing edits to one frame does not affect a sibling frame's content", async ({page}) => {
+        // Creating a frame from a bare typed character is itself its own undoable step (it goes
+        // through a separate "paste the typed character into the newly-created slot" step, not
+        // the scoped onInput() path -- see createFuncCallFrame's callers elsewhere in this file).
+        // The undo stack is strictly chronological (LIFO), so B's 3 steps (creation + 2 edits)
+        // are always on top of A's -- this walks all the way down through B's, including its own
+        // creation (which removes frame B entirely), before reaching A's edits underneath.
+        const frameAId = await createFuncCallFrame(page, "x"); // a1
+        await page.keyboard.type("AB"); // a2, a3
+        await waitForEditorSettled(page);
+        expect(await getFirstSlotText(page, frameAId)).toEqual("xAB");
+
+        // Move below frame A and create a second, sibling frame B, then two more scoped edits.
+        await page.keyboard.press("Escape");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("ArrowDown");
+        await waitForEditorSettled(page);
+        const frameBId = await createFuncCallFrame(page, "y"); // b1
+        expect(frameBId).not.toEqual(frameAId);
+        await page.keyboard.type("CD"); // b2, b3
+        await waitForEditorSettled(page);
+        expect(await getFirstSlotText(page, frameBId)).toEqual("yCD");
+
+        // Undo frame B's two scoped edits: only B should change, A must stay exactly as it was.
+        await undo(page, 1); // undoes b3
+        expect(await getFirstSlotText(page, frameBId)).toEqual("yC");
+        expect(await getFirstSlotText(page, frameAId)).toEqual("xAB");
+
+        await undo(page, 1); // undoes b2
+        expect(await getFirstSlotText(page, frameBId)).toEqual("y");
+        expect(await getFirstSlotText(page, frameAId)).toEqual("xAB");
+
+        // Undo B's own creation: B disappears, but A -- lower down the stack, untouched by B's
+        // scoped diffs -- must still be exactly as it was.
+        await undo(page, 1); // undoes b1
+        await expect(page.locator(".frame-div")).toHaveCount(1);
+        expect(await getFirstSlotText(page, frameAId)).toEqual("xAB");
+
+        // Now undo frame A's two scoped edits.
+        await undo(page, 1); // undoes a3
+        expect(await getFirstSlotText(page, frameAId)).toEqual("xA");
+
+        await undo(page, 1); // undoes a2
+        expect(await getFirstSlotText(page, frameAId)).toEqual("x");
+
+        // Redo everything back: both frames restored, with B's content intact.
+        await redo(page, 5);
+        await expect(page.locator(".frame-div")).toHaveCount(2);
+        expect(await getFirstSlotText(page, frameAId)).toEqual("xAB");
+        expect(await getFirstSlotText(page, frameBId)).toEqual("yCD");
+    });
+});
+
+test.describe("Undo/redo -- full-scope path (edits reaching beyond one frame)", () => {
+    test("undoing a plain (non-joint) keyword-frame conversion restores the original func-call content", async ({page}) => {
+        // Typing "try " converts a func-call frame to a "try" frame in a single frame -- unlike
+        // the elif/else/except/finally conversions below, "try" doesn't attach to anything else,
+        // so this doesn't actually need the full-scope widen to be correct. It's still routed
+        // through it (checkSlotRefactoring widens for every keyword conversion, not just joint
+        // ones -- see its comment), so this checks that widening back to a full clone/diff for a
+        // single-frame change doesn't itself corrupt anything.
+        const frameId = await createFuncCallFrame(page, "t");
+        await page.keyboard.type("ry");
+        await waitForEditorSettled(page);
+        expect(await getFirstSlotText(page, frameId)).toEqual("try");
+        await assertConversionDidNotHappen(page, frameId);
+
+        await page.keyboard.type(" "); // fires the conversion
+        await waitForEditorSettled(page);
+        await assertFrameType(page, frameId, AllFrameTypesIdentifier.try);
+
+        // One undo reverts the whole conversion back to a func-call frame with its typed content.
+        // The trigger space itself lands in the slot as ordinary text before the conversion logic
+        // consumes it, so the state captured just before converting still has it -- trim it off
+        // rather than asserting an exact match, since that trailing space isn't what this is about.
+        await undo(page, 1);
+        await assertConversionDidNotHappen(page, frameId);
+        expect((await getFirstSlotText(page, frameId)).trim()).toEqual("try");
+
+        // Redo restores the conversion again.
+        await redo(page, 1);
+        await assertFrameType(page, frameId, AllFrameTypesIdentifier.try);
+
+        // The earlier per-character edits ("r", then "y") are still individually undoable
+        // underneath, each its own scoped step (mirroring the single-frame test above):
+        await undo(page, 3); // undo conversion, then "y", then "r"
+        expect(await getFirstSlotText(page, frameId)).toEqual("t");
+    });
+
+    test("undoing an elif/else conversion that attaches to an existing if's joint chain leaves the if's own content untouched", async ({page}) => {
+        // Build "if x :" then move to a blank line directly after it (not nested in its body).
+        await page.keyboard.press(" ");
+        await page.keyboard.press("i"); // if
+        await waitForEditorSettled(page);
+        const ifId = await getFocusedFrameId(page);
+        await page.keyboard.type("x");
+        await waitForEditorSettled(page);
+        expect(await getFirstSlotText(page, ifId)).toEqual("x");
+
+        await page.keyboard.press("Escape");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("ArrowDown");
+        await waitForEditorSettled(page);
+
+        // Typing "else" here converts a func-call frame and attaches it as a joint frame on ifId
+        // -- a mutation of the if frame's own jointFrameIds, i.e. a second frame beyond the one
+        // being typed into.
+        const elseId = await typeKeywordConversionTrigger(page, "else");
+        await assertFrameType(page, elseId, AllFrameTypesIdentifier.else);
+        await expect(page.locator(".frame-div")).toHaveCount(2);
+
+        await undo(page, 1);
+        // The else conversion (and its attachment to the if) should be fully undone:
+        await assertConversionDidNotHappen(page, elseId);
+        await expect(page.locator(".frame-div")).toHaveCount(2);
+        // Critically, the if frame's own content must be untouched by undoing a change that was
+        // captured (and diffed) against the WHOLE state, not just the else frame's own subtree:
+        expect(await getFirstSlotText(page, ifId)).toEqual("x");
+
+        await redo(page, 1);
+        await assertFrameType(page, elseId, AllFrameTypesIdentifier.else);
+        expect(await getFirstSlotText(page, ifId)).toEqual("x");
+    });
+});


### PR DESCRIPTION
## Summary

Two lines of work on this branch:

**Run/Stop stuck-button fix (this session)**
- `client.call(client.workerProxy.executePython, ...).then(...)` had no `.catch()`. If that promise rejected — concretely, a `ServiceWorkerError` from the sync-message channel the Pyodide worker depends on for `input()`, cloud file I/O, and output catch-up — the rejection went unhandled and none of the `.then()` recovery ran. The Run button was left stuck showing "Stop" with nothing executing until the user clicked Stop (which force-resets state) then Run again. This matches the reported bug exactly, including the workaround. Fixed with a `.catch()` that mirrors the existing reset logic.
- Added a pre-flight health check before a run starts: ping the sync-message channel's `/version` endpoint with a short timeout, and if it's not answering, try to get the service worker to reclaim the page before proceeding. Not a hard gate — if the channel is still down the run still goes ahead and the fix above cleanly resets the button rather than hanging.
- Fixed a bug in that health check itself, found while writing a Playwright repro: it used a plain `fetch()` (GET) to `/version`, but a GET to an unmatched path is commonly rewritten to `200` by SPA-fallback routing (Vite dev server does this, and so do many production static hosts serving a client-routed SPA) — so it could report "healthy" when the channel was actually dead. Switched to POST, which correctly falls through to a real 404.

All three verified against a live, real reproduction: disabled the service worker's fetch listener to force the exact `ServiceWorkerError`/404 pattern from the original report, confirmed the button got stuck pre-fix and recovers cleanly post-fix, via a Playwright script driving a real browser against the actual dev server (not just unit-level reasoning).

**Editor typing performance (prior session, included on this branch)**
- Scope undo/redo state clone/diff to touched frames for plain typing, instead of the whole document.
- Debounce autocomplete/param-prompt TigerPython reparsing on large files.
- Cancel pending debounced `updateAC()` on unmount/blur.

## Test plan

- [x] `npx vue-tsc --noEmit` and `eslint` clean on all changed files
- [x] Live reproduction of the original stuck-Run-button bug, confirmed fixed, via a Playwright script driving a real browser against the dev server with the service worker's fetch listener disabled
- [x] Confirmed a normal run still completes correctly afterward
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)