### PR TITLE
Fix Run/Stop button getting stuck when the service worker drops out

### DIFF
--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -782,8 +782,21 @@ export default defineComponent({
                             }
                         });
                     }
+                }).catch((err) => {
+                    // client.call() itself can reject -- not just resolve with a possibleError --
+                    // e.g. if a sync request from the worker (see bridgeSync/makeRawRequest) couldn't
+                    // reach the main thread because the service worker sync-message channel was briefly
+                    // down (ServiceWorkerError). Without this handler that rejection went unhandled and
+                    // the .then() above never ran, leaving the Run button stuck showing "Stop" with
+                    // nothing running until the user clicked Stop then Run again to force a reset:
+                    console.error("Python execution failed to complete: ", err);
+                    setPythonExecAreaLayoutButtonPos();
+                    // The worker may be left in a broken/uncertain state, so get a clean one for next time:
+                    void terminateAndRestartPyodide();
+                    soundManager?.stopAllSounds();
+                    useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
                 });
-                
+
                 // We make sure the number of errors shown in the interface is in line with the current state of the code
                 // Note that a run time error can still occur later.                
                 this.checkNonePrecompiledErrors();

--- a/src/components/PythonExecutionArea.vue
+++ b/src/components/PythonExecutionArea.vue
@@ -85,11 +85,11 @@ import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
 import { BTab, BTabs } from "bootstrap-vue-next";
 import * as Comlink from "comlink";
 import {handleErrorTrace, setSInputConsole} from "@/helpers/execPythonCode";
-import {PyodideErrorDetails, serviceWorkerReadyAndInControl} from "@/workers/shared_helpers";
+import {isServiceWorkerChannelResponsive, PyodideErrorDetails, serviceWorkerReadyAndInControl} from "@/workers/shared_helpers";
 import {SpriteHandle, SyncOrAsyncStrypePyodideWorkerRequest} from "@/stryperuntime/worker_bridge_type";
 import {SoundManager} from "@/stryperuntime/sound_manager";
 import {handleAsyncRequests, handleSyncRequests} from "@/stryperuntime/main_bridge_handler";
-import {getPythonClient, isPythonWorkerReady, renderer, terminateAndRestartPyodide} from "@/stryperuntime/main_thread_python_handler";
+import {getPythonClient, isPythonWorkerReady, renderer, serviceWorkerChannel, terminateAndRestartPyodide} from "@/stryperuntime/main_thread_python_handler";
 import { TurtlePixiHandler } from "@/stryperuntime/turtle_pixi_handler";
 import {createOrGetAudioContext} from "@/helpers/audioContext";
 import {clearAllRuntimeErrors, computeFrameSnapshot} from "@/helpers/storeMethods";
@@ -641,7 +641,7 @@ export default defineComponent({
                 setSInputConsole(pythonConsole);
                 
                 // getPythonClient() can change value if restarted so important we take one
-                // const reference to it for the duration of a Python run: 
+                // const reference to it for the duration of a Python run:
                 const client = getPythonClient();
                 if (client == null) {
                     // Shouldn't normally happen (the Run button is disabled while
@@ -650,7 +650,30 @@ export default defineComponent({
                     useStore().pythonExecRunningState = PythonExecRunningState.NotRunning;
                     return;
                 }
-                
+
+                // The run depends on the sync-message service worker channel throughout (input(),
+                // cloud file I/O, output catch-up), but nothing normally confirms it's actually
+                // being intercepted before we commit to running -- a controller can be present yet
+                // not truly answering (Safari is known to silently lose a backgrounded tab's service
+                // worker), in which case the run would only fail ~5s in, deep inside the worker.
+                // Check fast, and if it's not responding try to get the service worker to reclaim
+                // us before proceeding; if that doesn't help either, we still go ahead -- the
+                // .then()/.catch() below will reset the Run button cleanly rather than leaving it
+                // stuck, so this is a best-effort speed-up, not a hard gate:
+                if (!(await isServiceWorkerChannelResponsive(serviceWorkerChannel.baseUrl))) {
+                    console.error("Service worker sync channel not responding; attempting to reclaim control before running");
+                    const registration = await navigator.serviceWorker.getRegistration();
+                    await registration?.update();
+                    await new Promise<void>((resolve) => {
+                        const timeout = setTimeout(resolve, 1500);
+                        navigator.serviceWorker.addEventListener("controllerchange", () => {
+                            clearTimeout(timeout);
+                            resolve();
+                        }, {once: true});
+                        registration?.active?.postMessage("claim");
+                    });
+                }
+
                 const syncBridgePromise = handleSyncRequests(renderer, soundManager as SoundManager, turtlePixiHandler, {
                     getPressedKeys: () => pressedKeys,
                     waitForNextKey: () => {

--- a/src/stryperuntime/main_thread_python_handler.ts
+++ b/src/stryperuntime/main_thread_python_handler.ts
@@ -18,8 +18,11 @@ import * as Comlink from "comlink";
 import {makeServiceWorkerChannel} from "sync-message";
 import {ref} from "vue";
 
-// Can be re-used:
-const serviceWorkerChannel = makeServiceWorkerChannel({scope: import.meta.env.BASE_URL});
+// Can be re-used. Exported so PythonExecutionArea can health-check it before a run (see
+// isServiceWorkerChannelResponsive in shared_helpers.ts) -- Safari in particular is known to
+// silently drop a page's service worker controller (e.g. after backgrounding the tab), which
+// otherwise only surfaces ~5s into a run as a ServiceWorkerError from deep inside Pyodide:
+export const serviceWorkerChannel = makeServiceWorkerChannel({scope: import.meta.env.BASE_URL});
 
 export const renderer = new Renderer();
 export const isPythonWorkerReady = ref(false);

--- a/src/workers/shared_helpers.ts
+++ b/src/workers/shared_helpers.ts
@@ -28,12 +28,14 @@ export async function serviceWorkerReadyAndInControl() : Promise<void> {
 // short timeout so a genuinely dead channel is detected fast rather than stalling the Run click:
 export async function isServiceWorkerChannelResponsive(channelBaseUrl: string, timeoutMs = 800) : Promise<boolean> {
     try {
-        // Must be POST, not the fetch() default of GET: sync-message's own fetch listener
-        // doesn't care about method for /version, but if the service worker *isn't*
-        // intercepting, a GET to an unmatched path is commonly rewritten to a 200 (e.g. an SPA's
-        // own index.html fallback, in dev and in many production static hosts) -- so a GET here
-        // could report "healthy" when the channel is actually dead. POST to the same unmatched
-        // path correctly falls through to a real 404 instead:
+        // /version is answered by the sync-message package's own service-worker fetch listener
+        // (not anything Strype implements) -- it responds to any request whose URL ends in
+        // /version with a 200, purely as a liveness signal, regardless of method.
+        // Must be POST here, not the fetch() default of GET, though: if the service worker
+        // *isn't* intercepting, a GET to an unmatched path is commonly rewritten to a 200 (e.g.
+        // an SPA's own index.html fallback, in dev and in many production static hosts) -- so a
+        // GET here could report "healthy" when the channel is actually dead. POST to the same
+        // unmatched path correctly falls through to a real 404 instead:
         const response = await fetch(channelBaseUrl + "/version", {method: "POST", signal: AbortSignal.timeout(timeoutMs)});
         return response.ok;
     }

--- a/src/workers/shared_helpers.ts
+++ b/src/workers/shared_helpers.ts
@@ -19,3 +19,20 @@ export async function serviceWorkerReadyAndInControl() : Promise<void> {
     });
 }
 
+// Unlike serviceWorkerReadyAndInControl() above (which only checks that *some* controller is
+// present), this actually round-trips through the sync-message channel to confirm the service
+// worker is currently intercepting requests for it. A controller can be present yet not truly
+// answering (e.g. Safari silently losing a backgrounded tab's service worker), in which case a
+// Pyodide run that depends on the channel (input(), cloud file I/O, output catch-up) would only
+// discover the problem ~5s in, via a ServiceWorkerError from deep inside the worker. Kept to a
+// short timeout so a genuinely dead channel is detected fast rather than stalling the Run click:
+export async function isServiceWorkerChannelResponsive(channelBaseUrl: string, timeoutMs = 800) : Promise<boolean> {
+    try {
+        const response = await fetch(channelBaseUrl + "/version", {signal: AbortSignal.timeout(timeoutMs)});
+        return response.ok;
+    }
+    catch {
+        return false;
+    }
+}
+

--- a/src/workers/shared_helpers.ts
+++ b/src/workers/shared_helpers.ts
@@ -28,7 +28,13 @@ export async function serviceWorkerReadyAndInControl() : Promise<void> {
 // short timeout so a genuinely dead channel is detected fast rather than stalling the Run click:
 export async function isServiceWorkerChannelResponsive(channelBaseUrl: string, timeoutMs = 800) : Promise<boolean> {
     try {
-        const response = await fetch(channelBaseUrl + "/version", {signal: AbortSignal.timeout(timeoutMs)});
+        // Must be POST, not the fetch() default of GET: sync-message's own fetch listener
+        // doesn't care about method for /version, but if the service worker *isn't*
+        // intercepting, a GET to an unmatched path is commonly rewritten to a 200 (e.g. an SPA's
+        // own index.html fallback, in dev and in many production static hosts) -- so a GET here
+        // could report "healthy" when the channel is actually dead. POST to the same unmatched
+        // path correctly falls through to a real 404 instead:
+        const response = await fetch(channelBaseUrl + "/version", {method: "POST", signal: AbortSignal.timeout(timeoutMs)});
         return response.ok;
     }
     catch {


### PR DESCRIPTION
## Summary

- `client.call(client.workerProxy.executePython, ...).then(...)` had no `.catch()`. If that promise rejected — concretely, a `ServiceWorkerError` from the sync-message channel the Pyodide worker depends on for `input()`, cloud file I/O, and output catch-up — the rejection went unhandled and none of the `.then()` recovery ran. The Run button was left stuck showing "Stop" with nothing executing until the user clicked Stop (which force-resets state) then Run again. This matches the reported bug exactly, including the workaround. Fixed with a `.catch()` that mirrors the existing reset logic.
- Added a pre-flight health check before a run starts: ping the sync-message channel's `/version` endpoint with a short timeout, and if it's not answering, try to get the service worker to reclaim the page before proceeding. Not a hard gate — if the channel is still down the run still goes ahead and the fix above cleanly resets the button rather than hanging.
- Fixed a bug in that health check itself, found while writing a reproduction: it used a plain `fetch()` (GET) to `/version`, but a GET to an unmatched path is commonly rewritten to `200` by SPA-fallback routing (Vite dev server does this, and so do many production static hosts serving a client-routed SPA) — so it could report "healthy" when the channel was actually dead. Switched to POST, which correctly falls through to a real 404.

All three verified against a live, real reproduction: disabled the service worker's fetch listener to force the exact `ServiceWorkerError`/404 pattern from the original report, confirmed the button got stuck pre-fix and recovers cleanly post-fix, via a Playwright script driving a real browser against the actual dev server (not just unit-level reasoning).

## Test plan

- [x] `npx vue-tsc --noEmit` and `eslint` clean on all changed files
- [x] Live reproduction of the original stuck-Run-button bug, confirmed fixed, via a Playwright script driving a real browser against the dev server with the service worker's fetch listener disabled
- [x] Confirmed a normal run still completes correctly afterward
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)