### PR TITLE
Switch @tigerpython/tpparser to published npm version 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@imengyu/vue3-context-menu": "^1.5.4",
                 "@microbit/microbit-fs": "^0.9.2",
                 "@popperjs/core": "^2.11.4",
-                "@tigerpython/tpparser": "github:neilccbrown/TigerPython-Parser#type-inference-remove",
+                "@tigerpython/tpparser": "^1.2.3",
                 "@types/google.accounts": "^0.0.2",
                 "@types/google.picker": "^0.0.39",
                 "@types/jquery": "^3.5.16",
@@ -3323,8 +3323,9 @@
             }
         },
         "node_modules/@tigerpython/tpparser": {
-            "version": "1.2.2",
-            "resolved": "git+ssh://git@github.com/neilccbrown/TigerPython-Parser.git#df65380e04209caedd96b28802e0cd3c42817a8d",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@tigerpython/tpparser/-/tpparser-1.2.3.tgz",
+            "integrity": "sha512-gcK0DI7KHk9OU8w6m6XHhTy0mf7EvmPj6ZaZwbxmQFidLvEQVOiuE+wocc2/8x1nVHvZiRAK/q14uCLticUVpQ==",
             "license": "MPL-2.0"
         },
         "node_modules/@ts-morph/common": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@imengyu/vue3-context-menu": "^1.5.4",
         "@microbit/microbit-fs": "^0.9.2",
         "@popperjs/core": "^2.11.4",
-        "@tigerpython/tpparser": "github:neilccbrown/TigerPython-Parser#type-inference-remove",
+        "@tigerpython/tpparser": "^1.2.3",
         "@types/google.accounts": "^0.0.2",
         "@types/google.picker": "^0.0.39",
         "@types/jquery": "^3.5.16",


### PR DESCRIPTION
## Summary
- Replaces the GitHub branch dependency (`neilccbrown/TigerPython-Parser#type-inference-remove`) with the published npm release `@tigerpython/tpparser@^1.2.3`, now that those changes are available there.

## Test plan
- [x] `npm install` resolves cleanly to 1.2.3
- [x] `npm run type:check` passes