### PR TITLE
Fix strict-mode violation in fireworks book-dialog Playwright tests

### DIFF
--- a/tests/playwright/e2e/load-save-demos-books.spec.ts
+++ b/tests/playwright/e2e/load-save-demos-books.spec.ts
@@ -34,7 +34,7 @@ test.describe("Load/save book projects", () => {
             await page.click("#" + await strypeElIds.getEditorMenuUID());
             await page.locator("." + scssVars.strypeMenuItemClassName, {hasText: "Book..."}).click();
             await page.locator(".open-book-dlg-book-group-item", {hasText: "Chapter 2"}).click();
-            await page.locator(".open-book-dlg-name", {hasText: "fireworks"}).click({clickCount: 2});
+            await page.locator(".open-book-dlg-name", {hasText: /^fireworks$/}).click({clickCount: 2});
             // Selecting a book example loads it asynchronously (Menu.vue awaits
             // selectedProject.projectFile before applying the new state); the visible
             // ".project-name" label only updates once that's truly in place, mirroring the same
@@ -86,7 +86,7 @@ test.describe("Book dialog chapter selection survives dialog opening", () => {
         await page.click("#" + await strypeElIds.getEditorMenuUID());
         await page.locator("." + scssVars.strypeMenuItemClassName, {hasText: "Book..."}).click();
         await page.locator(".open-book-dlg-book-group-item", {hasText: "Chapter 2"}).click();
-        const fireworksEntry = page.locator(".open-book-dlg-name", {hasText: "fireworks"});
+        const fireworksEntry = page.locator(".open-book-dlg-name", {hasText: /^fireworks$/});
         await expect(fireworksEntry).toBeVisible();
 
         // Give the dialog's "shown" event (and anything it might still trigger) every chance to


### PR DESCRIPTION
## Summary
- CI run https://github.com/k-pet-group/Strype/actions/runs/31113392629 failed consistently on every OS/browser combination in `load-save-demos-books.spec.ts` with `strict mode violation: locator('.open-book-dlg-name').filter({ hasText: 'fireworks' }) resolved to 2 elements`.
- Cause: 63b573a9 added a new Chapter 2 book project, `fireworks-finished.spy`. The tests use `hasText: "fireworks"`, which does substring matching, so it now matches both "fireworks" and "fireworks-finished" entries in the book dialog.
- Fix: use an exact-match regex (`hasText: /^fireworks$/`) in both places the test locates the "fireworks" entry.

## Test plan
- [x] `npx eslint tests/playwright/e2e/load-save-demos-books.spec.ts` passes
- [ ] CI Playwright run passes on all platforms