### PR TITLE
Fix book/demo examples spuriously showing as modified after loading

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1686,7 +1686,7 @@ export default defineComponent({
         },
 
         // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
-        onExpandedPythonExecAreaSplitPaneResize(event: any, calledForResize?: boolean){
+        onExpandedPythonExecAreaSplitPaneResize(event: any, calledForResize?: boolean, isProgrammaticRestore?: boolean){
             // We want to know the size of the second pane (https://antoniandre.github.io/splitpanes/#emitted-events).
             // It will dictate the size of the Python execution area (expanded, with a range between 20% and 80% of the vh)
             const lowerPanelSize = event.panes[1].size as number;
@@ -1701,9 +1701,11 @@ export default defineComponent({
 
                 }
 
-                // A change of divider position triggers a modification notification only when the user actively moves the divider,
-                // we can distinguish between a sitation when the divider is position is loaded and user event by the content of the event
-                if((event?.panes?.length??0) > 1){
+                // A change of divider position triggers a modification notification only when the user actively moves the divider.
+                // We can't infer this from the event's shape (a real Splitpanes "resize" event and the synthetic event used to
+                // restore a saved layout both carry a 2-element "panes" array), so callers doing a programmatic restore must
+                // say so explicitly via isProgrammaticRestore.
+                if(!isProgrammaticRestore){
                     this.appStore.isEditorContentModified = true;
                     this.appStore.editorLastModificationAt = Date.now();
                 }

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -1211,7 +1211,7 @@ export default defineComponent({
             return waitForPanesSettled();
         },
 
-        onCommandsSplitterResize(event: any) {
+        onCommandsSplitterResize(event: any, isProgrammaticRestore?: boolean) {
             // When the splitter is resized, we need to resize the frame commands container (wrap/unwrap)
             // and the PEA (will take the full space in its pane, breaking the initial 4:3 ratio)
             document.getElementById(getPEATabContentContainerDivId())?.dispatchEvent(new CustomEvent(CustomEventTypes.pythonExecAreaSizeChanged));
@@ -1228,13 +1228,15 @@ export default defineComponent({
                 this.appStore.peaCommandsSplitterPane2Size = {...defaultEmptyStrypeLayoutDividerSettings, [this.appStore.peaLayoutMode??StrypePEALayoutMode.tabsCollapsed]: event.panes[1].size};
             }
 
-            // A change of divider position triggers a modification notification only when the user actively moves the divider,
-            // we can distinguish between a sitation when the divider is position is loaded and user event by the content of the event
-            if(event.panes.length > 1){
+            // A change of divider position triggers a modification notification only when the user actively moves the divider.
+            // We can't infer this from the event's shape (a real Splitpanes "resize" event and the synthetic event used to
+            // restore a saved layout both carry a 2-element "panes" array), so callers doing a programmatic restore must
+            // say so explicitly via isProgrammaticRestore.
+            if(!isProgrammaticRestore){
                 this.appStore.isEditorContentModified = true;
                 this.appStore.editorLastModificationAt = Date.now();
             }
-        }, 
+        },
 
         setPEACommandsSplitterPanesMinSize(onlyResizePEA?: boolean) {
             // Called to get the right min sizes of the pea/Commands splitter.

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2622,7 +2622,7 @@ export const useStore = defineStore("app", {
                 if (forceSetUndefined || (newPEACommandsSplitterPane2Size && newPEACommandsSplitterPane2Size[newPEALayout] != undefined)) {
                     await waitForPanesSettled();
                     if (this.peaCommandsSplitterPane2Size && this.peaCommandsSplitterPane2Size[newPEALayout] != undefined) {
-                        vueComponentsAPIHandler.commandsComponentAPI?.onCommandsSplitterResize({panes: [{}, {size: this.peaCommandsSplitterPane2Size[newPEALayout]}]});
+                        vueComponentsAPIHandler.commandsComponentAPI?.onCommandsSplitterResize({panes: [{}, {size: this.peaCommandsSplitterPane2Size[newPEALayout]}]}, true);
                     }
                 }
             }
@@ -2637,7 +2637,7 @@ export const useStore = defineStore("app", {
                 if (forceSetUndefined || (newPEAExpandedSplitterPane2Size != undefined && newPEAExpandedSplitterPane2Size[newPEALayout] != undefined)) {
                     await waitForPanesSettled();
                     if (this.peaExpandedSplitterPane2Size != undefined && this.peaExpandedSplitterPane2Size[newPEALayout] != undefined) {
-                        vueComponentsAPIHandler.appComponentAPI?.onExpandedPythonExecAreaSplitPaneResize({panes: [{}, {size: this.peaExpandedSplitterPane2Size[newPEALayout]}]});
+                        vueComponentsAPIHandler.appComponentAPI?.onExpandedPythonExecAreaSplitPaneResize({panes: [{}, {size: this.peaExpandedSplitterPane2Size[newPEALayout]}]}, false, true);
                     }
                 }
             }

--- a/src/types/vue-component-api-types.ts
+++ b/src/types/vue-component-api-types.ts
@@ -28,12 +28,12 @@ export type AppComponentAPI = {
   applyShowAppProgress: (event: AppEvent) => void;
   setStateFromPythonFile: (completeSource: string, fileName: string, lastSaveDate: number, requestFSFileLoadedNotification: boolean, fileLocation: FileSystemFileHandle | "local" | "cloud" | "import") => Promise<void>,
   finaliseOpenShareProject: (message?: {key: string, param: string}) => void,
-  onExpandedPythonExecAreaSplitPaneResize: (event: any, calledForResize?: boolean) => void,
+  onExpandedPythonExecAreaSplitPaneResize: (event: any, calledForResize?: boolean, isProgrammaticRestore?: boolean) => void,
   onStrypeCommandsSplitPaneResize: (event: any, useSpecificPEALayout?: StrypePEALayoutMode) => void,
 };
 
 export type CommandsComponentAPI = {
-  onCommandsSplitterResize: (event: any) => void,
+  onCommandsSplitterResize: (event: any, isProgrammaticRestore?: boolean) => void,
   resetPEACommmandsSplitterDefaultState: () => Promise<void>,
   setCommandsSplitterPane2Size: (v: number) => void,
   // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE

--- a/tests/playwright/e2e/load-save-demos-books.spec.ts
+++ b/tests/playwright/e2e/load-save-demos-books.spec.ts
@@ -66,6 +66,24 @@ test.describe("Load/save book projects", () => {
     }
 });
 
+test.describe("Loading a book project does not spuriously mark it as modified", () => {
+    // Regression test for #954: loading a book/demo project restores its saved splitter/layout
+    // sizes via a synthetic resize event, which used to be indistinguishable from a real user
+    // drag (both carry a same-shaped "panes" array), so it wrongly flipped the project back to
+    // "modified" immediately after loading. yellow-fish-v7 has a saved peaCommandsSplitterPane2Size
+    // for its layout, so it reliably exercises that path.
+    test("Loading yellow-fish-v7 leaves the project showing as unmodified", async ({page}) => {
+        await page.click("#" + await strypeElIds.getEditorMenuUID());
+        await page.locator("." + scssVars.strypeMenuItemClassName, {hasText: "Book..."}).click();
+        await page.locator(".open-book-dlg-book-group-item", {hasText: "Chapter 4"}).click();
+        await page.locator(".open-book-dlg-name", {hasText: "yellow-fish-v7"}).click({clickCount: 2});
+        // As above, the ".project-name" label only updates once the load (including restoring
+        // the saved divider positions) has fully completed, so no extra wait is needed here.
+        await expect(page.locator(".project-name")).toHaveText("yellow-fish-v7", {timeout: 30000});
+        await expect(page.locator(".gdrive-sync-label", {hasText: "Modified"})).toHaveCount(0);
+    });
+});
+
 test.describe("Book dialog chapter selection survives dialog opening", () => {
     // Regression test for the intermittent "fireworks entry never became clickable" CI failures
     // above: the book dialog used to reset its chapter selection back to Chapter 1 from its


### PR DESCRIPTION
## Summary
- Loading a project restores its saved splitter/layout sizes via a synthetic resize event, dispatched through the same handlers used for real user drags in `Commands.vue`/`App.vue`. Those handlers tried to distinguish a real drag from the synthetic restore by checking `event.panes.length`, but both shapes carry a same-shaped 2-element `panes` array, so the check was always true and every load wrongly flipped `isEditorContentModified` back on.
- Other load paths (local file, cloud drive, shared link) happened to mask this with an explicit reset placed after loading completes; the book/demo example load path didn't, so the false "Modified" indicator surfaced there (e.g. loading `yellow-fish-v7`).
- Callers doing a programmatic restore now say so explicitly via a new `isProgrammaticRestore` flag instead of the handlers guessing from the event shape.

Fixes #954.

## Test plan
- [x] Added a Playwright regression test (`tests/playwright/e2e/load-save-demos-books.spec.ts`) that loads the `yellow-fish-v7` book example and asserts the project doesn't show as "Modified"; confirmed it fails on the pre-fix code and passes with the fix.
- [x] `npm run type:check` and `npm run lint:check` pass.
- [x] Existing book/demo round-trip Playwright tests (including `yellow-fish-v7`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)