### PR TITLE
Fix hang when pasting text with an unterminated quote at frame cursor

### DIFF
--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -504,6 +504,10 @@ function transformCommentsAndBlanks(codeLines: string[], format: "py" | "spy") :
                         if (afterEnd != -1) {
                             charIndex = afterEnd;
                         }
+                        else {
+                            // No closing quote on this line; treat the rest of the line as part of the string:
+                            charIndex = line.length;
+                        }
                     }
                     else if (line.slice(charIndex, charIndex+1) == "#") {
                         // Start of a comment and we're not in a string, so rest of the line is comment

--- a/tests/playwright/e2e/frame-selection-manipulation.spec.ts
+++ b/tests/playwright/e2e/frame-selection-manipulation.spec.ts
@@ -512,6 +512,22 @@ else :
     print('Bye bye') 
 `]));
     });
+
+    // https://github.com/k-pet-group/Strype/issues/941 -- pasting a line with an unterminated
+    // string quote (e.g. an apostrophe used as punctuation, not a string delimiter) used to hang
+    // the tab entirely rather than being rejected as invalid/nonsense pasted text.  These simply
+    // check the paste completes (rather than hanging) and is rejected, leaving main empty.
+    test("Test pasting text with an unterminated single quote doesn't hang", async ({page}) => {
+        await testPaste(page, "", [], "C'est un chat noir", makeStrypeFile(["", "", ""]));
+    });
+
+    test("Test pasting text with an unterminated double quote doesn't hang", async ({page}) => {
+        await testPaste(page, "", [], "She said \"hello", makeStrypeFile(["", "", ""]));
+    });
+
+    test("Test pasting text with a closed string followed by an unterminated one doesn't hang", async ({page}) => {
+        await testPaste(page, "", [], "\"a\" + \"b", makeStrypeFile(["", "", ""]));
+    });
 });
 
 test.describe("Pasting assignments at section boundaries", () => {


### PR DESCRIPTION
## Summary
- Pasting a line at the frame cursor that contains an unmatched `'`/`"` (e.g. `C'est un chat noir`, where the apostrophe has no matching close on the line) hung the tab forever.
- `transformCommentsAndBlanks()` in `src/helpers/pythonToFrames.ts` scans each pasted line character-by-character for string/comment boundaries. When `findStringEnd()` found no closing quote on the line, `charIndex` was left unchanged, so the enclosing `while` loop kept re-examining the same character indefinitely.
- Fix: when no closing quote is found, advance `charIndex` to the end of the line (treating the rest of the line as part of the string), matching the existing "otherwise proceed as if it finished on this line" comment's intent.

Fixes #941

## Test plan
- [x] Added Playwright tests in `tests/playwright/e2e/frame-selection-manipulation.spec.ts` ("Invalid pastes" describe block) covering: unterminated single quote, unterminated double quote, and a closed string followed by an unterminated one (`"a" + "b`).
- [x] Confirmed these tests hang/timeout against the unfixed code and pass against the fix.
- [x] Ran the full "Invalid pastes" describe block (16 tests) against the fix — all pass.
- [x] `vue-tsc --noEmit` passes.