### PR TITLE
Fix Run button permanently stuck on Initialising in Chromium and Firefox

### DIFF
--- a/src/workers/python-execution.ts
+++ b/src/workers/python-execution.ts
@@ -84,7 +84,8 @@ import {SpriteManager} from "@/stryperuntime/image_and_collisions";
 import {asyncBridge, PyodideWorkerGlobalScope, syncBridge} from "@/workers/python_execution_type";
 import {getFSForEmscripten} from "@/stryperuntime/pyodide-emscripten-cloud-fs";
 import { assetsFilePrefixes, createLazyFetchAssetsFS } from "@/stryperuntime/pyodide-emscripten-assets-fs";
-import {PyodideErrorDetails} from "@/workers/shared_helpers";
+import {isServiceWorkerChannelResponsive, PyodideErrorDetails} from "@/workers/shared_helpers";
+import {makeServiceWorkerChannel} from "sync-message";
 import {createLazyFetchFS} from "@/stryperuntime/pyodide-emscript-fetch-fs";
 
 // We only specify updatePort here as we don't want other files using it directly:
@@ -558,17 +559,38 @@ self.addEventListener("message", (e : any) => {
     }
 });
 
-// Reports our own navigator.serviceWorker.controller status to the main thread, both immediately
-// on startup and again on any controllerchange. We've confirmed (see logFirstSyncReadDiagnosticsOnce()
-// above, and the PyodideSlot.controlled comment in main_thread_python_handler.ts) a real case where
-// this worker -- specifically the spare pre-warmed at page load -- ends up with no controller at
-// all despite the page itself being controlled, silently breaking every sync-message request it
-// makes (they fall through to a real 404 instead of being intercepted by the service worker). The
-// main thread uses this to detect that and trigger a reclaim before treating this worker as usable:
-function reportControllerStatus() {
-    (self as unknown as DedicatedWorkerGlobalScope).postMessage({controllerStatus: ("serviceWorker" in navigator) && navigator.serviceWorker.controller != null});
+// Reports whether this worker's own sync-message requests are actually being intercepted by the
+// service worker, both immediately on startup and again on any controllerchange. We've confirmed
+// (see logFirstSyncReadDiagnosticsOnce() above, and the PyodideSlot.controlled comment in
+// main_thread_python_handler.ts) a real case where this worker -- specifically the spare
+// pre-warmed at page load -- ends up with no controller at all despite the page itself being
+// controlled, silently breaking every sync-message request it makes (they fall through to a real
+// 404 instead of being intercepted). The main thread uses this to detect that and trigger a
+// reclaim before treating this worker as usable.
+//
+// This deliberately checks via a real round-trip fetch (isServiceWorkerChannelResponsive) rather
+// than inspecting navigator.serviceWorker.controller directly: that introspection API isn't
+// exposed to Workers at all in Chromium (crbug.com/40364838), and even where it is (Firefox 133+),
+// we've observed it can stay null indefinitely from inside a worker despite the service worker
+// already correctly intercepting that same worker's fetches -- either way, trusting it here would
+// leave isPythonWorkerReady permanently false and Run permanently disabled. A functional probe is
+// the only signal that's actually reliable across engines:
+const workerServiceWorkerChannel = makeServiceWorkerChannel({scope: import.meta.env.BASE_URL});
+async function checkAndReportControllerStatus() : Promise<boolean> {
+    const controlled = await isServiceWorkerChannelResponsive(workerServiceWorkerChannel.baseUrl);
+    (self as unknown as DedicatedWorkerGlobalScope).postMessage({controllerStatus: controlled});
+    return controlled;
 }
 if ("serviceWorker" in navigator) {
-    navigator.serviceWorker.addEventListener("controllerchange", reportControllerStatus);
+    navigator.serviceWorker.addEventListener("controllerchange", () => void checkAndReportControllerStatus());
 }
-reportControllerStatus();
+// The very first check can easily race the service worker's own install/activate/claim sequence,
+// especially for the worker created synchronously at page load -- so retry with a short backoff
+// for a while rather than only trying once and relying solely on a controllerchange event that,
+// per above, isn't a reliable signal to wait on in every engine:
+(async () => {
+    const deadline = Date.now() + 20000;
+    while (!(await checkAndReportControllerStatus()) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+})();

--- a/src/workers/shared_helpers.ts
+++ b/src/workers/shared_helpers.ts
@@ -25,14 +25,20 @@ export async function serviceWorkerReadyAndInControl() : Promise<void> {
 // answering (e.g. Safari silently losing a backgrounded tab's service worker), in which case a
 // Pyodide run that depends on the channel (input(), cloud file I/O, output catch-up) would only
 // discover the problem ~5s in, via a ServiceWorkerError from deep inside the worker. Kept to a
-// short timeout so a genuinely dead channel is detected fast rather than stalling the Run click:
+// short timeout so a genuinely dead channel is detected fast rather than stalling the Run click.
+// Also callable from inside a dedicated Worker (see reportControllerStatus() in
+// python-execution.ts) -- `document` and `navigator.serviceWorker` aren't necessarily defined
+// there (Chromium doesn't expose navigator.serviceWorker to Workers at all: crbug.com/40364838),
+// so both are guarded rather than assumed:
 export async function isServiceWorkerChannelResponsive(channelBaseUrl: string, timeoutMs = 800) : Promise<boolean> {
     // Logged (temporarily, while we're chasing down a report of the Run button getting stuck on
     // "Stop" with nothing happening, even though the page stayed foregrounded/visible throughout)
     // so a repro can confirm whether this pre-flight check is the thing catching (or failing to
     // catch) a dead channel -- and whether document.visibilityState really was "visible" the whole
     // time, ruling backgrounding out directly rather than just by the user's recollection:
-    const logPrefix = `[SW channel check ${new Date().toISOString()}] visibilityState=${document.visibilityState} hasFocus=${document.hasFocus()} controller=${navigator.serviceWorker.controller != null}`;
+    const hasDocument = typeof document !== "undefined";
+    const hasController = ("serviceWorker" in navigator) && navigator.serviceWorker.controller != null;
+    const logPrefix = `[SW channel check ${new Date().toISOString()}] visibilityState=${hasDocument ? document.visibilityState : "n/a"} hasFocus=${hasDocument ? document.hasFocus() : "n/a"} controller=${hasController}`;
     try {
         // /version is answered by the sync-message package's own service-worker fetch listener
         // (not anything Strype implements) -- it responds to any request whose URL ends in


### PR DESCRIPTION
## Summary
- `7234738a` (#1030) gated Run readiness on the Pyodide worker self-reporting `navigator.serviceWorker.controller != null` from inside the worker. That API isn't exposed to Workers at all in Chromium (crbug.com/40364838), and even where it is (Firefox 133+), it can stay `null` indefinitely from inside a worker despite the service worker already correctly intercepting that worker's own fetches -- only Safari reports it reliably. So the gate could never become `true` in Chromium or Firefox, permanently disabling Run there.
- This explains the current CI failures on `main`: every non-WebKit Playwright job either failed (`toHaveText("Run")` timeouts) or timed out entirely, and the Cypress `python` shards failed the same way -- one of them badly enough that the stuck retry loop caused a V8 OOM crash in the Electron renderer. WebKit was the only browser unaffected.
- Replaces the introspection-based check with the functional round-trip the codebase already had (`isServiceWorkerChannelResponsive`), run from inside the worker with a short retry loop, instead of trusting an API that isn't reliably available there.

## Test plan
- [x] `vue-tsc --noEmit` and `eslint` clean on the changed files
- [x] Live-probed the real dev-server app in Chromium, Firefox and WebKit before/after: before, Chromium and Firefox stuck on "Initialising..." forever (WebKit fine); after, all three enable Run correctly
- [x] `console-execution.spec.ts`: 28/28 passing on Chromium; 28/28 passing on Firefox serially (occasional single-test flake under 4-way local parallel CPU contention, not reproducible serially -- looks like local resource contention, not a functional issue)