### PR TITLE
Fix Run button stuck on Initialising when a worker fails to load, and make Pyodide's runtime safely cacheable

### DIFF
--- a/.github/workflows/attach-release-build.yml
+++ b/.github/workflows/attach-release-build.yml
@@ -27,7 +27,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: public/pyodide
-                  key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json') }}
+                  key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json', 'scripts/download-pyodide-libs.cjs') }}
             - name: Install Pyodide
               if: steps.cache-pyodide.outputs.cache-hit != 'true'
               run: npm run build:download-pyodide-libs

--- a/.github/workflows/build-pages-test-site.yml
+++ b/.github/workflows/build-pages-test-site.yml
@@ -40,7 +40,7 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: public/pyodide
-                key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json') }}
+                key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json', 'scripts/download-pyodide-libs.cjs') }}
             - name: Install Pyodide
               if: steps.cache-pyodide.outputs.cache-hit != 'true'
               run: npm run build:download-pyodide-libs
@@ -102,7 +102,7 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: public/pyodide
-                key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json') }}
+                key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json', 'scripts/download-pyodide-libs.cjs') }}
             - name: Install Pyodide
               if: steps.cache-pyodide.outputs.cache-hit != 'true'
               run: npm run build:download-pyodide-libs

--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: public/pyodide
-          key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json', 'scripts/download-pyodide-libs.cjs') }}
       - name: Install Pyodide
         if: steps.cache-pyodide.outputs.cache-hit != 'true'
         run: npm run build:download-pyodide-libs

--- a/.github/workflows/run-playwright-tests.yml
+++ b/.github/workflows/run-playwright-tests.yml
@@ -73,7 +73,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: public/pyodide
-        key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-pyodide-${{ hashFiles('package-lock.json', 'scripts/download-pyodide-libs.cjs') }}
     - name: Install Pyodide
       if: steps.cache-pyodide.outputs.cache-hit != 'true'
       run: npm run build:download-pyodide-libs

--- a/APACHE_CONFIG.md
+++ b/APACHE_CONFIG.md
@@ -1,0 +1,94 @@
+# Apache caching config for strype.org
+
+This documents the `Cache-Control` policy the production Apache server
+(`strype.org/editor`) should apply. It's **not** applied via a `.htaccess`
+file in this repo — add it to the main server/vhost config instead. Requires
+`mod_headers`.
+
+## Why
+
+Investigating a report of the Run button getting permanently stuck on
+"Initialising..." (2026-08-07) traced back to: a tab left open across a
+deploy, whose already-loaded page still referenced a JS chunk by the
+content hash of the *previous* build. When Strype tried to spin up a new
+background Pyodide worker using that stale URL, the file no longer existed
+on the server (GitHub Pages' single-deployment scheme replaces the whole
+site on every deploy) — a permanent, unrecoverable 404 with no way for the
+client to fix it locally.
+
+Checking the live server (`curl -I`) at the time showed the deeper cause:
+**every** asset on `strype.org/editor`, including the content-hashed chunks
+that are supposed to be safe to cache forever, was being served with
+`Cache-Control: public, no-cache, max-age=0, must-revalidate`. That forces a
+revalidation round-trip on every fetch — for a page that's stayed open a
+while, that's a real chance of asking the server for a file whose hash has
+since rotated out from under it, and getting a 404 with nothing to fall
+back to. It's also just wasteful: the Pyodide runtime alone is tens of MB
+that gets revalidated (or fully re-fetched, depending on the client's own
+cache) on every load.
+
+The **goal** is that once a page has fully loaded, Strype should never need
+to talk to the server again during normal operation (loading a new data
+file or library is the one deliberate exception) — matching how
+content-hashed build output is meant to be cached.
+
+## What to change
+
+Split the policy by file type, rather than one blanket rule for everything:
+
+```apache
+# --- Vite's content-hashed build output: safe to cache forever ---
+# Vite names every hashed JS/CSS chunk "<name>-<hash>.<ext>" (e.g.
+# index-QHEbX0xQ.js, python-execution-Dmw0KcAm.js) -- the hash changes
+# whenever the content does, so the browser can keep a cached copy
+# indefinitely without ever serving stale content.
+#
+# Deliberately does NOT match files without a hash suffix, e.g. the Pyodide
+# files vite-plugin-static-copy copies into assets/ unmodified (see
+# viteStaticCopyPyodide() in vite.config.mjs) -- their filenames never
+# change even when their content does, so they must NOT get this treatment.
+<FilesMatch "-[A-Za-z0-9_]{6,12}\.(js|css)$">
+    Header set Cache-Control "public, max-age=31536000, immutable"
+</FilesMatch>
+
+# --- The Pyodide runtime: also safe to cache forever, once versioned ---
+# public/pyodide/<version>/ (built by scripts/download-pyodide-libs.cjs,
+# referenced via indexURL in src/workers/python-execution.ts) is scoped by
+# Pyodide's own version, so a future upgrade lands at a brand new path
+# rather than overwriting this one in place -- nothing will ever change at
+# a URL a browser has already fetched.
+<LocationMatch "^/editor/pyodide/[^/]+/">
+    Header set Cache-Control "public, max-age=31536000, immutable"
+</LocationMatch>
+```
+
+Everything else — `index.html`, `compiled-service-worker.js`, and any other
+unhashed file — should keep the existing short/no-cache handling. That's
+deliberate, not an oversight: those are exactly the files that must always
+be fetched fresh, since they're what tell the browser which hashed
+filenames (and which Pyodide version) are current. Caching *those* long
+would defeat the whole point, leaving a browser with no way to ever
+discover a new build.
+
+`<LocationMatch>` needs to live in the main server config (`<VirtualHost>`
+block or included file) — it isn't valid inside `.htaccess`.
+
+## What this does not fully solve
+
+Even with this in place, "never talk to the server again" is *very likely*
+rather than absolutely guaranteed: a browser can still evict a cached
+response under storage pressure (Safari in particular is aggressive about
+this), which would send that one request back to the network. A page that
+survives that would hit the same live-server assets (since nothing on the
+server has moved), so it would very likely just succeed — but it's not a
+hard guarantee the way a service-worker precache (Cache Storage, not the
+HTTP cache) would be. That's a bigger, separate piece of work (Workbox is
+already an unused dependency in `package.json`, left over from an earlier
+implementation, and would be the natural tool) that hasn't been done here.
+
+## Out of scope: the GitHub Pages test site
+
+`k-pet-group.github.io/Strype` (`build-pages-test-site.yml`) is capped at
+`max-age=600` on everything — a hard GitHub Pages platform limitation, since
+it doesn't support custom response headers at all. Not fixable from this
+repo; probably an acceptable tradeoff for a fast-moving CI preview site.

--- a/APACHE_CONFIG.md
+++ b/APACHE_CONFIG.md
@@ -34,41 +34,50 @@ content-hashed build output is meant to be cached.
 
 ## What to change
 
-Split the policy by file type, rather than one blanket rule for everything:
+Scoped to `/editor/` and `/microbit/` specifically -- the two Strype
+platform builds actually deployed on this server -- rather than a
+server-wide rule, since the same Apache instance serves other things too
+that this policy has no business touching. Split by file type within that
+scope, rather than one blanket rule for everything under those paths:
 
 ```apache
-# --- Vite's content-hashed build output: safe to cache forever ---
-# Vite names every hashed JS/CSS chunk "<name>-<hash>.<ext>" (e.g.
-# index-QHEbX0xQ.js, python-execution-Dmw0KcAm.js) -- the hash changes
-# whenever the content does, so the browser can keep a cached copy
-# indefinitely without ever serving stale content.
-#
-# Deliberately does NOT match files without a hash suffix, e.g. the Pyodide
-# files vite-plugin-static-copy copies into assets/ unmodified (see
-# viteStaticCopyPyodide() in vite.config.mjs) -- their filenames never
-# change even when their content does, so they must NOT get this treatment.
-<FilesMatch "-[A-Za-z0-9_]{6,12}\.(js|css)$">
-    Header set Cache-Control "public, max-age=31536000, immutable"
-</FilesMatch>
+<LocationMatch "^/(editor|microbit)/">
+    # --- Vite's content-hashed build output: safe to cache forever ---
+    # Vite names every hashed JS/CSS chunk "<name>-<hash>.<ext>" (e.g.
+    # index-QHEbX0xQ.js, python-execution-Dmw0KcAm.js) -- the hash changes
+    # whenever the content does, so the browser can keep a cached copy
+    # indefinitely without ever serving stale content.
+    #
+    # Deliberately does NOT match files without a hash suffix, e.g. the
+    # Pyodide files vite-plugin-static-copy copies into assets/ unmodified
+    # (see viteStaticCopyPyodide() in vite.config.mjs) -- their filenames
+    # never change even when their content does, so they must NOT get this
+    # treatment.
+    <FilesMatch "-[A-Za-z0-9_]{6,12}\.(js|css)$">
+        Header set Cache-Control "public, max-age=31536000, immutable"
+    </FilesMatch>
+</LocationMatch>
 
 # --- The Pyodide runtime: also safe to cache forever, once versioned ---
 # public/pyodide/<version>/ (built by scripts/download-pyodide-libs.cjs,
 # referenced via indexURL in src/workers/python-execution.ts) is scoped by
 # Pyodide's own version, so a future upgrade lands at a brand new path
 # rather than overwriting this one in place -- nothing will ever change at
-# a URL a browser has already fetched.
-<LocationMatch "^/editor/pyodide/[^/]+/">
+# a URL a browser has already fetched. (Only /editor/ actually ships this
+# today -- micro:bit runs on-device, not via Pyodide -- but matching both
+# costs nothing and doesn't need updating if that ever changes.)
+<LocationMatch "^/(editor|microbit)/pyodide/[^/]+/">
     Header set Cache-Control "public, max-age=31536000, immutable"
 </LocationMatch>
 ```
 
-Everything else — `index.html`, `compiled-service-worker.js`, and any other
-unhashed file — should keep the existing short/no-cache handling. That's
-deliberate, not an oversight: those are exactly the files that must always
-be fetched fresh, since they're what tell the browser which hashed
-filenames (and which Pyodide version) are current. Caching *those* long
-would defeat the whole point, leaving a browser with no way to ever
-discover a new build.
+Everything else — `index.html`, `compiled-service-worker.js`, any other
+unhashed file, and anything outside `/editor/` or `/microbit/` entirely —
+should keep the existing short/no-cache handling. That's deliberate, not
+an oversight: those are exactly the files that must always be fetched
+fresh, since they're what tell the browser which hashed filenames (and
+which Pyodide version) are current. Caching *those* long would defeat the
+whole point, leaving a browser with no way to ever discover a new build.
 
 `<LocationMatch>` needs to live in the main server config (`<VirtualHost>`
 block or included file) — it isn't valid inside `.htaccess`.

--- a/scripts/download-pyodide-libs.cjs
+++ b/scripts/download-pyodide-libs.cjs
@@ -1,7 +1,13 @@
 // Downloads the Pyodide libraries (including numpy, pandas, etc) from Github
-// and unpacks it to public/pyodide.  Only needs to be run:
+// and unpacks it to public/pyodide/<version>.  Only needs to be run:
 // - After initial checkout of project from Git
 // - When the Pyodide version is updated (change version in package.json, run npm install, then run this script).
+//
+// The version segment in the destination path is deliberate, not incidental: it's what lets the
+// deployed server mark this whole directory as cacheable forever (see indexURL in
+// python-execution.ts, and the server config documented in APACHE_CONFIG.md) -- a stable,
+// unversioned path would mean either never caching it (slow) or risking a browser never picking
+// up a future Pyodide upgrade because the URL never changed.
 
 const fs = require("fs");
 const path = require("path");
@@ -10,7 +16,7 @@ const { pipeline } = require("stream/promises");
 const tar = require("tar");
 const bz2 = require("unbzip2-stream");
 
-const DEST_DIR = path.resolve(__dirname, "../public/pyodide");
+const DEST_ROOT = path.resolve(__dirname, "../public/pyodide");
 
 // --- Get pyodide version from package-lock.json ---
 function getPyodideVersion() {
@@ -58,10 +64,13 @@ async function main() {
     const url = `https://github.com/pyodide/pyodide/releases/download/${version}/pyodide-${version}.tar.bz2`;
 
     const tmpFile = path.resolve(__dirname, `../pyodide-${version}.tar.bz2`);
+    const destDir = path.join(DEST_ROOT, version);
 
-    // clean old output
-    fs.rmSync(DEST_DIR, { recursive: true, force: true });
-    fs.mkdirSync(DEST_DIR, { recursive: true });
+    // Clean the whole DEST_ROOT (not just this version's folder), so a version bump doesn't leave
+    // the previous version's files sitting around alongside the new ones -- there's never a reason
+    // to keep both, since nothing on the deployed site references the old version's URL any more:
+    fs.rmSync(DEST_ROOT, { recursive: true, force: true });
+    fs.mkdirSync(destDir, { recursive: true });
 
     // download
     await download(url, tmpFile);
@@ -73,7 +82,7 @@ async function main() {
             .pipe(bz2())
             .pipe(
                 tar.x({
-                    cwd: DEST_DIR,
+                    cwd: destDir,
                     strip: 1, // removes top-level folder
                 })
             )
@@ -83,7 +92,7 @@ async function main() {
 
     fs.unlinkSync(tmpFile);
 
-    console.log("Pyodide ready in public/pyodide");
+    console.log(`Pyodide ready in public/pyodide/${version}`);
 }
 
 main().catch((err) => {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@
 // So the descriptions MUST MATCH THE VARIABLE NAMES USED IN VITE.CONFIG.JS;
 declare const __BUILD_DATE_TICKS__: number;
 declare const __BUILD_GIT_HASH__ : string;
+declare const __PYODIDE_VERSION__ : string;
 
 interface ImportMetaEnv {
     readonly VITE_ANALYTICS_INGEST_URL?: string;

--- a/src/stryperuntime/main_thread_python_handler.ts
+++ b/src/stryperuntime/main_thread_python_handler.ts
@@ -69,6 +69,19 @@ async function triggerServiceWorkerReclaim() : Promise<void> {
     registration?.active?.postMessage("claim");
 }
 
+// How many times in a row we'll automatically replace an *active* slot whose worker failed to even
+// load (see the "error" listener in createPyodideSlot() below) before giving up and leaving Run
+// disabled rather than retrying forever. Reset to 0 whenever any slot successfully finishes loading.
+// A handful of retries is enough to ride out a genuinely transient blip (a dropped request, a brief
+// server hiccup); it will *not* help the confirmed real-world cause we chased this down from: the
+// page's own already-loaded bundle references this worker's script by a content hash baked in at
+// build time, and if a deploy has replaced the site's assets since this page loaded, that exact file
+// is gone for good (GitHub Pages caps every asset -- hashed or not -- at a 10-minute Cache-Control,
+// so any tab left open longer than that can easily outlive a deploy). No amount of local retrying
+// fixes that; only reloading the page does, which is a separate piece of work:
+const maxActiveSlotLoadRetries = 3;
+let activeSlotLoadRetriesUsed = 0;
+
 function createPyodideSlot() : PyodideSlot | null {
     if (sessionStorage.getItem("TestingNoPyodide")) {
         console.info("Skipping Pyodide as in testing mode");
@@ -108,10 +121,47 @@ function createPyodideSlot() : PyodideSlot | null {
     // if the worker is already controlled:
     void triggerServiceWorkerReclaim();
 
+    // Only fires for a worker that never gets going at all -- its script fails to load, or it
+    // throws before ever calling onReady below. A worker that's already up and running has its own
+    // error handling elsewhere (see the .catch() around client.call() in PythonExecutionArea.vue);
+    // this is specifically for the case confirmed by the "error" listener's own comment above the
+    // retry counter: a slot that's dead on arrival, which would otherwise sit with
+    // ready=false/controlled=false forever, with nothing retrying it and nothing telling anyone why:
+    worker.addEventListener("error", (e: ErrorEvent) => {
+        if (slot.ready) {
+            // Already up and running by the time this fired -- not the load-failure case this
+            // handles, so leave it alone rather than tearing down a working worker:
+            return;
+        }
+        console.error(`[Pyodide worker load failed ${new Date().toISOString()}] ${e.message || "unknown error"}`);
+        slot.worker.terminate();
+        if (slot === spareSlot) {
+            // Just a background optimisation -- drop it and let the next maybeCreateSpareSlot()
+            // call (made after every run stops, see terminateAndRestartPyodide() below) try again:
+            spareSlot = null;
+        }
+        else if (slot === activeSlot) {
+            // This one is actually blocking Run, so it's worth retrying -- bounded, with a short
+            // backoff, so a persistently stale page doesn't hammer the server forever:
+            if (activeSlotLoadRetriesUsed < maxActiveSlotLoadRetries) {
+                activeSlotLoadRetriesUsed++;
+                const attempt = activeSlotLoadRetriesUsed;
+                console.info(`[Pyodide active slot retry ${new Date().toISOString()}] attempt ${attempt}/${maxActiveSlotLoadRetries}`);
+                setTimeout(() => activateSlot(createPyodideSlot()), 500 * attempt);
+            }
+            else {
+                console.error(`[Pyodide active slot retry ${new Date().toISOString()}] giving up after ${maxActiveSlotLoadRetries} failed attempts -- Run will stay disabled until the page is reloaded`);
+                activateSlot(null);
+            }
+        }
+    });
+
     client.call(
         client.workerProxy.onReady,
         Comlink.proxy(() => {
             slot.ready = true;
+            // A successful load is good evidence whatever was wrong (if anything) has cleared up:
+            activeSlotLoadRetriesUsed = 0;
             // Only surface readiness if this slot is still the active one by the time it
             // finishes loading (it may instead be sitting in the background as the spare):
             updateReadyFlag(slot);

--- a/src/workers/python-execution.ts
+++ b/src/workers/python-execution.ts
@@ -92,7 +92,13 @@ import {createLazyFetchFS} from "@/stryperuntime/pyodide-emscript-fetch-fs";
 declare const self: PyodideWorkerGlobalScope & { updatePort: MessagePort };
 
 async function loadOnly() : Promise<PyodideInterface> {
-    const pyodide = await loadPyodideAndPackage({url: `${import.meta.env.BASE_URL}pysrc.zip`, format: "zip"}, () => loadPyodide({indexURL: `${import.meta.env.BASE_URL}pyodide/`}));
+    // The version segment here is deliberate, not incidental: it's what lets the deployed server
+    // mark this whole directory as cacheable forever (see scripts/download-pyodide-libs.cjs, which
+    // downloads into the matching public/pyodide/<version>/ folder, and the server config
+    // documented in APACHE_CONFIG.md). A stable, unversioned path would mean either never caching
+    // this multi-megabyte payload, or risking a browser never picking up a future Pyodide upgrade
+    // because the URL never changed:
+    const pyodide = await loadPyodideAndPackage({url: `${import.meta.env.BASE_URL}pysrc.zip`, format: "zip"}, () => loadPyodide({indexURL: `${import.meta.env.BASE_URL}pyodide/${__PYODIDE_VERSION__}/`}));
     
     // Register our strype.graphics etc modules with Pyodide by pointing it to the Javascript:
     pyodide.registerJsModule("strype_bridge", strype_bridge);

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -12,6 +12,20 @@ import { zipDir } from "./scripts/zip-dir.js";
 import checker from 'vite-plugin-checker';
 import {randomUUID} from "node:crypto";
 
+// Reads the exact resolved Pyodide version from package-lock.json -- must match the same lookup
+// in scripts/download-pyodide-libs.cjs, which uses this same version as the folder name under
+// public/pyodide/ (see the comment on indexURL in python-execution.ts for why: the folder needs a
+// version segment so it's safe to cache indefinitely, and the two need to agree on that segment or
+// the runtime will fetch a URL that was never downloaded there):
+function getPyodideVersion() {
+    const lock = JSON.parse(fs.readFileSync(path.resolve(__dirname, "package-lock.json"), "utf-8"));
+    const version = lock.packages?.["node_modules/pyodide"]?.version ?? lock.dependencies?.pyodide?.version;
+    if (!version) {
+        throw new Error("Could not find pyodide version in package-lock.json");
+    }
+    return version;
+}
+
 function zipPysrcPlugin() {
     let running = false;
     const run = async () => {
@@ -151,6 +165,7 @@ export default defineConfig(({mode}) => {
             __BUILD_GIT_HASH__: JSON.stringify(
                 execSync("git rev-parse --short=8 HEAD").toString().trim()
             ),
+            __PYODIDE_VERSION__: JSON.stringify(getPyodideVersion()),
         },
 
         resolve: {


### PR DESCRIPTION
## Summary

Investigating a colleague's report (Safari/macOS, screenshot + console log) of the Run button getting permanently stuck on "Initialising..." traced back to a tab left open across a deploy: the already-loaded page still referenced a Pyodide worker chunk by its previous build's content hash, and GitHub Pages' single-deployment scheme had since removed that exact file. `createPyodideSlot()` never listened for the Worker's `error` event, so a script-load failure left the slot silently stuck at `ready=false`/`controlled=false` forever, with nothing retrying it or explaining why.

- `main_thread_python_handler.ts`: add a worker `"error"` listener. A dead spare is just dropped (the next run's restart already retries it); a dead active slot is retried up to 3 times with backoff before giving up and leaving Run cleanly disabled instead of hanging indefinitely.
- Separately, checking strype.org's actual response headers showed every asset — hashed or not, including the ~11MB Pyodide runtime — was being served with a blanket no-cache/must-revalidate policy, defeating the point of content-hashed filenames and contributing to exactly this class of bug. Pyodide's runtime was also served from an unversioned path, so it couldn't safely be marked cacheable-forever even if the server policy were fixed. Version-scope it (`public/pyodide/<version>/`, driven by the same `package-lock.json` lookup already used by the download script) so it can be, and document the server-side `Cache-Control` policy needed in `APACHE_CONFIG.md` (to be applied via the main Apache config, not a committed `.htaccess`).

## Test plan

- [x] `npm run type:check` passes
- [x] `npm run lint:check` (targeted eslint run on changed files) passes
- [ ] Manual smoke test: run code, stop mid-run, run again, confirm Pyodide restarts normally
- [ ] After deploying with `APACHE_CONFIG.md`'s config applied to strype.org, confirm hashed assets and `pyodide/<version>/*` are served with long-lived `Cache-Control` while `index.html`/the service worker stay short-cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019L8UQzbsKS6F32MQ421RF8