### PR TITLE
Record OS and browser (with major version) in analytics

### DIFF
--- a/src/helpers/analyticsUserAgent.ts
+++ b/src/helpers/analyticsUserAgent.ts
@@ -1,0 +1,68 @@
+export interface UserAgentInfo {
+    os: string;
+    browserName: string;
+    browserVersion: string | null;
+}
+
+// OS version is deliberately not attempted: it's unreliable across the browsers/OSes Strype
+// actually sees in schools. Windows 10 and 11 report the identical "Windows NT 10.0" (Microsoft
+// never bumped it), and Chrome freezes the reported macOS version in its UA string for privacy --
+// so any OS version we recorded would be wrong often enough to be misleading. The OS *name* and
+// the browser's major version are both reliable, so that's what we record.
+function detectOs(ua: string): string {
+    // Order matters: Android's UA also contains "Linux", and iOS's contains "like Mac OS X":
+    if (/Windows/.test(ua)) {
+        return "Windows";
+    }
+    if (/Android/.test(ua)) {
+        return "Android";
+    }
+    if (/iPhone|iPad|iPod/.test(ua)) {
+        return "iOS";
+    }
+    if (/CrOS/.test(ua)) {
+        return "ChromeOS";
+    }
+    if (/Mac OS X/.test(ua)) {
+        return "macOS";
+    }
+    if (/Linux/.test(ua)) {
+        return "Linux";
+    }
+    return "Other";
+}
+
+function detectBrowserNameAndVersion(ua: string): {name: string, version: string | null} {
+    // Order matters: Edge and Opera are Chromium-based, so their UA strings also carry a
+    // "Chrome/x" token, and Chrome's UA string also carries a "Safari/x" token -- so the more
+    // specific brand checks have to come first, or they'd all get misidentified as Chrome/Safari.
+    // Safari's real version comes from a separate "Version/x" token, not "Safari/x" (that's the
+    // WebKit build number, not the browser version).
+    const edge = ua.match(/\bEdg\/(\d+)/);
+    if (edge) {
+        return {name: "Edge", version: edge[1]};
+    }
+    const opera = ua.match(/\bOPR\/(\d+)/);
+    if (opera) {
+        return {name: "Opera", version: opera[1]};
+    }
+    const firefox = ua.match(/\bFirefox\/(\d+)/);
+    if (firefox) {
+        return {name: "Firefox", version: firefox[1]};
+    }
+    const chrome = ua.match(/\bChrome\/(\d+)/);
+    if (chrome) {
+        return {name: "Chrome", version: chrome[1]};
+    }
+    if (/\bSafari\//.test(ua)) {
+        const version = ua.match(/\bVersion\/(\d+)/);
+        return {name: "Safari", version: version ? version[1] : null};
+    }
+    return {name: "Other", version: null};
+}
+
+export function detectOsAndBrowser(): UserAgentInfo {
+    const ua = navigator.userAgent;
+    const {name, version} = detectBrowserNameAndVersion(ua);
+    return {os: detectOs(ua), browserName: name, browserVersion: version};
+}

--- a/src/helpers/initialiseAnalytics.ts
+++ b/src/helpers/initialiseAnalytics.ts
@@ -8,6 +8,7 @@ import {
     initAnalyticsCountry,
     initAnalyticsPlatform,
     initAnalyticsSession,
+    initAnalyticsUserAgent,
     initAnalyticsUserId,
     trackAnalyticsLocaleChange,
 } from "@/store/analytics";
@@ -16,6 +17,7 @@ export function initialiseAnalytics(): void {
     initAnalyticsUserId();
     initAnalyticsSession();
     initAnalyticsPlatform();
+    initAnalyticsUserAgent();
     startSessionTracking();
     void initAnalyticsCountry();
 

--- a/src/store/analytics.ts
+++ b/src/store/analytics.ts
@@ -1,4 +1,5 @@
 import { fetchUserCountry, type UserCountry } from "@/helpers/analyticsCountry";
+import { detectOsAndBrowser } from "@/helpers/analyticsUserAgent";
 import { Analytics_batch_max_events, Analytics_queue_overflow_cap } from "@/helpers/analyticsConstants";
 import { StrypeSyncTarget } from "@/types/types";
 
@@ -15,6 +16,9 @@ export type AnalyticsFlushReason = "interval" | "size_cap" | "critical" | "unloa
 export const analyticsState = {
     countryCode: null as string | null,
     countryName: null as string | null,
+    os: "" as string,
+    browserName: "" as string,
+    browserVersion: null as string | null,
     userId: "" as string,
     sessionStartTime: 0 as number,
     activeSessionTime: 0 as number,
@@ -50,6 +54,13 @@ export function initAnalyticsPlatform(): void {
     const path = (typeof window !== "undefined") ? window.location.pathname.toLowerCase() : "";
     analyticsState.platform = path.includes("microbit") ? "microbit" : "editor";
     // #v-endif
+}
+
+export function initAnalyticsUserAgent(): void {
+    const {os, browserName, browserVersion} = detectOsAndBrowser();
+    analyticsState.os = os;
+    analyticsState.browserName = browserName;
+    analyticsState.browserVersion = browserVersion;
 }
 
 export function setAnalyticsCountry(country: UserCountry): void {
@@ -106,6 +117,9 @@ export function flushAnalyticsQueue(reason: AnalyticsFlushReason): void {
         platform: analyticsState.platform,
         countryCode: analyticsState.countryCode,
         countryName: analyticsState.countryName,
+        os: analyticsState.os,
+        browserName: analyticsState.browserName,
+        browserVersion: analyticsState.browserVersion,
         flushReason: reason,
         events: batch,
     });


### PR DESCRIPTION
## Summary

- Adds `os`, `browserName`, `browserVersion` to the analytics payload, computed once at session start (`initAnalyticsUserAgent()` in `initialiseAnalytics.ts`) and sent with every flush, the same way `countryCode`/`countryName`/`platform` already are.
- New `src/helpers/analyticsUserAgent.ts` parses `navigator.userAgent` for OS name and browser name + major version (Chrome/Firefox/Safari/Edge/Opera, Windows/macOS/Linux/iOS/Android/ChromeOS).
- Deliberately does **not** record OS version: Windows 10 and 11 report the identical UA string (Microsoft never bumped the NT version), and Chrome freezes the reported macOS version for privacy — so it would be wrong often enough to be misleading. Browser major version is reliable and is recorded.

## Test plan

- [x] `npm run type:check` passes
- [x] `npm run lint:check` (targeted eslint run on changed files) passes
- [x] Sanity-checked the UA parsing against 12 real-world UA strings (Chrome/Edge/Opera/Firefox on Windows, Safari/Chrome/Firefox on macOS, Safari on iPhone/iPad, Chrome on Android/Linux/ChromeOS) — all resolved correctly
- [ ] Manual check: confirm the new fields show up correctly in the ingest payload from a real browser session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019L8UQzbsKS6F32MQ421RF8