### PR TITLE
Prompt the user to reload when a new version has been deployed

### DIFF
--- a/src/components/MessageBanner.vue
+++ b/src/components/MessageBanner.vue
@@ -126,6 +126,9 @@ export default defineComponent({
                     this.appStore.applyStateUndoRedoChanges(true);
                     this.appStore.currentMessage = MessageDefinitions.NoMessage;
                     break;
+                case MessageDefinedActions.reload:
+                    window.location.reload();
+                    break;
                 case MessageDefinedActions.load:
                     if (this.appStore.foundRecentState != null) {
                         // Set both these items going in parallel (first is quick, second is longer and we don't need to wait for it):

--- a/src/helpers/versionCheck.ts
+++ b/src/helpers/versionCheck.ts
@@ -1,0 +1,40 @@
+import { useStore } from "@/store/store";
+import { MessageDefinitions } from "@/types/types";
+
+// How often a long-lived tab re-checks whether the deployed build has moved on since it loaded.
+// Not urgent -- the reload prompt is a courtesy, not a correctness requirement -- so this errs
+// on the infrequent side rather than adding needless background traffic:
+const VERSION_CHECK_INTERVAL_MS = 10 * 60 * 1000;
+
+let newVersionAlreadyShown = false;
+
+async function checkForNewVersion(): Promise<void> {
+    // Once shown, don't check again -- showMessage() would just be reasserting the same banner
+    // (or clobbering whatever the user's looking at now if they dismissed it), and the user's
+    // already been told what they need to know:
+    if (newVersionAlreadyShown) {
+        return;
+    }
+    try {
+        // cache: "no-store" is essential here, not just a nice-to-have: the whole point is asking
+        // the server what's current, so an HTTP-cached (even briefly cached) answer would defeat it.
+        const response = await fetch(`${import.meta.env.BASE_URL}version.json`, {cache: "no-store"});
+        if (!response.ok) {
+            return;
+        }
+        const data = await response.json() as {gitHash?: string};
+        if (data.gitHash && data.gitHash !== __BUILD_GIT_HASH__) {
+            newVersionAlreadyShown = true;
+            useStore().showMessage(MessageDefinitions.NewVersionAvailable, null);
+        }
+    }
+    catch {
+        // Network blip, offline, dev server with no version.json (only written by a real build --
+        // see writeVersionFilePlugin in vite.config.mjs), etc. -- none of that is evidence of a new
+        // version, so just try again next interval:
+    }
+}
+
+export function startVersionCheck(): void {
+    setInterval(() => void checkForNewVersion(), VERSION_CHECK_INTERVAL_MS);
+}

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -49,7 +49,8 @@
     "incompatiblePythonStrypeSection": "the Python code cannot be placed in the target Strype section",
     "invalidMatchStmtContent": "this content is not allowed inside a 'match' statement",
     "errorAccessingIndexedDB": "Error accessing browser storage (possibly due to private browsing).  Your project will not be automatically backed up.  (Error: {errorMsg})",
-    "foundRecentUnsavedState": "A recent unsaved project backup (last modified {when}) was found.  Do you want to load it?"
+    "foundRecentUnsavedState": "A recent unsaved project backup (last modified {when}) was found.  Do you want to load it?",
+    "newVersionAvailable": "A new version of Strype is available. Reload the page to update."
   },
   "buttonLabel": {
     "undo": "Undo",
@@ -73,6 +74,7 @@
     "select": "Select",
     "refresh": "refresh",
     "choose": "Choose",
+    "reload": "Reload",
     "renameAllWithShortcut": "Rename all <span class=\"kb-shortcut\">({modifierkey}+R)</span>"
   },
   "errorMessage": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {getAppLangSelectId, getEditorID, getEditorMenuUID, getFrameBodyUID, getF
 import "@imengyu/vue3-context-menu/lib/vue3-context-menu.css";
 import ContextMenu from "@imengyu/vue3-context-menu";
 import { initialiseAnalytics } from "./helpers/initialiseAnalytics";
+import { startVersionCheck } from "./helpers/versionCheck";
 import { openIndexedDBConnection, tidyUpDatabaseState } from "@/store/store-db-storage";
 import { getEditorTabId } from "@/store/store";
 import { showIndexDBError } from "@/helpers/storeMethods";
@@ -109,6 +110,7 @@ app.use(i18n);
 // Store package (Pinia is the default store management library for Vue 3)
 app.use(createPinia());
 initialiseAnalytics();
+startVersionCheck();
 // Create a directive "blur" to replace the package v-blur, only compatible with Vue 2
 const applyBlur = (el: HTMLElement, isBlurred: Boolean) => {
     el.style.filter = (isBlurred) ? "blur(1.5px)" : "none";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -926,6 +926,7 @@ export const MessageDefinedActions = {
     closeBanner: "close",
     undo: "undo",
     load: "load",
+    reload: "reload",
 };
 
 export enum imagePaths {
@@ -957,6 +958,7 @@ export const MessageTypes = {
     invalidPythonParsePaste: "invalidPythonParsePaste",
     errorAccessingIndexedDB: "errorAccessingIndexedDB",
     foundRecentUnsavedState: "foundRecentUnsavedState",
+    newVersionAvailable: "newVersionAvailable",
 };
 
 //empty message
@@ -1104,6 +1106,17 @@ const FoundRecentUnsavedState: MessageDefinition = {
     path: imagePaths.empty,
 };
 
+// Shown when startVersionCheck() (versionCheck.ts) detects that the deployed build has moved on
+// since this page loaded -- see its comment for why that can happen even in a single session.
+// No timeout: unlike most banners this isn't reacting to something the user just did, so there's
+// no natural moment it stops being relevant -- it should stay until they act or dismiss it.
+const NewVersionAvailable: MessageDefinition = {
+    ...NoMessage,
+    type: MessageTypes.newVersionAvailable,
+    message: "messageBannerMessage.newVersionAvailable",
+    buttons: [{ label: "buttonLabel.reload", action: MessageDefinedActions.reload }],
+};
+
 export const MessageDefinitions = {
     NoMessage,
     UploadSuccessMicrobit,
@@ -1121,6 +1134,7 @@ export const MessageDefinitions = {
     InvalidPythonParsePaste,
     ErrorAccessingIndexedDB,
     FoundRecentUnsavedState,
+    NewVersionAvailable,
 };
 
 //WebUSB listener

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -131,8 +131,12 @@ function removeFilesPlugin(isStandardPython) {
 function writeVersionFilePlugin(gitHash) {
     return {
         name: "write-version-file",
-        closeBundle() {
-            fs.writeFileSync(path.resolve(__dirname, "dist/version.json"), JSON.stringify({gitHash}));
+        // Use writeBundle (not closeBundle) so we get the actual resolved output dir: this config
+        // is also loaded, via vite's build() API, by scripts/build-service-worker.mjs to compile a
+        // single worker file into a temp dir ahead of the real app build -- writing to a
+        // hardcoded "dist/" there fails because the real dist/ doesn't exist yet at that point:
+        writeBundle(options) {
+            fs.writeFileSync(path.resolve(options.dir, "version.json"), JSON.stringify({gitHash}));
         },
     };
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -107,13 +107,30 @@ function removeFilesPlugin(isStandardPython) {
     };
 }
 
+// Writes a small, deliberately-unhashed version.json into the build output, containing the same
+// git hash already baked into the JS bundle as __BUILD_GIT_HASH__ (see the "define" block below).
+// A tab that's been open long enough to outlive a deploy periodically re-fetches this file (see
+// startVersionCheck() in src/helpers/versionCheck.ts) to detect that a new version exists and
+// prompt the user to reload -- which requires it to live at a stable, unhashed path (so the
+// already-loaded page knows where to ask) and to never be long-cached (so the answer is actually
+// current, not whatever was true when the page itself first loaded):
+function writeVersionFilePlugin(gitHash) {
+    return {
+        name: "write-version-file",
+        closeBundle() {
+            fs.writeFileSync(path.resolve(__dirname, "dist/version.json"), JSON.stringify({gitHash}));
+        },
+    };
+}
+
 export default defineConfig(({mode}) => {
     // The environment variable for the Strype "platform" (standard Python or for micro:bit) is set in the scripts (STRYPE_PLATFORM)
     // We use environment variables for listing the possible values (for the code, the literal values are used only in the serve/build scripts...).
     const viteEnv = loadEnv(mode, process.cwd(), "VITE_");
     const isStandardPython = process.env.STRYPE_PLATFORM === viteEnv.VITE_STANDARD_PYTHON_MODE;
-  
-    return {       
+    const gitHash = execSync("git rev-parse --short=8 HEAD").toString().trim();
+
+    return {
         plugins: [
             ConditionalCompile(),
             vue(),
@@ -123,8 +140,9 @@ export default defineConfig(({mode}) => {
             removeFilesPlugin(isStandardPython),
             viteStaticCopyPyodide(),
             zipPysrcPlugin(),
+            writeVersionFilePlugin(gitHash),
             // Ideally we want typescript: true, but only after finishing the Pyodide and Vue 3 work:
-            checker({ typescript: false }),        
+            checker({ typescript: false }),
         ],
 
         css: {
@@ -148,9 +166,7 @@ export default defineConfig(({mode}) => {
         // Global Vite define variables used in the application
         define: {
             __BUILD_DATE_TICKS__: Date.now(),
-            __BUILD_GIT_HASH__: JSON.stringify(
-                execSync("git rev-parse --short=8 HEAD").toString().trim()
-            ),
+            __BUILD_GIT_HASH__: JSON.stringify(gitHash),
         },
 
         resolve: {


### PR DESCRIPTION
## Summary

Deferred piece from the Run-button-stuck-on-Initialising investigation: the worker-error-handling fix (#1039) stops a tab from hanging forever when a stale asset 404s, but a long-lived tab still has no way to know its build is stale *before* something breaks. This detects it proactively and offers a reload.

- `vite.config.mjs`: writes a small, deliberately unhashed `version.json` into the build output containing the same git hash already baked into the JS bundle as `__BUILD_GIT_HASH__`.
- `src/helpers/versionCheck.ts`: every 10 minutes, re-fetches `version.json` with `cache: "no-store"` and compares the hash to this page's own. A mismatch means a deploy has happened since the page loaded.
- On mismatch, shows a persistent banner (new `MessageDefinitions.NewVersionAvailable`, no auto-timeout) with a Reload button — reuses the existing `MessageBanner`/`showMessage` infrastructure rather than new UI.

**Not for immediate merge** — intentionally independent of #1039/#1040 (separate concern), and per our plan should land in a *later* release after the current work has already gone out. Please don't merge this until you're ready for that.

## Test plan

- [x] `npm run type:check` passes
- [x] `npm run lint:check` (targeted eslint run on changed files) passes
- [x] Booted the dev server and confirmed no console errors from the new code (service worker + Pyodide worker both initialised cleanly); confirmed the `version.json` fetch fails closed (silently no-ops) when the file doesn't exist, which is what happens in dev mode
- [ ] Manual check against a real deploy: confirm `version.json` is served with a short/no-cache policy in production so the check actually reflects the live server, and that the banner + Reload button work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019L8UQzbsKS6F32MQ421RF8