### PR TITLE
Dedupe CI runs on push+PR, and skip CI entirely for no-ci-* branches

### DIFF
--- a/.github/workflows/lint-type-check.yml
+++ b/.github/workflows/lint-type-check.yml
@@ -1,5 +1,14 @@
 name: Run lint and type check
 on: [push,pull_request]
+# A push to a branch that already has an open PR fires both a push event and a pull_request
+# "synchronize" event for the same commit -- without this, that's two full runs of everything
+# below. Group push and pull_request runs for the same branch together (falling back to ref_name
+# for push events, which don't set head_ref) so the second event to arrive cancels the first
+# rather than both running to completion; genuinely independent branches/PRs don't share a group,
+# so this doesn't reduce coverage, just the redundant duplicate:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 jobs:
   Lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-type-check.yml
+++ b/.github/workflows/lint-type-check.yml
@@ -1,5 +1,11 @@
 name: Run lint and type check
-on: [push,pull_request]
+on:
+  push:
+    # A "no-ci-*" branch (e.g. for a trivial README-only change) skips this trigger entirely --
+    # no run is even created, unlike the pull_request case below where a head_ref check on each
+    # job is the best we can do (there's no equivalent head-branch trigger filter for PRs):
+    branches-ignore: ["no-ci-*"]
+  pull_request:
 # A push to a branch that already has an open PR fires both a push event and a pull_request
 # "synchronize" event for the same commit -- without this, that's two full runs of everything
 # below. Group push and pull_request runs for the same branch together (falling back to ref_name
@@ -11,6 +17,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   Lint:
+    # See the branches-ignore comment above -- this is the pull_request-side equivalent (head_ref
+    # is only set for pull_request events; a push that reaches this point already isn't excluded):
+    if: ${{ !startsWith(github.head_ref, 'no-ci-') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -23,6 +32,7 @@ jobs:
       - name: NPM Linter
         run: npm run lint:check        
   TypeCheck:
+    if: ${{ !startsWith(github.head_ref, 'no-ci-') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -35,6 +45,7 @@ jobs:
       - name: NPM Type check
         run: npm run type:check        
   Build:
+    if: ${{ !startsWith(github.head_ref, 'no-ci-') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code

--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -1,5 +1,11 @@
 name: Cypress tests
-on: [push,pull_request]
+on:
+  push:
+    # A "no-ci-*" branch (e.g. for a trivial README-only change) skips this trigger entirely --
+    # no run is even created, unlike the pull_request case below where a head_ref check on the
+    # job is the best we can do (there's no equivalent head-branch trigger filter for PRs):
+    branches-ignore: ["no-ci-*"]
+  pull_request:
 # A push to a branch that already has an open PR fires both a push event and a pull_request
 # "synchronize" event for the same commit -- without this, that's two full runs of everything
 # below. Group push and pull_request runs for the same branch together (falling back to ref_name
@@ -11,6 +17,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   Build-And-Run-Tests:
+    # See the branches-ignore comment above -- this is the pull_request-side equivalent (head_ref
+    # is only set for pull_request events; a push that reaches this point already isn't excluded):
+    if: ${{ !startsWith(github.head_ref, 'no-ci-') }}
     timeout-minutes: 125
     strategy:
       fail-fast: false

--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -1,5 +1,14 @@
 name: Cypress tests
 on: [push,pull_request]
+# A push to a branch that already has an open PR fires both a push event and a pull_request
+# "synchronize" event for the same commit -- without this, that's two full runs of everything
+# below. Group push and pull_request runs for the same branch together (falling back to ref_name
+# for push events, which don't set head_ref) so the second event to arrive cancels the first
+# rather than both running to completion; genuinely independent branches/PRs don't share a group,
+# so this doesn't reduce coverage, just the redundant duplicate:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 jobs:
   Build-And-Run-Tests:
     timeout-minutes: 125

--- a/.github/workflows/run-playwright-tests.yml
+++ b/.github/workflows/run-playwright-tests.yml
@@ -1,5 +1,14 @@
 name: Playwright Tests
 on: [push,pull_request]
+# A push to a branch that already has an open PR fires both a push event and a pull_request
+# "synchronize" event for the same commit -- without this, that's two full runs of everything
+# below. Group push and pull_request runs for the same branch together (falling back to ref_name
+# for push events, which don't set head_ref) so the second event to arrive cancels the first
+# rather than both running to completion; genuinely independent branches/PRs don't share a group,
+# so this doesn't reduce coverage, just the redundant duplicate:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 jobs:
   test:
     timeout-minutes: 125

--- a/.github/workflows/run-playwright-tests.yml
+++ b/.github/workflows/run-playwright-tests.yml
@@ -1,5 +1,11 @@
 name: Playwright Tests
-on: [push,pull_request]
+on:
+  push:
+    # A "no-ci-*" branch (e.g. for a trivial README-only change) skips this trigger entirely --
+    # no run is even created, unlike the pull_request case below where a head_ref check on the
+    # job is the best we can do (there's no equivalent head-branch trigger filter for PRs):
+    branches-ignore: ["no-ci-*"]
+  pull_request:
 # A push to a branch that already has an open PR fires both a push event and a pull_request
 # "synchronize" event for the same commit -- without this, that's two full runs of everything
 # below. Group push and pull_request runs for the same branch together (falling back to ref_name
@@ -11,6 +17,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
+    # See the branches-ignore comment above -- this is the pull_request-side equivalent (head_ref
+    # is only set for pull_request events; a push that reaches this point already isn't excluded):
+    if: ${{ !startsWith(github.head_ref, 'no-ci-') }}
     timeout-minutes: 125
     # 5 minutes extra to upload videos if we fail the timeout of one hour, below
     strategy:


### PR DESCRIPTION
## Summary

Two related fixes to `lint-type-check.yml`, `run-playwright-tests.yml` and `run-cypress-tests.yml` (all trigger on `[push, pull_request]`):

1. **Dedup**: pushing a commit to a branch that already has an open PR fires both a `push` event and a `pull_request: synchronize` event for the same commit, so every one of these (expensive) workflows ran twice per push. Added a `concurrency` group per workflow, keyed by branch name (falling back to `ref_name` for push events, which don't set `head_ref`), so the second event to arrive cancels whichever run from the first is still in progress.
2. **`no-ci-*` skip**: for trivial/admin changes (e.g. a README-only PR) where running the full suites is pure overhead. `push` uses `branches-ignore: ["no-ci-*"]` (no run created at all); `pull_request` has no equivalent head-branch trigger filter (`branches`/`branches-ignore` there filter the PR's *base* branch, not its source), so each job instead checks `github.head_ref` and skips if it starts with `no-ci-` — this also covers PRs from forks, since `head_ref` reflects the actual source branch regardless of repo.

`build-pages-test-site.yml` and `attach-release-build.yml` are untouched: neither has a `pull_request` trigger (so no dedup issue), and the preview-site deploy wasn't included in the `no-ci-*` skip since it's not really "CI" in the test-suite sense.

This PR is itself the live test of point 2 — its branch is named `no-ci-dedupe-ci-triggers`, and pushing it produced no `Run lint and type check`/`Playwright Tests`/`Cypress tests` runs at all (confirmed via `gh run list`), only the untouched pages-deploy workflow.

## Test plan

- [x] Confirmed via `gh run list` that pushing this branch triggered *only* `Deploy to GitHub Pages`, not any of the three modified workflows
- [ ] Confirm this PR itself (opened from a `no-ci-*` branch) shows the three jobs/workflows as skipped rather than pending/absent, and that merging still works normally despite required-check expectations (worth double-checking branch protection rules don't block merging when a required check never ran)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019L8UQzbsKS6F32MQ421RF8