### PR TITLE
[DRAFT] Fix Safari's "tiny paste menu" at frame cursors by giving the caret a real focus target

### DIFF
--- a/src/components/CaretContainer.vue
+++ b/src/components/CaretContainer.vue
@@ -1,13 +1,34 @@
 <template>
-    <div 
+    <div
         :class="{[scssVars.caretContainerClassName]: true, 'static-caret-container': isStaticCaretContainer, [scssVars.draggingFrameClassName]: areFramesDraggedOver}"
         @click.exact.prevent.stop="toggleCaret()"
         @contextmenu.prevent.stop="handleClick($event)"
         :key="UID"
         :id="UID"
-        tabindex="-1"        
+        tabindex="-1"
     >
-        <ContextMenu 
+        <!--
+            This input is the real DOM focus target for a frame cursor (see focusInputUID below).
+            It exists so that browsers -- Safari/WebKit in particular -- see a genuine editable element
+            under the caret and dispatch native clipboard "paste" events for Cmd/Ctrl-V, rather than
+            silently deciding paste isn't applicable at a plain, non-editable div.
+            It is visually hidden and not part of the tab order; it never keeps user-typed content
+            (see clearFocusInputContent()) and is not currently given any ARIA semantics -- see the PR
+            description for the accessibility implications of that.
+        -->
+        <input
+            type="text"
+            class="visually-hidden"
+            :id="focusInputUID"
+            tabindex="-1"
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="off"
+            spellcheck="false"
+            inputmode="none"
+            @input="clearFocusInputContent"
+        />
+        <ContextMenu
             :contextMenuItemsDef="frameContextMenuItems"
             :showContextMenu="showContextMenu"
             :showAt="showContextMenuAtCoordPos"
@@ -35,12 +56,11 @@ import { defineComponent, PropType } from "vue";
 import { useStore } from "@/store/store";
 import Caret from"@/components/Caret.vue";
 import {AllFrameTypesIdentifier, CaretPosition, Position, PythonExecRunningState, FrameContextMenuActionName, CollapsedState, StrypeContextMenuItem, CoordPosition} from "@/types/types";
-import { getCaretUID, setContextMenuEventClientXY, getAddFrameCmdElementUID, CustomEventTypes, getCaretContainerUID } from "@/helpers/editor";
+import { getCaretUID, setContextMenuEventClientXY, getAddFrameCmdElementUID, CustomEventTypes, getCaretContainerUID, getCaretContainerFocusInputUID } from "@/helpers/editor";
 import { mapStores } from "pinia";
 import { cloneDeep } from "lodash";
 import { pasteMixedPython } from "@/helpers/pythonToFrames";
 import scssVars  from "@/assets/style/_export.module.scss";
-import {detectBrowser} from "@/helpers/browser";
 import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
 import { getAboveFrameCaretPosition } from "@/helpers/storeMethods";
 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
@@ -144,6 +164,10 @@ export default defineComponent({
             return getCaretContainerUID(this.caretAssignedPosition,this.frameId);
         },
 
+        focusInputUID(): string {
+            return getCaretContainerFocusInputUID(this.caretAssignedPosition, this.frameId);
+        },
+
         caretUID(): string {
             return getCaretUID(this.caretAssignedPosition, this.frameId);
         },
@@ -184,7 +208,6 @@ export default defineComponent({
 
     mounted() {
         window.addEventListener("paste", this.pasteIfFocused);
-        window.addEventListener("keydown", this.keydownForSafariPaste);
         document.addEventListener(CustomEventTypes.scrollCaretIntoView, this.putCaretContainerInView);
         // When a frame is added, we need to make sure it will be visible in the view port. This is particularly true
         // when a paste or duplicate action is performed.
@@ -193,7 +216,6 @@ export default defineComponent({
 
     unmounted() {
         window.removeEventListener("paste", this.pasteIfFocused);
-        window.removeEventListener("keydown", this.keydownForSafariPaste);
         document.removeEventListener(CustomEventTypes.scrollCaretIntoView, this.putCaretContainerInView);
         // Remove the component's API instance
         if(vueComponentsAPIHandler.caretContainerComponentAPI?.forInstance[this.UID]){
@@ -213,30 +235,23 @@ export default defineComponent({
             }  
         },
         
-        keydownForSafariPaste(event: KeyboardEvent) {
-            // Safari-specific code.  Safari doesn't turn Cmd-V into a paste if it believes the paste
-            // is not applicable.  This can happen to us at frame cursors.  So we manually turn it into
-            // paste if we believe Safari won't turn it into paste:
-            // Note: Safari also won't paste if the clipboard is empty, which it is when frames are on the clipboard
-            // So this solves both issues.
-            if (this.isFocusedForPaste && detectBrowser() === "safari" && event.metaKey && event.key.toLowerCase() === "v") {
-                navigator.clipboard.readText().catch((err) => {
-                    // This can happen during Playwright testing:
-                    console.error("Failed to read clipboard during frame paste", err);
-                    return "";
-                }).then((text) => {
-                    this.pasteIfFocused(event, text);
-                });
-                
-                event.stopPropagation();
-                event.preventDefault();
-                event.stopImmediatePropagation();
-            }
+        // Clears out the invisible paste-focus input's content (see the template comment on it):
+        // nothing ever reads its value, but a stray typed character (anything that somehow reaches
+        // the input without a shortcut handler already having called preventDefault -- see
+        // Commands.vue's keydown handling of bare frame-cursor typing) or the browser's own default
+        // paste-insertion (see the top of pasteIfFocused below) would otherwise sit there indefinitely.
+        clearFocusInputContent(event: Event) {
+            (event.target as HTMLInputElement).value = "";
         },
 
-        pasteIfFocused(event: Event, overrideText?: string) {
+        pasteIfFocused(event: ClipboardEvent) {
             // Only respond if we are focused:
             if (this.isFocusedForPaste) {
+                // The paste focus input (see template) is a genuine editable element, so browsers will
+                // by default try to insert the pasted text into it; we handle the paste ourselves below,
+                // so stop that default insertion (it would immediately be wiped by clearFocusInputContent
+                // anyway, but there's no reason to let the browser do the work in the first place).
+                event.preventDefault();
                 let pasteDestination = {id: this.frameId, caretPosition: this.caretAssignedPosition};
                 const stateBeforeChanges = cloneDeep(this.appStore.$state);
                 let hasRemovedFrameSelection = false;
@@ -257,13 +272,13 @@ export default defineComponent({
 
                 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
                 const inFrameType = this.appStore.frameObjects[(this.appStore.currentFrame.caretPosition == CaretPosition.body) ? this.appStore.currentFrame.id : getParentOrJointParent(this.appStore.currentFrame.id)].frameType;
-                if(!inFrameType.forbiddenChildrenTypes.includes(AllFrameTypesIdentifier.funccall) && Object.values((event as ClipboardEvent).clipboardData?.items??[]).some((dataTransferItem: DataTransferItem) => dataTransferItem.kind == "file" && /^(image)|(audio)\//.test(dataTransferItem.type))){
+                if(!inFrameType.forbiddenChildrenTypes.includes(AllFrameTypesIdentifier.funccall) && Object.values(event.clipboardData?.items??[]).some((dataTransferItem: DataTransferItem) => dataTransferItem.kind == "file" && /^(image)|(audio)\//.test(dataTransferItem.type))){
                     // For the special case of image media, we want to simulate the addition of a method call with that media.
                     // Therefore, we will need to "wrap" around the media literal value with our usual wrappers.
                     // We don't rely on the frame authorised children rules for that, because we don't have a copied frame in the state.
                     // We know a media frame cannot be inside an import section, nor directly inside a definition section, nor directly inside a class or function frame
                     // (this test is done first in the condition above).
-                    preparePasteMediaData(event as ClipboardEvent, (code: string, dataAndDim: MediaDataAndDim) => {
+                    preparePasteMediaData(event, (code: string, dataAndDim: MediaDataAndDim) => {
                         // We create a new function call frame with the media-adapated code content
                         this.appStore.ignoreStateSavingActionsForUndoRedo = true;
                         this.appStore.addFrameWithCommand(getFrameDefType(AllFrameTypesIdentifier.funccall), undefined, true, true).then((frameId) => {
@@ -299,7 +314,7 @@ export default defineComponent({
                     return;
                 }
                 // #v-endif
-                const pythonCode = overrideText ?? (event as ClipboardEvent).clipboardData?.getData("text");
+                const pythonCode = event.clipboardData?.getData("text");
                 // Note we don't permanently trim the code because we need to preserve leading indent.
                 // But we trim for the purposes of checking if there's any content at all:
                 if (pythonCode != undefined && pythonCode?.trim()) {
@@ -393,6 +408,10 @@ export default defineComponent({
     scroll-margin-top: 50px;
     scroll-margin-bottom: 50px;
     outline: none;
+    // Establishes a positioning context for the invisible paste-focus <input> (position: absolute via
+    // Bootstrap's .visually-hidden), so it stays roughly where the visible caret is on screen rather
+    // than wherever the nearest other positioned ancestor happens to be.
+    position: relative;
 }
 
 .static-caret-container{

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -59,7 +59,7 @@ import { computed, defineComponent } from "vue";
 import { useStore } from "@/store/store";
 import { mapStores } from "pinia";
 import LabelSlot from "@/components/LabelSlot.vue";
-import { bumpCaretRequestSeq, CustomEventTypes, getEditableSelectionText, getFrameLabelSlotLiteralCodeAndFocus, getFrameLabelSlotsStructureUID, getFunctionCallDefaultText, getLabelSlotUID, getMatchingBracket, getSelectionCursorsComparisonValue, getUIQuote, isElementEditableLabelSlotInput, isLabelSlotEditable, openBracketCharacters, parseCodeLiteral, parseLabelSlotUID, setDocumentSelection, STRING_DOUBLEQUOTE_PLACERHOLDER, STRING_SINGLEQUOTE_PLACERHOLDER, stringQuoteCharacters, UIDoubleQuotesCharacters, UISingleQuotesCharacters, getGraphemeLength, getFrameHeaderUID, getFlatCodeSlotsInLabelStruct, getCaretContainerUID, closeRenameIdentifierPopups, getImportFrameNameBindings, waitForElementId } from "@/helpers/editor";
+import { bumpCaretRequestSeq, CustomEventTypes, getEditableSelectionText, getFrameLabelSlotLiteralCodeAndFocus, getFrameLabelSlotsStructureUID, getFunctionCallDefaultText, getLabelSlotUID, getMatchingBracket, getSelectionCursorsComparisonValue, getUIQuote, isElementEditableLabelSlotInput, isLabelSlotEditable, openBracketCharacters, parseCodeLiteral, parseLabelSlotUID, setDocumentSelection, STRING_DOUBLEQUOTE_PLACERHOLDER, STRING_SINGLEQUOTE_PLACERHOLDER, stringQuoteCharacters, UIDoubleQuotesCharacters, UISingleQuotesCharacters, getGraphemeLength, getFrameHeaderUID, getFlatCodeSlotsInLabelStruct, getCaretContainerFocusInputUID, closeRenameIdentifierPopups, getImportFrameNameBindings, waitForElementId } from "@/helpers/editor";
 import { checkCodeErrors, evaluateSlotType, filterAllowedJointChildrenAfter, generateFlatSlotBases, getFlatNeighbourFieldSlotInfos, getFrameParentSlotsLength, getParentOrJointParent, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, retrieveSlotByPredicate, retrieveSlotFromSlotInfos, getParentId, areSlotStructuresIsomorphic, getAncestorFrameOfTypeId, findSlotsWithIndentifierName, isAncestorGatedFrameTypeAllowed } from "@/helpers/storeMethods";
 import { cloneDeep } from "lodash";
 import Parser from "@/parser/parser";
@@ -1079,7 +1079,7 @@ export default defineComponent({
                         this.appStore.setSlotTextCursors(undefined, undefined);
                         this.appStore.isEditing = false;
                         this.appStore.toggleCaret({id: this.frameId, caretPosition: caretOnlyTargetPosition});
-                        document.getElementById(getCaretContainerUID(caretOnlyTargetPosition, this.frameId))?.focus();
+                        document.getElementById(getCaretContainerFocusInputUID(caretOnlyTargetPosition, this.frameId))?.focus();
                         options?.doAfterCursorSet?.();
                         this.appStore.saveStateChanges(stateBeforeChanges);
                         this.finishPendingConversion(undefined);
@@ -1483,15 +1483,15 @@ export default defineComponent({
                     this.appStore.toggleCaret({id: this.frameId, caretPosition: CaretPosition.below});
                     // In order to keep a coherence between our state's focus information and the internal browser active element,
                     // we explicitly set the focus on the frame cursor that holds it now.
-                    document.getElementById(getCaretContainerUID(CaretPosition.below, this.frameId))?.focus();
+                    document.getElementById(getCaretContainerFocusInputUID(CaretPosition.below, this.frameId))?.focus();
                 }
                 else {
                     // Restore the caret visibility
                     this.appStore.frameObjects[this.appStore.currentFrame.id].caretVisibility = this.appStore.currentFrame.caretPosition;
                     this.$nextTick(() => document.dispatchEvent(new CustomEvent(CustomEventTypes.scrollCaretIntoView, {})));
                     // In order to keep a coherence between our state's focus information and the internal browser active element,
-                    // we explicitly set the focus on the frame cursor that holds it now.                    
-                    document.getElementById(getCaretContainerUID(this.appStore.currentFrame.caretPosition, this.frameId))?.focus();
+                    // we explicitly set the focus on the frame cursor that holds it now.
+                    document.getElementById(getCaretContainerFocusInputUID(this.appStore.currentFrame.caretPosition, this.frameId))?.focus();
                 }
             }
         },

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -505,6 +505,13 @@ export function getCaretContainerUID(caretPos: CaretPosition, frameId: number): 
     return "caret_" + caretPos + "_of_frame_" + frameId;
 }
 
+// The id of the invisible <input> that actually receives DOM focus for a frame cursor (see CaretContainer.vue).
+// Real DOM focus must land on this input (rather than the caret container div) so that browsers -- Safari/WebKit
+// in particular -- recognise the location as a legitimate paste target and dispatch native clipboard events.
+export function getCaretContainerFocusInputUID(caretPos: CaretPosition, frameId: number): string {
+    return getCaretContainerUID(caretPos, frameId) + "_focusInput";
+}
+
 export function isCaretContainerElement(id: string): boolean {
     return caretContainerUIDRegex.test(id);
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,7 +6,7 @@ import {calculateNextCollapseState, checkCodeErrors, checkStateDataIntegrity, ev
 import { AppPlatform, AppVersion, eventBus, projectDocumentationFrameId } from "@/helpers/appContext";
 import initialStates from "@/store/initial-states";
 import { defineStore } from "pinia";
-import { bumpCaretRequestSeq, CustomEventTypes, generateAllFrameCommandsDefs, getAddCommandsDefs, getFocusedEditableSlotTextSelectionStartEnd, getLabelSlotUID, isLabelSlotEditable, setDocumentSelection, parseCodeLiteral, undoMaxSteps, getSelectionCursorsComparisonValue, getFrameHeaderUID, getImportDiffVersionModalDlgId, checkEditorCodeErrors, countEditorCodeErrors, getCaretUID, getCaretContainerUID, AutoSaveKeyNames, isFullyInViewport, copyFrameTextReadyForClipboard, waitForElementId } from "@/helpers/editor";
+import { bumpCaretRequestSeq, CustomEventTypes, generateAllFrameCommandsDefs, getAddCommandsDefs, getFocusedEditableSlotTextSelectionStartEnd, getLabelSlotUID, isLabelSlotEditable, setDocumentSelection, parseCodeLiteral, undoMaxSteps, getSelectionCursorsComparisonValue, getFrameHeaderUID, getImportDiffVersionModalDlgId, checkEditorCodeErrors, countEditorCodeErrors, getCaretUID, getCaretContainerUID, getCaretContainerFocusInputUID, AutoSaveKeyNames, isFullyInViewport, copyFrameTextReadyForClipboard, waitForElementId } from "@/helpers/editor";
 import { DAPWrapper } from "@/helpers/partial-flashing";
 import LZString from "lz-string";
 import { getAPIItemTextualDescriptions } from "@/helpers/microbitAPIDiscovery";
@@ -908,8 +908,9 @@ export const useStore = defineStore("app", {
             this.frameObjects[nextCaret.id].caretVisibility = nextCaret.caretPosition;
             
             // In order to keep a coherence between our state's focus information and the internal browser active element,
-            // we explicitly set the focus on the frame cursor that holds it now.
-            document.getElementById(getCaretContainerUID(nextCaret.caretPosition, nextCaret.id))?.focus();
+            // we explicitly set the focus on the frame cursor's invisible paste-focus input (see CaretContainer.vue)
+            // that holds it now.
+            document.getElementById(getCaretContainerFocusInputUID(nextCaret.caretPosition, nextCaret.id))?.focus();
 
             // Scroll caret into view when navigating with keyboard:
             nextTick(() => document.dispatchEvent(new CustomEvent(CustomEventTypes.scrollCaretIntoView, {})));
@@ -2404,7 +2405,7 @@ export const useStore = defineStore("app", {
                 // inside it, which handleDocumentSelectionChange() (App.vue) then reads as the user having
                 // moved the caret back into the slot we just left, immediately undoing this navigation.
                 if(wasEditing){
-                    document.getElementById(getCaretContainerUID(nextPosition.caretPosition as CaretPosition, nextPosition.frameId))?.focus();
+                    document.getElementById(getCaretContainerFocusInputUID(nextPosition.caretPosition as CaretPosition, nextPosition.frameId))?.focus();
                 }
 
                 // Scroll it into view:


### PR DESCRIPTION
## [DRAFT] Fix Safari's "tiny paste menu" at frame cursors by giving the caret a real focus target

Fixes #825 (upstream, `k-pet-group/Strype`).

**This is a draft: the core hypothesis (native paste now fires on Safari without our
manual workaround) has *not* been verified against real Safari/WebKit — only against
Playwright's `webkit` project, which doesn't necessarily reproduce WebKit's clipboard-
permission UI faithfully. See "What still needs checking" below before merging.**

### The bug

Pasting text at a frame cursor (the cursor *between* frames, not inside a slot) in
Safari pops up a small native "Paste" confirmation menu at the cursor, rather than
just pasting. Reported upstream as #825.

### Root cause

Frame cursors are a `<div tabindex="-1">` (`CaretContainer.vue`), not a real editable
element. Text-slot editing (`LabelSlot.vue`) uses genuine `contenteditable` spans, so
native paste works there without any special-casing. But WebKit refuses to dispatch a
native `paste` DOM event for Cmd/Ctrl-V when the focused element isn't one it
recognises as editable (input/textarea/contenteditable) — this was already documented
in the code (see `4a96d687`, fixing #652).

To work around that, `CaretContainer.vue` had Safari-only code
(`keydownForSafariPaste`) that manually intercepted `Cmd+V` on `window` and called
`navigator.clipboard.readText()` directly, bypassing the DOM paste-event system
entirely, on *every* Cmd+V at a frame cursor in Safari (an earlier "would Safari have
pasted anyway" guard was removed in `01623b6d`).

Recent Safari/WebKit versions gate `navigator.clipboard.readText()` behind a stricter
check than "was this called during a user gesture" — WebKit only lets it through
silently when it judges the call to be the direct result of a paste action on a
genuinely editable, focused target. Our `keydown`-triggered call on a plain `<div>`
doesn't qualify, so instead of silently allowing or denying it, WebKit shows its own
small "Paste" confirmation popup anchored at the focused element — i.e. right at the
frame cursor. That's issue #825.

(One of the workaround's two original justifications — "Safari won't paste if the
clipboard is empty, which it is when frames are on the clipboard" — is also now stale:
since the June 2026 copy/paste rework, frame copies write real serialized Python text
to the system clipboard, so the clipboard usually isn't empty any more. Only the
"no editable target" reason still held.)

### The fix

Give the frame cursor a real (invisible) editable focus target: an `<input>`, visually
hidden via Bootstrap's `.visually-hidden` (already loaded globally), that receives the
*actual* DOM focus instead of the caret container `<div>`. All the places that move
"logical" caret focus already call `.focus()` on an element looked up by ID
(`store.ts`, `LabelSlotsStructure.vue`) — they're repointed at the new input via a new
`getCaretContainerFocusInputUID()` helper (`helpers/editor.ts`), alongside the
existing `getCaretContainerUID()` (which stays as the ID of the *visible* container,
still used for bounding-rect/scroll/click/component-API purposes — those didn't need
to change).

With a real editable element under the cursor, Safari should now recognise Cmd/Ctrl-V
as a legitimate paste and dispatch the native `paste` DOM event through the ordinary
event system — the same one the existing `window.addEventListener("paste", ...)`
listener already handles for text-slot pasting. So `keydownForSafariPaste` and its
`navigator.clipboard.readText()` call are deleted outright, rather than tuned: Safari
paste at frame cursors now goes through the exact same code path as Chrome/Firefox
always have, instead of a separate manual re-implementation.

Since the input is now genuinely editable, the browser's own default action for both
an ordinary paste and a stray keypress would try to insert content into it (previously
a no-op on the non-editable div) — `pasteIfFocused` now calls `event.preventDefault()`
up front, and an `@input` handler resets the input's value on any change, so nothing
ever accumulates there or is read from it (it's a focus target, not a text source; the
paste content still comes from `event.clipboardData` as before).

### What still needs checking

- **Real Safari/WebKit, not just Playwright's `webkit` project.** Playwright's WebKit
  is not guaranteed to reproduce the specific clipboard-permission popup Safari shows,
  since that's implemented as native browser UI, not something CDP/automation
  necessarily surfaces the same way. This needs a manual check in actual Safari
  (macOS, and ideally iPadOS) before merging.
- **iPad/touch Safari virtual keyboard.** Frame cursors previously had no real
  focusable/editable element, so tapping one never brought up the on-screen keyboard.
  Now that the cursor's focus target is a real `<input>`, tapping a frame cursor on a
  touchscreen device *might* trigger the virtual keyboard to pop up — `inputmode="none"`
  is set as a mitigation, but iOS/iPadOS support for suppressing the keyboard that way
  is inconsistent across versions and needs a real-device check.
- **IME / composition input** at a bare frame cursor (dead-key accents etc.) is
  untested against the new focus target; it's plausible some composition-related
  events bypass the existing keydown-based `preventDefault()` shortcut handling in
  `Commands.vue` that normally stops stray characters reaching the input.

### Testing done so far

- `vue-tsc --noEmit` and `eslint` pass on all changed files.
- `tests/playwright/e2e/paste-joint-frames.spec.ts` (7 tests: frame/text pasting via a
  synthetic `paste` event dispatched at `document.activeElement`, which now resolves
  to the new input) passes on the `chromium` project.
- No change was made to the actual paste *logic* (frame insertion, mixed-Python
  parsing, media paste, undo/redo) — only to what receives DOM focus and how Safari's
  workaround is triggered — so existing paste-behaviour coverage should still apply
  as-is.

### Accessibility implications (why this is more than a Safari fix)

This change was deliberately chosen (over narrower alternatives — e.g. only taking
the manual `readText()` fallback when the clipboard is verifiably empty, or dropping
the pre-emptive Safari workaround altogether and accepting paste sometimes silently
not working there, reintroducing #652) because it also lays groundwork for making
frame cursors more legible to screen readers, which is a separate, ongoing goal for
Strype.

**Current state:** there is essentially no ARIA in this codebase today — the only
`aria-*` attributes anywhere are on a progress bar in `Commands.vue`. A screen reader
at a frame cursor currently hears nothing informative: no role, no label, no
indication it's even a cursor.

**Why this change is a natural foundation for that work:** Strype already uses a
"roving `tabindex="-1"` + explicit `.focus()`" pattern across frame headers, frame
bodies, and now this input — a single real DOM focus target tracking one logical
"current position" in app state. That's the standard skeleton ARIA authoring
practices recommend for tree/grid-like composite widgets; it was just missing the
ARIA vocabulary that turns it into something narratable. The new input is a natural
place to eventually carry an `aria-label`/`aria-roledescription` describing the
cursor's position (e.g. "Cursor before if-statement, line 4"), updated as the user
navigates, and/or an `aria-live` region for announcing moves, selection changes, and
paste/error results — none of which exist today.

**This PR deliberately does *not* do any of that** — no roles, no labels, no live
region — to keep scope to the paste fix. But it's worth flagging clearly because the
choice of *how* to fix #825 has accessibility consequences either way:

- Left as **plain, unlabelled input**: a screen reader landing on it today would
  likely announce something like "edit text, blank" — arguably *worse* than the
  current silence, since it looks like a genuine (and empty) text-entry field with no
  explanation. This regresses the (admittedly already poor) status quo until the
  follow-up labelling work lands.
- `contenteditable` was considered instead of `<input>` (matching how text slots
  already work) but rejected for this purpose: `contenteditable` accessibility support
  is notably inconsistent across AT/browser combinations (VoiceOver+Safari vs.
  NVDA+Chrome vs. JAWS all diverge), whereas a plain `<input>` behaves more
  predictably — even though on its own it's likely to be announced as a blank editable
  field for now.
- The input is visually hidden using Bootstrap's `.visually-hidden` (clip-based, not
  `display:none`/`aria-hidden`), which is the standard technique for staying in the
  accessibility tree and focusable while being invisible on screen — a new
  `position: relative` was added to the caret container's CSS so it's at least
  positioned near the visible caret, since some AT/magnifier combinations track focus
  by screen position, not just the accessibility tree.

**Follow-up work this opens up (not in this PR):**
- Label the focus input with the current cursor's context (frame type, position)
  and consider `aria-live` for navigation/paste/error announcements.
- Text slots (`LabelSlot.vue`) are real `contenteditable` already but carry no ARIA
  either — a screen reader user editing a slot currently has no indication of *what*
  that slot is (condition vs. target variable vs. argument N). Larger, separate piece
  of work.
- More fundamentally: block/frame-structured editors (Scratch, Blockly, etc.) have a
  history of struggling with standard tree/grid ARIA roles for this kind of custom-AST
  UI; some ship a parallel linear/textual editing mode for screen reader users instead
  of narrating the visual tree directly. Worth keeping in mind as the broader
  screen-reader initiative is scoped.

### Files changed

- `src/helpers/editor.ts` — new `getCaretContainerFocusInputUID()` helper.
- `src/components/CaretContainer.vue` — adds the invisible `<input>`, removes
  `keydownForSafariPaste`/`detectBrowser` usage, `pasteIfFocused` now takes a plain
  `ClipboardEvent` (the `overrideText` param is gone, it was only used by the deleted
  method) and calls `preventDefault()` up front.
- `src/store/store.ts`, `src/components/LabelSlotsStructure.vue` — the explicit
  `.focus()` calls that keep DOM focus in sync with app-state caret position now
  target the new input instead of the caret container `<div>`.
