### PR TITLE
Scope Apache caching config, mark Vite's hashed filenames, and fix a WebKit-only worker ReferenceError

### DIFF
--- a/APACHE_CONFIG.md
+++ b/APACHE_CONFIG.md
@@ -1,9 +1,10 @@
 # Apache caching config for strype.org
 
-This documents the `Cache-Control` policy the production Apache server
-(`strype.org/editor`) should apply. It's **not** applied via a `.htaccess`
-file in this repo — add it to the main server/vhost config instead. Requires
-`mod_headers`.
+This documents the `Cache-Control` policy the Apache server hosting
+`strype.org` (both `/editor/` and `/microbit/`, and their `/test/editor/`
+and `/test/microbit/` test-deployment counterparts) should apply. It's
+**not** applied via a `.htaccess` file in this repo — add it to the main
+server/vhost config instead. Requires `mod_headers`.
 
 ## Why
 
@@ -34,18 +35,19 @@ content-hashed build output is meant to be cached.
 
 ## What to change
 
-Scoped to `/editor/` and `/microbit/` specifically -- the two Strype
-platform builds actually deployed on this server -- rather than a
+Scoped to `/editor/` and `/microbit/` (and their `/test/editor/` and
+`/test/microbit/` counterparts on the test server) specifically -- the
+Strype platform builds actually deployed on this server -- rather than a
 server-wide rule, since the same Apache instance serves other things too
 that this policy has no business touching. Split by file type within that
 scope, rather than one blanket rule for everything under those paths:
 
 ```apache
-# Scoped to assets/ specifically, not just /(editor|microbit)/ generally --
-# that's Vite's default assetsDir, so every hashed JS/CSS chunk lives here
-# and (short of Vite's own static-copied Pyodide files -- see below) nothing
-# else does.
-<LocationMatch "^/(editor|microbit)/assets/">
+# Scoped to assets/ specifically, not just /(test/)?(editor|microbit)/
+# generally -- that's Vite's default assetsDir, so every hashed JS/CSS
+# chunk lives here and (short of Vite's own static-copied Pyodide files --
+# see below) nothing else does.
+<LocationMatch "^/(test/)?(editor|microbit)/assets/">
     # --- Vite's content-hashed build output: safe to cache forever ---
     # vite.config.mjs's build.rollupOptions.output inserts a literal
     # "-vuehashed-" marker before the hash in every hashed filename (e.g.
@@ -72,16 +74,17 @@ scope, rather than one blanket rule for everything under those paths:
 # referenced via indexURL in src/workers/python-execution.ts) is scoped by
 # Pyodide's own version, so a future upgrade lands at a brand new path
 # rather than overwriting this one in place -- nothing will ever change at
-# a URL a browser has already fetched. (Only /editor/ actually ships this
-# today -- micro:bit runs on-device, not via Pyodide -- but matching both
-# costs nothing and doesn't need updating if that ever changes.)
-<LocationMatch "^/(editor|microbit)/pyodide/[^/]+/">
+# a URL a browser has already fetched. (Only /editor/ and /test/editor/
+# actually ship this today -- micro:bit runs on-device, not via Pyodide --
+# but matching both costs nothing and doesn't need updating if that ever
+# changes.)
+<LocationMatch "^/(test/)?(editor|microbit)/pyodide/[^/]+/">
     Header set Cache-Control "public, max-age=31536000, immutable"
 </LocationMatch>
 ```
 
 Everything else — `index.html`, `compiled-service-worker.js`, any other
-unhashed file, and anything outside `/editor/` or `/microbit/` entirely —
+unhashed file, and anything outside `/(test/)?(editor|microbit)/` entirely —
 should keep the existing short/no-cache handling. That's deliberate, not
 an oversight: those are exactly the files that must always be fetched
 fresh, since they're what tell the browser which hashed filenames (and

--- a/APACHE_CONFIG.md
+++ b/APACHE_CONFIG.md
@@ -43,29 +43,26 @@ scope, rather than one blanket rule for everything under those paths:
 ```apache
 # Scoped to assets/ specifically, not just /(editor|microbit)/ generally --
 # that's Vite's default assetsDir, so every hashed JS/CSS chunk lives here
-# and (short of Vite's own static-copied Pyodide files, excluded below by
-# the FilesMatch not matching their unhashed names) nothing else does. This
-# matters because the FilesMatch pattern alone isn't a reliable hash test:
-# it's unanchored, so a perfectly ordinary hand-written filename like
-# my-javascript-codefile.js also matches ("-codefile" is a hyphen plus 8
-# alphanumeric characters, same shape as a real hash) -- tightening the
-# character class instead (e.g. requiring a digit) would just trade that
-# risk for false negatives on genuine hashes that happen to be all-letters.
-# Scoping to the one directory that's exclusively Vite's own output sidesteps
-# the ambiguity entirely, regardless of what any given filename looks like.
+# and (short of Vite's own static-copied Pyodide files -- see below) nothing
+# else does.
 <LocationMatch "^/(editor|microbit)/assets/">
     # --- Vite's content-hashed build output: safe to cache forever ---
-    # Vite names every hashed JS/CSS chunk "<name>-<hash>.<ext>" (e.g.
-    # index-QHEbX0xQ.js, python-execution-Dmw0KcAm.js) -- the hash changes
-    # whenever the content does, so the browser can keep a cached copy
-    # indefinitely without ever serving stale content.
-    #
-    # Deliberately does NOT match files without a hash suffix, e.g. the
-    # Pyodide files vite-plugin-static-copy copies into assets/ unmodified
-    # (see viteStaticCopyPyodide() in vite.config.mjs) -- their filenames
-    # never change even when their content does, so they must NOT get this
-    # treatment.
-    <FilesMatch "-[A-Za-z0-9_]{6,12}\.(js|css)$">
+    # vite.config.mjs's build.rollupOptions.output inserts a literal
+    # "-vuehashed-" marker before the hash in every hashed filename (e.g.
+    # index-vuehashed-QHEbX0xQ.js) specifically so this pattern can be exact
+    # rather than a guess at what a hash "looks like" -- matching purely on
+    # shape (a hyphen followed by alphanumeric characters) would also match
+    # an ordinary hand-written name like my-javascript-codefile.js
+    # ("-codefile" fits that shape too), and separately, vite-plugin-static-
+    # copy's raw Pyodide files land in this same assets/ directory unmodified
+    # (see viteStaticCopyPyodide() in vite.config.mjs) -- today none of their
+    # names happen to fit a hash-like shape either, but that's incidental,
+    # not guaranteed, and a future Pyodide release could easily ship one that
+    # does. Requiring this exact marker makes both false-positive risks
+    # structural instead of coincidental: only Vite's own hashing ever
+    # produces it, so nothing else ever will, regardless of what any given
+    # filename looks like:
+    <FilesMatch "-vuehashed-[A-Za-z0-9_]+\.(js|css)$">
         Header set Cache-Control "public, max-age=31536000, immutable"
     </FilesMatch>
 </LocationMatch>

--- a/APACHE_CONFIG.md
+++ b/APACHE_CONFIG.md
@@ -1,115 +1,56 @@
-# Apache caching config for strype.org
+# Apache config for strype.org
 
-This documents the `Cache-Control` policy the Apache server hosting
-`strype.org` (both `/editor/` and `/microbit/`, and their `/test/editor/`
-and `/test/microbit/` test-deployment counterparts) should apply. It's
-**not** applied via a `.htaccess` file in this repo — add it to the main
-server/vhost config instead. Requires `mod_headers`.
-
-## Why
-
-Investigating a report of the Run button getting permanently stuck on
-"Initialising..." (2026-08-07) traced back to: a tab left open across a
-deploy, whose already-loaded page still referenced a JS chunk by the
-content hash of the *previous* build. When Strype tried to spin up a new
-background Pyodide worker using that stale URL, the file no longer existed
-on the server (GitHub Pages' single-deployment scheme replaces the whole
-site on every deploy) — a permanent, unrecoverable 404 with no way for the
-client to fix it locally.
-
-Checking the live server (`curl -I`) at the time showed the deeper cause:
-**every** asset on `strype.org/editor`, including the content-hashed chunks
-that are supposed to be safe to cache forever, was being served with
-`Cache-Control: public, no-cache, max-age=0, must-revalidate`. That forces a
-revalidation round-trip on every fetch — for a page that's stayed open a
-while, that's a real chance of asking the server for a file whose hash has
-since rotated out from under it, and getting a 404 with nothing to fall
-back to. It's also just wasteful: the Pyodide runtime alone is tens of MB
-that gets revalidated (or fully re-fetched, depending on the client's own
-cache) on every load.
-
-The **goal** is that once a page has fully loaded, Strype should never need
-to talk to the server again during normal operation (loading a new data
-file or library is the one deliberate exception) — matching how
-content-hashed build output is meant to be cached.
-
-## What to change
-
-Scoped to `/editor/` and `/microbit/` (and their `/test/editor/` and
-`/test/microbit/` counterparts on the test server) specifically -- the
-Strype platform builds actually deployed on this server -- rather than a
-server-wide rule, since the same Apache instance serves other things too
-that this policy has no business touching. Split by file type within that
-scope, rather than one blanket rule for everything under those paths:
+Security headers and caching policy for the Apache server hosting
+`strype.org` — `/editor/` and `/microbit/` (the standard and micro:bit
+builds) plus their `/test/editor/` and `/test/microbit/` test-deployment
+counterparts. Not applied via `.htaccess` — add it to the main server/vhost
+config. Requires `mod_headers`.
 
 ```apache
-# Scoped to assets/ specifically, not just /(test/)?(editor|microbit)/
-# generally -- that's Vite's default assetsDir, so every hashed JS/CSS
-# chunk lives here and (short of Vite's own static-copied Pyodide files --
-# see below) nothing else does.
-<LocationMatch "^/(test/)?(editor|microbit)/assets/">
-    # --- Vite's content-hashed build output: safe to cache forever ---
-    # vite.config.mjs's build.rollupOptions.output inserts a literal
-    # "-vuehashed-" marker before the hash in every hashed filename (e.g.
-    # index-vuehashed-QHEbX0xQ.js) specifically so this pattern can be exact
-    # rather than a guess at what a hash "looks like" -- matching purely on
-    # shape (a hyphen followed by alphanumeric characters) would also match
-    # an ordinary hand-written name like my-javascript-codefile.js
-    # ("-codefile" fits that shape too), and separately, vite-plugin-static-
-    # copy's raw Pyodide files land in this same assets/ directory unmodified
-    # (see viteStaticCopyPyodide() in vite.config.mjs) -- today none of their
-    # names happen to fit a hash-like shape either, but that's incidental,
-    # not guaranteed, and a future Pyodide release could easily ship one that
-    # does. Requiring this exact marker makes both false-positive risks
-    # structural instead of coincidental: only Vite's own hashing ever
-    # produces it, so nothing else ever will, regardless of what any given
-    # filename looks like:
-    <FilesMatch "-vuehashed-[A-Za-z0-9_]+\.(js|css)$">
-        Header set Cache-Control "public, max-age=31536000, immutable"
-    </FilesMatch>
+# Security headers (site-wide):
+Header set Content-Security-Policy "frame-ancestors 'self'"
+Header set Access-Control-Allow-Origin "https://www.strype.org"
+Header set X-Content-Type-Options "nosniff"
+Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains;"
+
+# Default caching policy (site-wide): always revalidate. This is what lets a
+# browser discover a new release, so it must stay the default for anything
+# not explicitly overridden below. No explicit Last-Modified/ETag here --
+# Apache sets one automatically per file from its actual filesystem mtime,
+# which is self-maintaining and per-file accurate, unlike a manually-set
+# date that needs remembering on every release and is no more precise even
+# when someone does.
+Header always set Cache-Control "public, no-cache, max-age=0, must-revalidate"
+
+# Vite's content-hashed build output (JS/CSS chunks) is exempt from the
+# default above: the filename itself changes whenever the content does, so
+# these are safe to cache indefinitely -- nothing will ever change at a URL
+# a browser has already fetched. Scoped to assets/ (Vite's default output
+# directory) and matched on the "-vuehashed-" marker vite.config.mjs inserts
+# before every hash, so this can't accidentally match an unrelated file that
+# merely happens to look hash-shaped.
+<LocationMatch "^/(test/)?(editor|microbit)/assets/.*-vuehashed-[A-Za-z0-9_]+\.(js|css)$">
+    Header onsuccess unset Cache-Control
+    Header always set Cache-Control "public, max-age=31536000, immutable"
 </LocationMatch>
 
-# --- The Pyodide runtime: also safe to cache forever, once versioned ---
-# public/pyodide/<version>/ (built by scripts/download-pyodide-libs.cjs,
-# referenced via indexURL in src/workers/python-execution.ts) is scoped by
-# Pyodide's own version, so a future upgrade lands at a brand new path
-# rather than overwriting this one in place -- nothing will ever change at
-# a URL a browser has already fetched. (Only /editor/ and /test/editor/
-# actually ship this today -- micro:bit runs on-device, not via Pyodide --
-# but matching both costs nothing and doesn't need updating if that ever
-# changes.)
+# The Pyodide runtime is exempt the same way, once served from a
+# version-scoped path (see indexURL in src/workers/python-execution.ts,
+# and scripts/download-pyodide-libs.cjs which downloads it there) -- a
+# future Pyodide upgrade lands at a new path rather than overwriting this
+# one, so nothing here ever changes at a URL a browser has already fetched.
 <LocationMatch "^/(test/)?(editor|microbit)/pyodide/[^/]+/">
-    Header set Cache-Control "public, max-age=31536000, immutable"
+    Header onsuccess unset Cache-Control
+    Header always set Cache-Control "public, max-age=31536000, immutable"
 </LocationMatch>
 ```
 
-Everything else — `index.html`, `compiled-service-worker.js`, any other
-unhashed file, and anything outside `/(test/)?(editor|microbit)/` entirely —
-should keep the existing short/no-cache handling. That's deliberate, not
-an oversight: those are exactly the files that must always be fetched
-fresh, since they're what tell the browser which hashed filenames (and
-which Pyodide version) are current. Caching *those* long would defeat the
-whole point, leaving a browser with no way to ever discover a new build.
+`Header onsuccess unset` before `Header always set` in the two overrides is
+required, not optional: `mod_headers` keeps separate `onsuccess`/`always`
+header tables, and the site-wide default above uses `always`. Without the
+`unset`, the override and the default would both apply from different
+tables, and Cache-Control would come out duplicated instead of the
+more-specific rule winning.
 
-`<LocationMatch>` needs to live in the main server config (`<VirtualHost>`
-block or included file) — it isn't valid inside `.htaccess`.
-
-## What this does not fully solve
-
-Even with this in place, "never talk to the server again" is *very likely*
-rather than absolutely guaranteed: a browser can still evict a cached
-response under storage pressure (Safari in particular is aggressive about
-this), which would send that one request back to the network. A page that
-survives that would hit the same live-server assets (since nothing on the
-server has moved), so it would very likely just succeed — but it's not a
-hard guarantee the way a service-worker precache (Cache Storage, not the
-HTTP cache) would be. That's a bigger, separate piece of work (Workbox is
-already an unused dependency in `package.json`, left over from an earlier
-implementation, and would be the natural tool) that hasn't been done here.
-
-## Out of scope: the GitHub Pages test site
-
-`k-pet-group.github.io/Strype` (`build-pages-test-site.yml`) is capped at
-`max-age=600` on everything — a hard GitHub Pages platform limitation, since
-it doesn't support custom response headers at all. Not fixable from this
-repo; probably an acceptable tradeoff for a fast-moving CI preview site.
+Adjust the CORS origin for your own deployment; the path names match how
+Strype itself is deployed here and should be adjusted if yours differs.

--- a/APACHE_CONFIG.md
+++ b/APACHE_CONFIG.md
@@ -41,7 +41,19 @@ that this policy has no business touching. Split by file type within that
 scope, rather than one blanket rule for everything under those paths:
 
 ```apache
-<LocationMatch "^/(editor|microbit)/">
+# Scoped to assets/ specifically, not just /(editor|microbit)/ generally --
+# that's Vite's default assetsDir, so every hashed JS/CSS chunk lives here
+# and (short of Vite's own static-copied Pyodide files, excluded below by
+# the FilesMatch not matching their unhashed names) nothing else does. This
+# matters because the FilesMatch pattern alone isn't a reliable hash test:
+# it's unanchored, so a perfectly ordinary hand-written filename like
+# my-javascript-codefile.js also matches ("-codefile" is a hyphen plus 8
+# alphanumeric characters, same shape as a real hash) -- tightening the
+# character class instead (e.g. requiring a digit) would just trade that
+# risk for false negatives on genuine hashes that happen to be all-letters.
+# Scoping to the one directory that's exclusively Vite's own output sidesteps
+# the ambiguity entirely, regardless of what any given filename looks like.
+<LocationMatch "^/(editor|microbit)/assets/">
     # --- Vite's content-hashed build output: safe to cache forever ---
     # Vite names every hashed JS/CSS chunk "<name>-<hash>.<ext>" (e.g.
     # index-QHEbX0xQ.js, python-execution-Dmw0KcAm.js) -- the hash changes

--- a/src/workers/shared_helpers.ts
+++ b/src/workers/shared_helpers.ts
@@ -60,10 +60,17 @@ export async function isServiceWorkerChannelResponsive(channelBaseUrl: string, t
 
 // Logged (temporarily, see isServiceWorkerChannelResponsive() above) so we can see if the
 // controller is changing (e.g. being reclaimed after a termination) while the page is still
-// visible, which would confirm this isn't a backgrounding-related issue:
+// visible, which would confirm this isn't a backgrounding-related issue. This file is loadable
+// from inside a dedicated Worker (see isServiceWorkerChannelResponsive()'s own comment on that),
+// and unlike Chromium, WebKit does expose navigator.serviceWorker to Workers -- so `document`
+// must be guarded here the same way isServiceWorkerChannelResponsive() already guards it above,
+// or this throws a ReferenceError inside the worker the moment a controllerchange event fires
+// there (confirmed via a real CI failure on macOS/WebKit: tests/playwright/e2e/sound-wait-after-run.spec.ts,
+// https://github.com/k-pet-group/Strype/actions/runs/31181917214):
 if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
     navigator.serviceWorker.addEventListener("controllerchange", () => {
-        console.info(`[SW controllerchange ${new Date().toISOString()}] visibilityState=${document.visibilityState} hasFocus=${document.hasFocus()}`);
+        const hasDocument = typeof document !== "undefined";
+        console.info(`[SW controllerchange ${new Date().toISOString()}] visibilityState=${hasDocument ? document.visibilityState : "n/a"} hasFocus=${hasDocument ? document.hasFocus() : "n/a"}`);
     });
 }
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -176,6 +176,28 @@ export default defineConfig(({mode}) => {
             },
         },
 
+        // Inserts a literal, distinctive marker before the hash in every content-hashed output
+        // filename (default template is "assets/[name]-[hash].js" etc. -- this just adds
+        // "-vuehashed-" before "[hash]"). A production server can then reliably tell "this is a
+        // hash Vite generated" apart from "this filename happens to look hash-shaped" -- e.g.
+        // matching purely on shape (a hyphen followed by 6-12 alphanumeric characters) would also
+        // match an ordinary hand-written name like my-javascript-codefile.js ("-codefile" fits
+        // that shape too), and separately, vite-plugin-static-copy's raw Pyodide files land in
+        // this same assets/ directory unmodified (see viteStaticCopyPyodide() below) -- today
+        // none of their names happen to fit the shape either, but that's incidental, not
+        // guaranteed, and a future Pyodide release could easily ship one that does. Requiring
+        // this exact marker makes both false-positive risks structural instead of coincidental:
+        // only Vite's own hashing ever produces it, so nothing else ever will:
+        build: {
+            rollupOptions: {
+                output: {
+                    entryFileNames: "assets/[name]-vuehashed-[hash].js",
+                    chunkFileNames: "assets/[name]-vuehashed-[hash].js",
+                    assetFileNames: "assets/[name]-vuehashed-[hash][extname]",
+                },
+            },
+        },
+
         optimizeDeps: { exclude: ["pyodide"] },
 
         worker: { format: 'es' },


### PR DESCRIPTION
## Summary

Follow-up to #1039, now with a real bug fix included:

1. **`APACHE_CONFIG.md` rewrite**: single, self-contained Apache config merging the existing site-wide security/caching headers with immutable-caching overrides for Vite's hashed `assets/` output (matched on a literal `-vuehashed-` marker rather than filename shape) and the version-scoped Pyodide runtime, covering `/test/editor/` and `/test/microbit/` alongside production. Drops the previous config's manually-bumped `Last-Modified` header in favour of Apache's own automatic per-file one. Both overrides use `Header onsuccess unset` before `Header always set`, required because the site-wide default already uses `always` (`mod_headers` keeps separate tables; without this, Cache-Control would come out duplicated instead of the override winning).
2. **`vite.config.mjs`**: inserts a literal `-vuehashed-` marker into every Vite-hashed output filename, which the Apache config above matches on.
3. **`src/workers/shared_helpers.ts` fix**: a `controllerchange` listener referenced `document` unguarded, in a module that's loadable inside the Pyodide worker. Chromium doesn't expose `navigator.serviceWorker` to Workers at all, but WebKit does — so on WebKit, a `controllerchange` event firing inside the worker threw `ReferenceError: Can't find variable: document`. Confirmed via a real CI failure (`sound-wait-after-run.spec.ts`, run [31181917214](https://github.com/k-pet-group/Strype/actions/runs/31181917214)) that the worker error-listener logging added in #1039 surfaced — the bug itself predates that PR. Fixed by guarding it the same way `isServiceWorkerChannelResponsive()` already guards the identical case just above it in the same file.

## Test plan

- [x] `npm run type:check` / `npm run lint:check` pass
- [x] Verified the `-vuehashed-` naming template against an isolated throwaway Vite build
- [x] Fixed a real `apachectl configtest` failure caught during review (`<FilesMatch>` isn't valid inside `<LocationMatch>`)
- [ ] Watching this PR's own CI to confirm the `shared_helpers.ts` fix actually resolves the WebKit failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019L8UQzbsKS6F32MQ421RF8