### PR TITLE
Remember previously selected chapter in the book dialogue

### DIFF
--- a/src/components/OpenBookDlg.vue
+++ b/src/components/OpenBookDlg.vue
@@ -207,7 +207,7 @@ async function changeBookDialogCategory(index: number) {
 }
 
 function shown() {
-    changeBookDialogCategory(0);
+    changeBookDialogCategory(selectedChapterIndex.value);
 }
 
 function getSelectedProject(): ({ name: string, chapter: string, projectFile: Promise<string | undefined> } | undefined) {


### PR DESCRIPTION
## Summary
- The "Open Book Project" dialogue remembered the previously selected project (and scroll position) but not the previously selected chapter, because `shown()` unconditionally reset the chapter selection to index 0 on every open.
- Now reopens on the last-selected chapter (`selectedChapterIndex`), which was already tracked but not being read back on show.

Fixes #1038

## Test plan
- [ ] Open the book dialogue, select a chapter other than the first, close it, reopen it, and confirm the same chapter is still selected/highlighted.