### PR TITLE
Add regression test confirming except-clause error location fix (#341)

### DIFF
--- a/tests/playwright/e2e/check-error-locations.spec.ts
+++ b/tests/playwright/e2e/check-error-locations.spec.ts
@@ -79,6 +79,26 @@ except Exception:
         await expectHasVisibleErrorIcon(page.locator("span", {hasText: "This will cause an error:"}));
     });
 
+    test("Check error shows on except frame, not try frame, for invalid except clause", async ({page}) => {
+        // Regression test for https://github.com/k-pet-group/Strype/issues/341 :
+        // "except e:" (old Python 2 syntax) is invalid in Python 3, it raises a NameError
+        // for the undefined name "e" while evaluating the except clause itself. The error
+        // used to be (wrongly) shown on the frame inside the try body instead of on the
+        // except frame, and an uncaught "errorElement is undefined" JS exception could occur.
+        const pageErrors: string[] = [];
+        page.on("pageerror", (err) => pageErrors.push(err.message));
+        await enterCode(page, ["", "", `
+try:
+    raise ValueError
+except e:
+    print("Error!")
+`.trimStart()]);
+        await runToFinish(page);
+        expect(pageErrors).toEqual([]);
+        await checkConsoleContent(page, /.*NameError: name 'e' is not defined.*/);
+        await expectHasVisibleErrorIcon(page.locator("div.frame-header-label", {hasText: "except"}));
+    });
+
     test("Check error shows correctly when a funcdef with documentation follows a multiline comment", async ({page}) => {
         // astroids.spy is ~400KB, by far the largest fixture used in any Playwright test (most are a
         // few KB) -- parsing/rendering that much state is genuinely slower, not just contended, so this


### PR DESCRIPTION
## Summary
- Issue #341 reported that a `try: ... except e:` block (invalid Python 3 syntax, raises `NameError: name 'e' is not defined`) highlighted the error on the frame inside the `try` body instead of the `except` frame, plus an uncaught `TypeError: errorElement is undefined` JS exception during error navigation.
- Investigated the current line-to-frame error mapping (`Parser.framePositionMap` / `handleErrorTrace` in `src/helpers/execPythonCode.ts`), which is purely driven by the line number reported in the Python traceback.
- Since the runtime migrated from Skulpt to Pyodide, reproducing the original repro now correctly attributes the error to the `except` frame, with no uncaught JS exception — this looks like it was a Skulpt-specific line-attribution quirk (as suspected in the issue thread) that no longer applies under Pyodide/CPython.
- Rather than a fix, this PR adds a regression test (`tests/playwright/e2e/check-error-locations.spec.ts`) that reproduces the exact repro from the issue and asserts: no uncaught JS error, correct `NameError` console output, and the error icon showing on the `except` frame rather than the `try` frame.

Fixes #341

## Test plan
- [x] `SPEC=tests/playwright/e2e/check-error-locations.spec.ts npm run test:playwright` — new test passes on chromium and firefox (webkit unavailable in this local environment, unrelated to the change).