### PR TITLE
Colour picker: hex field in tile view, fix shade-tile selection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -105,9 +105,9 @@
             <MediaPreviewPopup ref="mediaPreviewPopup" />
             <EditImageDlg dlgId="editImageDlg" ref="editImageDlg" :imgToEdit="imgToEditInDialog" :showImgPreview="showImgPreview" :showReRecordButton="editImageDlgShowReRecord" />
             <EditSoundDlg dlgId="editSoundDlg" ref="editSoundDlg" :soundToEdit="soundToEditInDialog" :showReRecordButton="editSoundDlgShowReRecord" />
-            <RecordImageDlg dlgId="recordImageDlg" ref="recordImageDlg" :dlgTitle="$t('media.recordImageTitle')" />
-            <RecordSoundDlg dlgId="recordSoundDlg" ref="recordSoundDlg" :dlgTitle="$t('media.recordSoundTitle')" />
-            <ColourPickerDlg dlgId="colourPickerDlg" ref="colourPickerDlg" :dlgTitle="$t('media.colourPickerTitle')" :initialColour="colourPickerInitialColour" />
+            <RecordImageDlg ref="recordImageDlg" />
+            <RecordSoundDlg ref="recordSoundDlg" />
+            <ColourPickerDlg ref="colourPickerDlg" :initialColour="colourPickerInitialColour" />
             <canvas v-show="appStore.isDraggingFrame" :id="getCompanionDndCanvasId" class="companion-canvas-dnd"/>
             <ModalDlg :dlgId="confirmNewProjectModalDlgId" :okCustomTitle="$t('buttonLabel.continue')">
                 <span style="white-space:pre-wrap" v-html="$t('appMessage.newProjectConfirmation')"></span>

--- a/src/App.vue
+++ b/src/App.vue
@@ -107,6 +107,7 @@
             <EditSoundDlg dlgId="editSoundDlg" ref="editSoundDlg" :soundToEdit="soundToEditInDialog" :showReRecordButton="editSoundDlgShowReRecord" />
             <RecordImageDlg dlgId="recordImageDlg" ref="recordImageDlg" :dlgTitle="$t('media.recordImageTitle')" />
             <RecordSoundDlg dlgId="recordSoundDlg" ref="recordSoundDlg" :dlgTitle="$t('media.recordSoundTitle')" />
+            <ColourPickerDlg dlgId="colourPickerDlg" ref="colourPickerDlg" :dlgTitle="$t('media.colourPickerTitle')" :initialColour="colourPickerInitialColour" />
             <canvas v-show="appStore.isDraggingFrame" :id="getCompanionDndCanvasId" class="companion-canvas-dnd"/>
             <ModalDlg :dlgId="confirmNewProjectModalDlgId" :okCustomTitle="$t('buttonLabel.continue')">
                 <span style="white-space:pre-wrap" v-html="$t('appMessage.newProjectConfirmation')"></span>
@@ -130,7 +131,7 @@ import ModalDlg from "@/components/ModalDlg.vue";
 import SimpleMsgModalDlg from "@/components/SimpleMsgModalDlg.vue";
 import {Splitpanes, Pane} from "splitpanes";
 import { useStore, settingsStore, getEditorTabId } from "@/store/store";
-import { AppEvent, ProjectSaveFunction, BaseSlot, CaretPosition, FrameObject, FrozenState, MessageTypes, ModifierKeyCode, Position, PythonExecRunningState, SaveRequestReason, SlotCursorInfos, SlotsStructure, SlotType, StringSlot, StrypeSyncTarget, StrypePEALayoutMode, defaultEmptyStrypeLayoutDividerSettings, EditImageInDialogFunction, EditSoundInDialogFunction, RecordNewImageInDialogFunction, RecordNewSoundInDialogFunction, areSlotCoreInfosEqual, SlotCoreInfos, ProjectDocumentationDefinition, CollapsedState, LoadRequestReason, StateAppObject, MessageDefinitions, FormattedMessage, FormattedMessageArgKeyValuePlaceholders } from "@/types/types";
+import { AppEvent, ProjectSaveFunction, BaseSlot, CaretPosition, FrameObject, FrozenState, MessageTypes, ModifierKeyCode, Position, PythonExecRunningState, SaveRequestReason, SlotCursorInfos, SlotsStructure, SlotType, StringSlot, StrypeSyncTarget, StrypePEALayoutMode, defaultEmptyStrypeLayoutDividerSettings, EditImageInDialogFunction, EditSoundInDialogFunction, RecordNewImageInDialogFunction, RecordNewSoundInDialogFunction, OpenColourPickerInDialogFunction, areSlotCoreInfosEqual, SlotCoreInfos, ProjectDocumentationDefinition, CollapsedState, LoadRequestReason, StateAppObject, MessageDefinitions, FormattedMessage, FormattedMessageArgKeyValuePlaceholders } from "@/types/types";
 import { CloudDriveAPIState, isSyncTargetCloudDrive } from "@/types/cloud-drive-types";
 import { getFrameContainerUID, getMenuLeftPaneUID, getEditorMiddleUID, getCommandsRightPaneContainerId, isElementLabelSlotInput, CustomEventTypes, getFrameUID, parseLabelSlotUID, getLabelSlotUID, getFrameLabelSlotsStructureUID, getSelectionCursorsComparisonValue, setDocumentSelection, getSameLevelAncestorIndex, autoSaveFreqMins, getImportDiffVersionModalDlgId, getAppSimpleMsgDlgId, getActiveContextMenu, actOnGraphicsImport, setPythonExecutionAreaTabsContentMaxHeight, setManuallyResizedEditorHeightFlag, setPythonExecAreaLayoutButtonPos, getStrypeCommandComponentRefId, frameContextMenuShortcuts, getCompanionDndCanvasId, addDuplicateActionOnFramesDnD, removeDuplicateActionOnFramesDnD, sharedStrypeProjectTargetKey, sharedStrypeProjectIdKey, getCaretContainerUID, getEditorID, getLoadProjectLinkId, AutoSaveKeyNames, getFrameHeaderUID, closeRenameIdentifierPopups, newStrypeProject } from "./helpers/editor";
 import { AllFrameTypesIdentifier} from "@/types/types";
@@ -149,6 +150,7 @@ import EditImageDlg from "@/components/EditImageDlg.vue";
 import EditSoundDlg from "@/components/EditSoundDlg.vue";
 import RecordImageDlg from "@/components/RecordImageDlg.vue";
 import RecordSoundDlg from "@/components/RecordSoundDlg.vue";
+import ColourPickerDlg from "@/components/ColourPickerDlg.vue";
 import axios from "axios";
 import scssVars from "@/assets/style/_export.module.scss";
 import {loadDivider} from "@/helpers/load-save";
@@ -203,6 +205,7 @@ export default defineComponent({
         EditSoundDlg,
         RecordImageDlg,
         RecordSoundDlg,
+        ColourPickerDlg,
         MediaPreviewPopup,
         Menu,
         ModalDlg,
@@ -231,6 +234,7 @@ export default defineComponent({
             // already in progress, which would otherwise register a second competing
             // strypeModalHidden listener chain:
             isRecordingMediaFlowActive: false,
+            colourPickerInitialColour: null as string | null,
         };
     },
 
@@ -1971,9 +1975,42 @@ export default defineComponent({
 
             eventBus.emit(CustomEventTypes.showStrypeModal, "recordSoundDlg");
         },
+        // Public entry point for the colour picker (Ctrl-Shift-L). callback is only called if the
+        // user confirms with "OK"; onCancelled is called instead if the user cancels. Guarded by
+        // appStore.isModalDlgShown (checked by the caller in LabelSlot.vue) rather than a dedicated
+        // flag, since -- unlike the record-then-edit media flows above -- this is a single dialog
+        // with no follow-on modal to chain into.
+        openColourPickerInDialog(initialColour: string | null, callback: (hex: string) => void, onCancelled: () => void) {
+            const colourPickerDlgComponentAPI = vueComponentsAPIHandler.colourPickerDlgComponentAPI;
+            this.colourPickerInitialColour = initialColour;
+
+            const picked = (event: BvTriggerableEvent) => {
+                if (event.componentId != "colourPickerDlg") {
+                    return;
+                }
+                eventBus.off(CustomEventTypes.strypeModalHidden, picked);
+                this.colourPickerInitialColour = null;
+
+                if (event.trigger == "ok") {
+                    const hex = colourPickerDlgComponentAPI?.getHexValue();
+                    if (hex) {
+                        callback(hex);
+                    }
+                    else {
+                        onCancelled();
+                    }
+                }
+                else {
+                    onCancelled();
+                }
+            };
+            eventBus.on(CustomEventTypes.strypeModalHidden, picked);
+
+            eventBus.emit(CustomEventTypes.showStrypeModal, "colourPickerDlg");
+        },
     },
 
-    provide() : { peaComponent: any, editImageInDialog : EditImageInDialogFunction, editSoundInDialog : EditSoundInDialogFunction, recordNewImageInDialog : RecordNewImageInDialogFunction, recordNewSoundInDialog : RecordNewSoundInDialogFunction} {
+    provide() : { peaComponent: any, editImageInDialog : EditImageInDialogFunction, editSoundInDialog : EditSoundInDialogFunction, recordNewImageInDialog : RecordNewImageInDialogFunction, recordNewSoundInDialog : RecordNewSoundInDialogFunction, openColourPickerInDialog : OpenColourPickerInDialogFunction} {
         return {
             peaComponent: this.getPeaComponent,
             // Note, this provides the function:
@@ -1981,6 +2018,7 @@ export default defineComponent({
             editSoundInDialog: this.editSoundInDialog,
             recordNewImageInDialog: this.recordNewImageInDialog,
             recordNewSoundInDialog: this.recordNewSoundInDialog,
+            openColourPickerInDialog: this.openColourPickerInDialog,
         };
     },
 });

--- a/src/components/ColourPickerDlg.vue
+++ b/src/components/ColourPickerDlg.vue
@@ -102,7 +102,13 @@ import { defineComponent, nextTick, PropType } from "vue";
 import ModalDlg from "@/components/ModalDlg.vue";
 import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
 import { eventBus } from "@/helpers/appContext";
-import { CustomEventTypes, getPEAGraphicsContainerDivId } from "@/helpers/editor";
+import { CustomEventTypes } from "@/helpers/editor";
+// #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
+// getPEAGraphicsContainerDivId() only exists in standard mode -- micro:bit mode has no "Graphics"
+// PEA tab/canvas for the live colour preview to dim a hole over (see punchBackdropHoleOverGraphics
+// below), so this whole live-preview mechanism is standard-mode-only.
+import { getPEAGraphicsContainerDivId } from "@/helpers/editor";
+// #v-endif
 import { BvTriggerableEvent } from "bootstrap-vue-next";
 import {
     parseColourToHex, hexToHsv, hsvToHex, hexToHsl, hslToHex,
@@ -520,6 +526,7 @@ export default defineComponent({
         // the net result is a plain rectangle with a rectangular hole, without needing an evenodd
         // fill rule (which the plain CSS polygon() function doesn't support).
         punchBackdropHoleOverGraphics() {
+            // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
             const backdrop = document.querySelector(".modal-backdrop") as HTMLElement | null;
             const graphicsEl = document.getElementById(getPEAGraphicsContainerDivId());
             if (!backdrop || !graphicsEl) {
@@ -535,6 +542,7 @@ export default defineComponent({
                 `${rect.left}px ${rect.top}px`, `0px ${rect.top}px`,
             ].join(", ");
             backdrop.style.clipPath = `polygon(${points})`;
+            // #v-endif
         },
 
         clearGraphicsColourPreview() {

--- a/src/components/ColourPickerDlg.vue
+++ b/src/components/ColourPickerDlg.vue
@@ -1,5 +1,5 @@
 <template>
-    <ModalDlg :dlgId="dlgId" :dlgTitle="dlgTitle" :okDisabled="okDisabled">
+    <ModalDlg dlgId="colourPickerDlg" :dlgTitle="$t('media.colourPickerTitle')" :okDisabled="okDisabled">
         <div class="ColourPickerDlg-content">
             <div class="ColourPickerDlg-view-area">
                 <div v-if="view === 'grid'" class="ColourPickerDlg-family-grid">
@@ -120,16 +120,24 @@ import {
 
 const DEFAULT_HEX = "#ff0000";
 
+// Only ever one instance of this dialog (see App.vue), so its id is fixed rather than a prop.
+const DLG_ID = "colourPickerDlg";
+
 function clamp(x: number, lo: number, hi: number): number {
     return Math.min(hi, Math.max(lo, x));
 }
 
+// Squared Euclidean ("Pythagoras") distance between two hex colours in RGB space, for finding the
+// closest of a set of candidate swatches to a target colour.
 function hexColourDistance(a: string, b: string): number {
     const ar = parseInt(a.substring(1, 3), 16), ag = parseInt(a.substring(3, 5), 16), ab = parseInt(a.substring(5, 7), 16);
     const br = parseInt(b.substring(1, 3), 16), bg = parseInt(b.substring(3, 5), 16), bb = parseInt(b.substring(5, 7), 16);
     return (ar - br) ** 2 + (ag - bg) ** 2 + (ab - bb) ** 2;
 }
 
+// A single tile in the shade grid. No hue field: the grid always shows shades of whichever hue is
+// currently selected (or of the family's fixed hue for hue-less families like grey), so hue lives
+// on the component's own state rather than per-cell.
 interface ShadeCell {
     sat: number;
     light: number;
@@ -145,8 +153,6 @@ export default defineComponent({
     },
 
     props: {
-        dlgId: String,
-        dlgTitle: String,
         // A hex code or recognised CSS colour name to seed the picker with; null/unparseable
         // falls back to a default colour.
         initialColour: {type: String as PropType<string | null>, default: null},
@@ -154,7 +160,10 @@ export default defineComponent({
 
     data: function () {
         return {
+            // "grid" is the family-swatch overview; "tinker" is the hue/shade tile picker for a
+            // chosen family; "classic" is the free-form HSV square-and-slider fine-grained selector.
             view: "grid" as "grid" | "tinker" | "classic",
+            // The family currently open in the tinker view, or null while on the grid.
             currentFamilyKey: null as string | null,
             // The "current colour" while browsing the family grid/shade grid, as HSL:
             hue: 0,
@@ -205,6 +214,7 @@ export default defineComponent({
             return this.currentFamily != null && familyHasHueChoice(this.currentFamily);
         },
 
+        // The row of selectable hue swatches shown above the shade grid for families with a hue choice.
         hueChips(): {hue: number, hex: string, selected: boolean}[] {
             if (!this.currentFamily || !this.hasHue) {
                 return [];
@@ -220,6 +230,11 @@ export default defineComponent({
             return chips;
         },
 
+        // The grid of shade tiles for the current family, at the currently selected hue: rows spaced
+        // evenly across the family's lightness range, columns across its saturation range (with a
+        // fixed number of columns per row, from SHADE_ROW_SAT_COUNTS -- fewer near the light/dark
+        // ends, where saturation differences are barely visible). Hue-less families (grey) instead
+        // use fixed-hue/zero-saturation bands spaced across their lightness range.
         shadeRows(): ShadeCell[][] {
             if (!this.currentFamily) {
                 return [];
@@ -255,6 +270,14 @@ export default defineComponent({
             }
         },
 
+        // The tile views (grid/tinker) use HSL because the family/hue/shade data (COLOUR_FAMILIES,
+        // GOOD_CHIP_SAT/LIGHT etc.) is authored as hue/saturation/lightness ranges, which is the
+        // natural way to describe families like "pale pastels" or "dark shades" as fixed bands.
+        // The fine-grained selector uses HSV instead because its square-plus-hue-slider widget is
+        // the standard colour-picker UI, and that widget is inherently a saturation/value square
+        // (S on one axis, V on the other) rather than an HSL shape -- so the two views are kept on
+        // their own natural models and converted at the boundary (see toggleFineGrained) rather
+        // than forcing one view's data to fit the other's model.
         currentHex(): string {
             return this.view == "classic"
                 ? hsvToHex(this.classicHue, this.classicSat, this.classicVal)
@@ -348,7 +371,7 @@ export default defineComponent({
         // which is already reactive to the assignments just below, so no need to wait a tick.
         selectShadeCellAndConfirm(sat: number, light: number) {
             this.selectShadeCell(sat, light);
-            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "ok", componentId: this.dlgId});
+            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "ok", componentId: DLG_ID});
         },
 
         toggleFineGrained() {
@@ -388,16 +411,11 @@ export default defineComponent({
             this.hexText = hsvToHex(this.classicHue, this.classicSat, this.classicVal);
         },
 
-        // Called on user input into the always-visible hex text field. Mirrors the logic used when
-        // the dialog is first opened with an existing colour (see onShownModalDlg below): if the
-        // typed colour lands exactly on a tile swatch, jump to that tile selected in the tinker
-        // view; otherwise fall through to the fine-grained selector with the colour in place.
-        onHexTextEdited() {
-            const hex = parseColourToHex(this.hexText);
-            if (!hex) {
-                return;
-            }
-            this.hasSelectedColour = true;
+        // If the given colour lands exactly on a tile swatch, jump to that tile selected in the
+        // tinker view; otherwise fall through to the fine-grained selector with the colour in
+        // place. Used both for user edits to the hex text field and, in onShownModalDlg below,
+        // when the dialog is first opened with an existing colour.
+        applyHexColour(hex: string) {
             const match = this.findExactSwatchMatch(hex);
             if (match) {
                 this.currentFamilyKey = match.family.key;
@@ -414,6 +432,16 @@ export default defineComponent({
                 this.currentFamilyKey = null;
                 this.view = "classic";
             }
+        },
+
+        // Called on user input into the always-visible hex text field.
+        onHexTextEdited() {
+            const hex = parseColourToHex(this.hexText);
+            if (!hex) {
+                return;
+            }
+            this.hasSelectedColour = true;
+            this.applyHexColour(hex);
         },
 
         onSvPointerDown(event: PointerEvent) {
@@ -476,7 +504,7 @@ export default defineComponent({
         },
 
         onShownModalDlg(event: BvTriggerableEvent) {
-            if (event.componentId != this.dlgId) {
+            if (event.componentId != DLG_ID) {
                 return;
             }
             // initialColour is only ever passed (non-null) when we're editing an existing string's
@@ -489,24 +517,18 @@ export default defineComponent({
                 // If it lands exactly on a swatch, start there with it selected; otherwise (including
                 // when the existing content wasn't a valid colour at all) there's no sensible swatch
                 // to preselect, so go straight to the fine-grained selector with the colour in place.
-                const match = parsedInitial ? this.findExactSwatchMatch(parsedInitial) : null;
-                if (match) {
-                    this.currentFamilyKey = match.family.key;
-                    this.hue = match.hue;
-                    this.sat = match.sat;
-                    this.light = match.light;
-                    this.view = "tinker";
-                    this.hexText = seededHex;
+                if (parsedInitial) {
+                    this.applyHexColour(parsedInitial);
                 }
                 else {
                     const {h, s, v} = hexToHsv(seededHex);
                     this.classicHue = h;
                     this.classicSat = s;
                     this.classicVal = v;
-                    this.hexText = seededHex;
                     this.currentFamilyKey = null;
                     this.view = "classic";
                 }
+                this.hexText = seededHex;
                 this.isShown = true;
                 this.hasSelectedColour = true;
                 this.showGraphicsColourPreview(seededHex);
@@ -529,7 +551,7 @@ export default defineComponent({
         },
 
         onHiddenModalDlg(event: BvTriggerableEvent) {
-            if (event.componentId != this.dlgId) {
+            if (event.componentId != DLG_ID) {
                 return;
             }
             this.isShown = false;

--- a/src/components/ColourPickerDlg.vue
+++ b/src/components/ColourPickerDlg.vue
@@ -61,18 +61,20 @@
                     <div ref="svSquare" class="ColourPickerDlg-sv-square" :style="svSquareStyle" @pointerdown="onSvPointerDown">
                         <div class="ColourPickerDlg-sv-cursor" :style="{left: classicSat + '%', top: (100 - classicVal) + '%'}"></div>
                     </div>
-                    <div class="ColourPickerDlg-hex-row">
-                        <span class="ColourPickerDlg-swatch" :style="{background: currentHex}"></span>
-                        <input
-                            id="ColourPickerDlg-hex-input"
-                            type="text"
-                            class="ColourPickerDlg-hex-input"
-                            :class="{'ColourPickerDlg-hex-input-invalid': !isClassicHexValid}"
-                            v-model="hexText"
-                            spellcheck="false"
-                        />
-                    </div>
                 </div>
+            </div>
+
+            <div class="ColourPickerDlg-hex-row">
+                <span class="ColourPickerDlg-swatch" :style="{background: currentHex}"></span>
+                <input
+                    id="ColourPickerDlg-hex-input"
+                    type="text"
+                    class="ColourPickerDlg-hex-input"
+                    :class="{'ColourPickerDlg-hex-input-invalid': !isClassicHexValid}"
+                    v-model="hexText"
+                    spellcheck="false"
+                    @input="onHexTextEdited"
+                />
             </div>
 
             <div class="ColourPickerDlg-bottom-row" :class="{'ColourPickerDlg-bottom-row-split': view === 'tinker'}">
@@ -122,6 +124,12 @@ function clamp(x: number, lo: number, hi: number): number {
     return Math.min(hi, Math.max(lo, x));
 }
 
+function hexColourDistance(a: string, b: string): number {
+    const ar = parseInt(a.substring(1, 3), 16), ag = parseInt(a.substring(3, 5), 16), ab = parseInt(a.substring(5, 7), 16);
+    const br = parseInt(b.substring(1, 3), 16), bg = parseInt(b.substring(3, 5), 16), bb = parseInt(b.substring(5, 7), 16);
+    return (ar - br) ** 2 + (ag - bg) ** 2 + (ab - bb) ** 2;
+}
+
 interface ShadeCell {
     sat: number;
     light: number;
@@ -157,11 +165,6 @@ export default defineComponent({
             classicSat: 100,
             classicVal: 100,
             hexText: DEFAULT_HEX,
-            // Set just before we overwrite hexText ourselves (from the SV square / hue slider), so
-            // the hexText watcher below knows not to re-derive classic HSV from its own output --
-            // that round trip is lossy enough (due to hue wrap-around and rounding) to make the
-            // square's cursor visibly jitter while dragging.
-            settingHexFromPicker: false,
             // Whether the dialog is currently visible; gates the graphics-area colour preview so we
             // don't try to touch it while the dialog (and hence this component's reactive state) is
             // just sitting there unshown.
@@ -263,7 +266,7 @@ export default defineComponent({
         },
 
         okDisabled(): boolean {
-            return this.view == "classic" && !this.isClassicHexValid;
+            return !this.isClassicHexValid;
         },
 
         svSquareStyle(): Record<string, string> {
@@ -272,21 +275,6 @@ export default defineComponent({
     },
 
     watch: {
-        hexText() {
-            if (this.settingHexFromPicker) {
-                this.settingHexFromPicker = false;
-                return;
-            }
-            const hex = parseColourToHex(this.hexText);
-            if (hex) {
-                this.hasSelectedColour = true;
-                const {h, s, v} = hexToHsv(hex);
-                this.classicHue = h;
-                this.classicSat = s;
-                this.classicVal = v;
-            }
-        },
-
         currentHex(newHex: string) {
             if (this.isShown && this.hasSelectedColour) {
                 this.showGraphicsColourPreview(newHex);
@@ -312,9 +300,30 @@ export default defineComponent({
             this.hasSelectedColour = true;
             this.currentFamilyKey = family.key;
             this.hue = midOfRange(family.hue);
-            this.sat = midOfRange(family.sat);
-            this.light = midOfRange(family.light);
+            // The shade grid's rows/columns sit at fixed fractions of the family's sat/light ranges
+            // (see SHADE_ROW_SAT_COUNTS), so there's no single "middle" cell -- pick whichever real
+            // cell renders closest (in RGB terms) to whatever's shown at the top of the tinker view
+            // the user's just landed on: the selected hue chip when the family has one (which uses
+            // GOOD_CHIP_SAT/LIGHT, not the family's own sat/light range), or the family's grid swatch
+            // for hue-less families like grey (which have no chip strip to compare against).
+            const targetHex = familyHasHueChoice(family)
+                ? hslToHex(this.hue, family.chipSat ?? GOOD_CHIP_SAT, family.chipLight ?? GOOD_CHIP_LIGHT)
+                : this.familySwatchHex(family);
+            let nearest: ShadeCell | null = null;
+            let nearestDist = Infinity;
+            for (const row of this.shadeRows) {
+                for (const cell of row) {
+                    const dist = hexColourDistance(cell.hex, targetHex);
+                    if (dist < nearestDist) {
+                        nearestDist = dist;
+                        nearest = cell;
+                    }
+                }
+            }
+            this.sat = nearest ? nearest.sat : midOfRange(family.sat);
+            this.light = nearest ? nearest.light : midOfRange(family.light);
             this.view = "tinker";
+            this.hexText = this.currentHex;
         },
 
         backToGrid() {
@@ -324,12 +333,14 @@ export default defineComponent({
         selectHueChip(hue: number) {
             this.hasSelectedColour = true;
             this.hue = hue;
+            this.hexText = this.currentHex;
         },
 
         selectShadeCell(sat: number, light: number) {
             this.hasSelectedColour = true;
             this.sat = sat;
             this.light = light;
+            this.hexText = this.currentHex;
         },
 
         // Double-clicking a shade tile picks it and immediately confirms the dialog, same as
@@ -359,6 +370,7 @@ export default defineComponent({
                     this.light = l;
                     this.view = "grid";
                 }
+                this.hexText = this.currentHex;
             }
             else {
                 // Entering the fine-grained selector: seed its HSV state from whatever's currently picked.
@@ -373,8 +385,35 @@ export default defineComponent({
 
         updateHexFromClassic() {
             this.hasSelectedColour = true;
-            this.settingHexFromPicker = true;
             this.hexText = hsvToHex(this.classicHue, this.classicSat, this.classicVal);
+        },
+
+        // Called on user input into the always-visible hex text field. Mirrors the logic used when
+        // the dialog is first opened with an existing colour (see onShownModalDlg below): if the
+        // typed colour lands exactly on a tile swatch, jump to that tile selected in the tinker
+        // view; otherwise fall through to the fine-grained selector with the colour in place.
+        onHexTextEdited() {
+            const hex = parseColourToHex(this.hexText);
+            if (!hex) {
+                return;
+            }
+            this.hasSelectedColour = true;
+            const match = this.findExactSwatchMatch(hex);
+            if (match) {
+                this.currentFamilyKey = match.family.key;
+                this.hue = match.hue;
+                this.sat = match.sat;
+                this.light = match.light;
+                this.view = "tinker";
+            }
+            else {
+                const {h, s, v} = hexToHsv(hex);
+                this.classicHue = h;
+                this.classicSat = s;
+                this.classicVal = v;
+                this.currentFamilyKey = null;
+                this.view = "classic";
+            }
         },
 
         onSvPointerDown(event: PointerEvent) {
@@ -457,6 +496,7 @@ export default defineComponent({
                     this.sat = match.sat;
                     this.light = match.light;
                     this.view = "tinker";
+                    this.hexText = seededHex;
                 }
                 else {
                     const {h, s, v} = hexToHsv(seededHex);
@@ -484,6 +524,7 @@ export default defineComponent({
             this.sat = s;
             this.light = l;
             this.view = "grid";
+            this.hexText = DEFAULT_HEX;
             this.isShown = true;
         },
 

--- a/src/components/ColourPickerDlg.vue
+++ b/src/components/ColourPickerDlg.vue
@@ -1,0 +1,771 @@
+<template>
+    <ModalDlg :dlgId="dlgId" :dlgTitle="dlgTitle" :okDisabled="okDisabled">
+        <div class="ColourPickerDlg-content">
+            <div class="ColourPickerDlg-view-area">
+                <div v-if="view === 'grid'" class="ColourPickerDlg-family-grid">
+                    <button
+                        v-for="family in families"
+                        :key="family.key"
+                        type="button"
+                        class="ColourPickerDlg-family-btn"
+                        @click="selectFamily(family)"
+                    >
+                        <span class="ColourPickerDlg-family-swatch" :style="{background: familySwatchHex(family)}"></span>
+                        <span class="ColourPickerDlg-family-name">{{ $t(family.nameKey) }}</span>
+                    </button>
+                </div>
+
+                <div v-else-if="view === 'tinker' && currentFamily">
+                    <div v-if="hasHue">
+                        <p class="ColourPickerDlg-section-label">{{ $t("colourPicker.hue") }}</p>
+                        <div class="ColourPickerDlg-hue-strip">
+                            <button
+                                v-for="chip in hueChips"
+                                :key="chip.hue"
+                                type="button"
+                                class="ColourPickerDlg-chip"
+                                :class="{'ColourPickerDlg-chip-selected': chip.selected}"
+                                :style="{background: chip.hex}"
+                                @click="selectHueChip(chip.hue)"
+                            ></button>
+                        </div>
+                    </div>
+
+                    <p class="ColourPickerDlg-section-label">{{ $t("colourPicker.shade") }}</p>
+                    <div class="ColourPickerDlg-shade-grid">
+                        <div v-for="(row, rowIndex) in shadeRows" :key="rowIndex" class="ColourPickerDlg-shade-row">
+                            <button
+                                v-for="cell in row"
+                                :key="cell.sat + '-' + cell.light"
+                                type="button"
+                                class="ColourPickerDlg-shade-cell"
+                                :class="{'ColourPickerDlg-shade-cell-selected': cell.selected}"
+                                :style="{background: cell.hex}"
+                                @click="selectShadeCell(cell.sat, cell.light)"
+                                @dblclick="selectShadeCellAndConfirm(cell.sat, cell.light)"
+                            ></button>
+                        </div>
+                    </div>
+                </div>
+
+                <div v-else-if="view === 'classic'" class="ColourPickerDlg-classic">
+                    <p class="ColourPickerDlg-section-label">{{ $t("colourPicker.fineGrainedSelector") }}</p>
+                    <input
+                        type="range"
+                        class="ColourPickerDlg-hue-slider"
+                        min="0"
+                        max="359"
+                        v-model.number="classicHue"
+                        @input="updateHexFromClassic"
+                    />
+                    <div ref="svSquare" class="ColourPickerDlg-sv-square" :style="svSquareStyle" @pointerdown="onSvPointerDown">
+                        <div class="ColourPickerDlg-sv-cursor" :style="{left: classicSat + '%', top: (100 - classicVal) + '%'}"></div>
+                    </div>
+                    <div class="ColourPickerDlg-hex-row">
+                        <span class="ColourPickerDlg-swatch" :style="{background: currentHex}"></span>
+                        <input
+                            id="ColourPickerDlg-hex-input"
+                            type="text"
+                            class="ColourPickerDlg-hex-input"
+                            :class="{'ColourPickerDlg-hex-input-invalid': !isClassicHexValid}"
+                            v-model="hexText"
+                            spellcheck="false"
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div class="ColourPickerDlg-bottom-row" :class="{'ColourPickerDlg-bottom-row-split': view === 'tinker'}">
+                <button
+                    v-if="view === 'tinker'"
+                    type="button"
+                    class="btn EditSoundImageDlg-info-btn ColourPickerDlg-bottom-btn"
+                    @click="backToGrid"
+                >
+                    &#8249; {{ $t("colourPicker.allColours") }}
+                </button>
+                <button
+                    type="button"
+                    class="btn EditSoundImageDlg-info-btn ColourPickerDlg-bottom-btn"
+                    :class="{'ColourPickerDlg-bottom-btn-right': view === 'grid', 'ColourPickerDlg-bottom-btn-half': view === 'classic'}"
+                    @click="toggleFineGrained"
+                >
+                    {{ view === "classic" ? $t("colourPicker.tiles") : $t("colourPicker.fineGrainedSelector") }}
+                </button>
+            </div>
+        </div>
+    </ModalDlg>
+</template>
+
+<script lang="ts">
+import { defineComponent, nextTick, PropType } from "vue";
+import ModalDlg from "@/components/ModalDlg.vue";
+import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
+import { eventBus } from "@/helpers/appContext";
+import { CustomEventTypes, getPEAGraphicsContainerDivId } from "@/helpers/editor";
+import { BvTriggerableEvent } from "bootstrap-vue-next";
+import {
+    parseColourToHex, hexToHsv, hsvToHex, hexToHsl, hslToHex,
+    ColourFamily, COLOUR_FAMILIES, HUE_CHIP_COUNT, GOOD_CHIP_SAT, GOOD_CHIP_LIGHT,
+    SHADE_ROW_SAT_COUNTS, GREY_SHADE_BANDS, familyHasHueChoice, midOfRange,
+} from "@/helpers/colour";
+
+const DEFAULT_HEX = "#ff0000";
+
+function clamp(x: number, lo: number, hi: number): number {
+    return Math.min(hi, Math.max(lo, x));
+}
+
+interface ShadeCell {
+    sat: number;
+    light: number;
+    hex: string;
+    selected: boolean;
+}
+
+export default defineComponent({
+    name: "ColourPickerDlg",
+
+    components: {
+        ModalDlg,
+    },
+
+    props: {
+        dlgId: String,
+        dlgTitle: String,
+        // A hex code or recognised CSS colour name to seed the picker with; null/unparseable
+        // falls back to a default colour.
+        initialColour: {type: String as PropType<string | null>, default: null},
+    },
+
+    data: function () {
+        return {
+            view: "grid" as "grid" | "tinker" | "classic",
+            currentFamilyKey: null as string | null,
+            // The "current colour" while browsing the family grid/shade grid, as HSL:
+            hue: 0,
+            sat: 0,
+            light: 0,
+            // The fine-grained selector's own state, as HSV, plus its hex text field:
+            classicHue: 0,
+            classicSat: 100,
+            classicVal: 100,
+            hexText: DEFAULT_HEX,
+            // Set just before we overwrite hexText ourselves (from the SV square / hue slider), so
+            // the hexText watcher below knows not to re-derive classic HSV from its own output --
+            // that round trip is lossy enough (due to hue wrap-around and rounding) to make the
+            // square's cursor visibly jitter while dragging.
+            settingHexFromPicker: false,
+            // Whether the dialog is currently visible; gates the graphics-area colour preview so we
+            // don't try to touch it while the dialog (and hence this component's reactive state) is
+            // just sitting there unshown.
+            isShown: false,
+            // Whether the user has actually picked a colour yet this time the dialog is open --
+            // gates the graphics-area preview so a fresh "insert a new colour" doesn't flood-fill
+            // with a colour the user hasn't chosen (the family grid's own default HSL/HSV starting
+            // state shouldn't count). Always true when editing an existing string, since there's
+            // already a real colour to preview there.
+            hasSelectedColour: false,
+        };
+    },
+
+    created() {
+        vueComponentsAPIHandler.colourPickerDlgComponentAPI = {
+            getHexValue: () => (this.view !== "classic" || this.isClassicHexValid) ? this.currentHex : null,
+        };
+
+        eventBus.on(CustomEventTypes.strypeModalShown, this.onShownModalDlg);
+        eventBus.on(CustomEventTypes.strypeModalHidden, this.onHiddenModalDlg);
+    },
+
+    beforeUnmount() {
+        eventBus.off(CustomEventTypes.strypeModalShown, this.onShownModalDlg);
+        eventBus.off(CustomEventTypes.strypeModalHidden, this.onHiddenModalDlg);
+    },
+
+    computed: {
+        families(): ColourFamily[] {
+            return COLOUR_FAMILIES;
+        },
+
+        currentFamily(): ColourFamily | null {
+            return this.families.find((f) => f.key == this.currentFamilyKey) ?? null;
+        },
+
+        hasHue(): boolean {
+            return this.currentFamily != null && familyHasHueChoice(this.currentFamily);
+        },
+
+        hueChips(): {hue: number, hex: string, selected: boolean}[] {
+            if (!this.currentFamily || !this.hasHue) {
+                return [];
+            }
+            const family = this.currentFamily;
+            const chipSat = family.chipSat ?? GOOD_CHIP_SAT;
+            const chipLight = family.chipLight ?? GOOD_CHIP_LIGHT;
+            const chips = [];
+            for (let i = 0; i < HUE_CHIP_COUNT; i++) {
+                const h = family.hue[0] + (family.hue[1] - family.hue[0]) * (i / (HUE_CHIP_COUNT - 1));
+                chips.push({hue: h, hex: hslToHex(h, chipSat, chipLight), selected: Math.abs(h - this.hue) < 0.01});
+            }
+            return chips;
+        },
+
+        shadeRows(): ShadeCell[][] {
+            if (!this.currentFamily) {
+                return [];
+            }
+            const family = this.currentFamily;
+            if (this.hasHue) {
+                const [s0, s1] = family.sat;
+                const [l0, l1] = family.light;
+                const rows = SHADE_ROW_SAT_COUNTS.length;
+                const result: ShadeCell[][] = [];
+                for (let row = 0; row < rows; row++) {
+                    const l = l1 - (l1 - l0) * (row / (rows - 1));
+                    const cols = SHADE_ROW_SAT_COUNTS[row];
+                    const rowCells: ShadeCell[] = [];
+                    for (let col = 0; col < cols; col++) {
+                        const s = cols == 1 ? midOfRange(family.sat) : s0 + (s1 - s0) * (col / (cols - 1));
+                        rowCells.push(this.makeShadeCell(this.hue, s, l));
+                    }
+                    result.push(rowCells);
+                }
+                return result;
+            }
+            else {
+                return GREY_SHADE_BANDS.map((band) => {
+                    const [lo, hi] = band.light;
+                    const rowCells: ShadeCell[] = [];
+                    for (let col = 0; col < band.count; col++) {
+                        const l = band.count == 1 ? lo : lo + (hi - lo) * (col / (band.count - 1));
+                        rowCells.push(this.makeShadeCell(0, 0, l));
+                    }
+                    return rowCells;
+                });
+            }
+        },
+
+        currentHex(): string {
+            return this.view == "classic"
+                ? hsvToHex(this.classicHue, this.classicSat, this.classicVal)
+                : hslToHex(this.hue, this.sat, this.light);
+        },
+
+        isClassicHexValid(): boolean {
+            return parseColourToHex(this.hexText) !== null;
+        },
+
+        okDisabled(): boolean {
+            return this.view == "classic" && !this.isClassicHexValid;
+        },
+
+        svSquareStyle(): Record<string, string> {
+            return {background: "linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, transparent), hsl(" + this.classicHue + ", 100%, 50%)"};
+        },
+    },
+
+    watch: {
+        hexText() {
+            if (this.settingHexFromPicker) {
+                this.settingHexFromPicker = false;
+                return;
+            }
+            const hex = parseColourToHex(this.hexText);
+            if (hex) {
+                this.hasSelectedColour = true;
+                const {h, s, v} = hexToHsv(hex);
+                this.classicHue = h;
+                this.classicSat = s;
+                this.classicVal = v;
+            }
+        },
+
+        currentHex(newHex: string) {
+            if (this.isShown && this.hasSelectedColour) {
+                this.showGraphicsColourPreview(newHex);
+            }
+        },
+    },
+
+    methods: {
+        familySwatchHex(family: ColourFamily): string {
+            return hslToHex(midOfRange(family.hue), midOfRange(family.sat), midOfRange(family.light));
+        },
+
+        makeShadeCell(h: number, s: number, l: number): ShadeCell {
+            return {
+                sat: s,
+                light: l,
+                hex: hslToHex(h, s, l),
+                selected: Math.abs(s - this.sat) < 0.01 && Math.abs(l - this.light) < 0.01,
+            };
+        },
+
+        selectFamily(family: ColourFamily) {
+            this.hasSelectedColour = true;
+            this.currentFamilyKey = family.key;
+            this.hue = midOfRange(family.hue);
+            this.sat = midOfRange(family.sat);
+            this.light = midOfRange(family.light);
+            this.view = "tinker";
+        },
+
+        backToGrid() {
+            this.view = "grid";
+        },
+
+        selectHueChip(hue: number) {
+            this.hasSelectedColour = true;
+            this.hue = hue;
+        },
+
+        selectShadeCell(sat: number, light: number) {
+            this.hasSelectedColour = true;
+            this.sat = sat;
+            this.light = light;
+        },
+
+        // Double-clicking a shade tile picks it and immediately confirms the dialog, same as
+        // clicking it then clicking OK -- getHexValue() (see created() above) reads currentHex,
+        // which is already reactive to the assignments just below, so no need to wait a tick.
+        selectShadeCellAndConfirm(sat: number, light: number) {
+            this.selectShadeCell(sat, light);
+            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "ok", componentId: this.dlgId});
+        },
+
+        toggleFineGrained() {
+            if (this.view == "classic") {
+                // Leaving the fine-grained selector: fold the classic HSV colour back into
+                // hue/sat/light, clamped into the active family's ranges (if any) so the shade
+                // grid's selection stays sensible; otherwise just carry the colour over as-is.
+                const hex = hsvToHex(this.classicHue, this.classicSat, this.classicVal);
+                const {h, s, l} = hexToHsl(hex);
+                if (this.currentFamily) {
+                    this.hue = clamp(h, this.currentFamily.hue[0], this.currentFamily.hue[1]);
+                    this.sat = clamp(s, this.currentFamily.sat[0], this.currentFamily.sat[1]);
+                    this.light = clamp(l, this.currentFamily.light[0], this.currentFamily.light[1]);
+                    this.view = "tinker";
+                }
+                else {
+                    this.hue = h;
+                    this.sat = s;
+                    this.light = l;
+                    this.view = "grid";
+                }
+            }
+            else {
+                // Entering the fine-grained selector: seed its HSV state from whatever's currently picked.
+                const {h, s, v} = hexToHsv(this.currentHex);
+                this.classicHue = h;
+                this.classicSat = s;
+                this.classicVal = v;
+                this.hexText = this.currentHex;
+                this.view = "classic";
+            }
+        },
+
+        updateHexFromClassic() {
+            this.hasSelectedColour = true;
+            this.settingHexFromPicker = true;
+            this.hexText = hsvToHex(this.classicHue, this.classicSat, this.classicVal);
+        },
+
+        onSvPointerDown(event: PointerEvent) {
+            const square = this.$refs.svSquare as HTMLDivElement;
+            square.setPointerCapture(event.pointerId);
+            const moveTo = (e: PointerEvent) => {
+                const rect = square.getBoundingClientRect();
+                const x = Math.min(Math.max(e.clientX - rect.left, 0), rect.width);
+                const y = Math.min(Math.max(e.clientY - rect.top, 0), rect.height);
+                this.classicSat = (x / rect.width) * 100;
+                this.classicVal = 100 - (y / rect.height) * 100;
+                this.updateHexFromClassic();
+            };
+            const onMove = (e: PointerEvent) => moveTo(e);
+            const onUp = (e: PointerEvent) => {
+                square.releasePointerCapture(e.pointerId);
+                square.removeEventListener("pointermove", onMove);
+                square.removeEventListener("pointerup", onUp);
+            };
+            square.addEventListener("pointermove", onMove);
+            square.addEventListener("pointerup", onUp);
+            moveTo(event);
+        },
+
+        // Searches every family's hue chips x shade grid (and the greyscale bands) for a swatch
+        // that renders to exactly this hex, so we can start the dialog already on that swatch
+        // instead of making the user hunt for the closest match themselves.
+        findExactSwatchMatch(hex: string): {family: ColourFamily, hue: number, sat: number, light: number} | null {
+            for (const family of this.families) {
+                if (familyHasHueChoice(family)) {
+                    for (let i = 0; i < HUE_CHIP_COUNT; i++) {
+                        const h = family.hue[0] + (family.hue[1] - family.hue[0]) * (i / (HUE_CHIP_COUNT - 1));
+                        const [s0, s1] = family.sat, [l0, l1] = family.light;
+                        const rows = SHADE_ROW_SAT_COUNTS.length;
+                        for (let row = 0; row < rows; row++) {
+                            const l = l1 - (l1 - l0) * (row / (rows - 1));
+                            const cols = SHADE_ROW_SAT_COUNTS[row];
+                            for (let col = 0; col < cols; col++) {
+                                const s = cols == 1 ? midOfRange(family.sat) : s0 + (s1 - s0) * (col / (cols - 1));
+                                if (hslToHex(h, s, l) == hex) {
+                                    return {family, hue: h, sat: s, light: l};
+                                }
+                            }
+                        }
+                    }
+                }
+                else {
+                    for (const band of GREY_SHADE_BANDS) {
+                        const [lo, hi] = band.light;
+                        for (let col = 0; col < band.count; col++) {
+                            const l = band.count == 1 ? lo : lo + (hi - lo) * (col / (band.count - 1));
+                            if (hslToHex(0, 0, l) == hex) {
+                                return {family, hue: 0, sat: 0, light: l};
+                            }
+                        }
+                    }
+                }
+            }
+            return null;
+        },
+
+        onShownModalDlg(event: BvTriggerableEvent) {
+            if (event.componentId != this.dlgId) {
+                return;
+            }
+            // initialColour is only ever passed (non-null) when we're editing an existing string's
+            // content, even if that content isn't a valid colour -- see triggerColourPicker in
+            // LabelSlot.vue, which always passes the current string text there and only passes null
+            // for the "not inside a string" insertion case.
+            if (this.initialColour !== null) {
+                const parsedInitial = parseColourToHex(this.initialColour);
+                const seededHex = parsedInitial ?? DEFAULT_HEX;
+                // If it lands exactly on a swatch, start there with it selected; otherwise (including
+                // when the existing content wasn't a valid colour at all) there's no sensible swatch
+                // to preselect, so go straight to the fine-grained selector with the colour in place.
+                const match = parsedInitial ? this.findExactSwatchMatch(parsedInitial) : null;
+                if (match) {
+                    this.currentFamilyKey = match.family.key;
+                    this.hue = match.hue;
+                    this.sat = match.sat;
+                    this.light = match.light;
+                    this.view = "tinker";
+                }
+                else {
+                    const {h, s, v} = hexToHsv(seededHex);
+                    this.classicHue = h;
+                    this.classicSat = s;
+                    this.classicVal = v;
+                    this.hexText = seededHex;
+                    this.currentFamilyKey = null;
+                    this.view = "classic";
+                }
+                this.isShown = true;
+                this.hasSelectedColour = true;
+                this.showGraphicsColourPreview(seededHex);
+                return;
+            }
+
+            // Fresh insert (not editing an existing string): start at the family grid, with no
+            // colour selected yet -- don't flood-fill the graphics preview until the user actually
+            // picks something (see the currentHex watcher, and hasSelectedColour being set to true
+            // in selectFamily/selectHueChip/selectShadeCell/updateHexFromClassic below).
+            this.hasSelectedColour = false;
+            this.currentFamilyKey = null;
+            const {h, s, l} = hexToHsl(DEFAULT_HEX);
+            this.hue = h;
+            this.sat = s;
+            this.light = l;
+            this.view = "grid";
+            this.isShown = true;
+        },
+
+        onHiddenModalDlg(event: BvTriggerableEvent) {
+            if (event.componentId != this.dlgId) {
+                return;
+            }
+            this.isShown = false;
+            this.clearGraphicsColourPreview();
+            window.removeEventListener("resize", this.punchBackdropHoleOverGraphics);
+        },
+
+        // While the dialog is open, flood-fill the whole graphics execution area with the currently
+        // selected colour -- the same live-preview mechanism the image-literal editor uses (see
+        // MediaPreviewPopup.vue's doPreviewImage), just filling the "background" canvas with a solid
+        // colour instead of drawing an image into it. Both overrideGraphics() params are required
+        // together to activate the override, so we pass the same filled canvas for both.
+        showGraphicsColourPreview(hex: string) {
+            document.getElementById("strypeGraphicsPEATab")?.click();
+            const canvas = new OffscreenCanvas(800, 600);
+            const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
+            ctx.fillStyle = hex;
+            ctx.fillRect(0, 0, 800, 600);
+            vueComponentsAPIHandler.peaComponentAPI?.overrideGraphics(canvas, canvas);
+            vueComponentsAPIHandler.peaComponentAPI?.redrawCanvas();
+            // Switching to the Graphics tab (above) may not have finished laying out the panel yet
+            // -- if it was hidden a moment ago, getBoundingClientRect() on it here would still
+            // measure its old (zero-sized) box. Deferring to nextTick lets that layout settle first.
+            nextTick(() => this.punchBackdropHoleOverGraphics());
+            window.addEventListener("resize", this.punchBackdropHoleOverGraphics);
+        },
+
+        // The modal backdrop sits on top of the whole page -- including the graphics panel, which
+        // isn't actually underneath the modal box itself -- so without this the preview would just
+        // look like a dimmed/greyed version of the real colour. We want the backdrop to keep dimming
+        // everywhere else, so instead of hiding it entirely we cut a rectangular hole in it over the
+        // graphics panel using a "keyhole" clip-path: trace the full-viewport rectangle, then a
+        // slit straight up to the hole's top edge, around the hole, and back out along the same
+        // slit. The slit is traversed twice along an identical line, so it has zero visible width --
+        // the net result is a plain rectangle with a rectangular hole, without needing an evenodd
+        // fill rule (which the plain CSS polygon() function doesn't support).
+        punchBackdropHoleOverGraphics() {
+            const backdrop = document.querySelector(".modal-backdrop") as HTMLElement | null;
+            const graphicsEl = document.getElementById(getPEAGraphicsContainerDivId());
+            if (!backdrop || !graphicsEl) {
+                return;
+            }
+            const rect = graphicsEl.getBoundingClientRect();
+            const w = window.innerWidth;
+            const h = window.innerHeight;
+            const points = [
+                "0px 0px", `${w}px 0px`, `${w}px ${h}px`, `0px ${h}px`, `0px ${rect.top}px`,
+                `${rect.left}px ${rect.top}px`, `${rect.left}px ${rect.bottom}px`,
+                `${rect.right}px ${rect.bottom}px`, `${rect.right}px ${rect.top}px`,
+                `${rect.left}px ${rect.top}px`, `0px ${rect.top}px`,
+            ].join(", ");
+            backdrop.style.clipPath = `polygon(${points})`;
+        },
+
+        clearGraphicsColourPreview() {
+            vueComponentsAPIHandler.peaComponentAPI?.overrideGraphics(null, null);
+            vueComponentsAPIHandler.peaComponentAPI?.redrawCanvas();
+            const backdrop = document.querySelector(".modal-backdrop") as HTMLElement | null;
+            if (backdrop) {
+                backdrop.style.clipPath = "";
+            }
+        },
+    },
+});
+</script>
+
+<style lang="scss">
+.ColourPickerDlg-content {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 14px;
+    width: 450px;
+    margin: 0 auto;
+}
+
+.ColourPickerDlg-family-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+}
+.ColourPickerDlg-family-btn {
+    all: unset;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    cursor: pointer;
+    padding: 3px;
+    border-radius: 6px;
+}
+.ColourPickerDlg-family-btn:hover .ColourPickerDlg-family-swatch {
+    transform: scale(1.08);
+}
+.ColourPickerDlg-family-btn:focus-visible {
+    outline: 2px solid var(--bs-primary);
+    outline-offset: 2px;
+}
+.ColourPickerDlg-family-swatch {
+    width: 100%;
+    aspect-ratio: 1;
+    border-radius: 8px;
+    box-shadow: inset 0 0 0 1px var(--bs-border-color);
+    transition: transform 120ms ease;
+}
+.ColourPickerDlg-family-name {
+    font-size: 105%;
+    font-weight: 600;
+    color: var(--bs-secondary-color);
+    text-align: center;
+}
+
+// Reserves enough height for the tallest view (the tinker view, hue chips + shade trapezoid) so
+// switching between the family grid / tinker / fine-grained selector doesn't resize the dialog.
+.ColourPickerDlg-view-area {
+    min-height: 350px;
+}
+
+.ColourPickerDlg-section-label {
+    font-size: 102%;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--bs-secondary-color);
+    margin: 0 0 7px;
+}
+
+.ColourPickerDlg-hue-strip {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 6px;
+    margin-bottom: 16px;
+}
+.ColourPickerDlg-chip {
+    all: unset;
+    aspect-ratio: 1.5;
+    border-radius: 5px;
+    box-shadow: inset 0 0 0 1px var(--bs-border-color);
+    cursor: pointer;
+    position: relative;
+    transition: transform 120ms ease;
+}
+.ColourPickerDlg-chip:hover {
+    transform: scale(1.05);
+}
+.ColourPickerDlg-chip:focus-visible {
+    outline: 2px solid var(--bs-primary);
+    outline-offset: 2px;
+}
+.ColourPickerDlg-chip-selected::after {
+    content: "";
+    position: absolute;
+    inset: -4px;
+    border-radius: 8px;
+    border: 2px solid var(--bs-primary);
+}
+
+.ColourPickerDlg-shade-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.ColourPickerDlg-shade-row {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+}
+.ColourPickerDlg-shade-cell {
+    all: unset;
+    width: 66px;
+    height: 46px;
+    border-radius: 5px;
+    box-shadow: inset 0 0 0 1px var(--bs-border-color);
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    transition: transform 120ms ease;
+}
+.ColourPickerDlg-shade-cell:hover {
+    transform: scale(1.06);
+}
+.ColourPickerDlg-shade-cell:focus-visible {
+    outline: 2px solid var(--bs-primary);
+    outline-offset: 2px;
+}
+.ColourPickerDlg-shade-cell-selected::after {
+    content: "";
+    position: absolute;
+    inset: -4px;
+    border-radius: 8px;
+    border: 2px solid var(--bs-primary);
+}
+
+.ColourPickerDlg-sv-square {
+    position: relative;
+    width: 100%;
+    height: 240px;
+    touch-action: none;
+    cursor: crosshair;
+    box-shadow: inset 0 0 0 1px var(--bs-border-color);
+    margin-top: 10px;
+}
+.ColourPickerDlg-sv-cursor {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid white;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+}
+.ColourPickerDlg-hue-slider {
+    width: 100%;
+    -webkit-appearance: none;
+    height: 14px;
+    border-radius: 7px;
+    background: linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
+}
+.ColourPickerDlg-hue-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: white;
+    border: 2px solid #555;
+    cursor: pointer;
+}
+.ColourPickerDlg-hue-slider::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: white;
+    border: 2px solid #555;
+    cursor: pointer;
+}
+.ColourPickerDlg-hex-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 12px;
+}
+.ColourPickerDlg-hex-input {
+    font-family: monospace;
+    font-size: 100%;
+    padding: 4px 8px;
+    width: 120px;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 4px;
+}
+.ColourPickerDlg-hex-input-invalid {
+    border-color: var(--bs-danger);
+    color: var(--bs-danger);
+}
+
+.ColourPickerDlg-swatch {
+    display: inline-block;
+    width: 30px;
+    height: 30px;
+    border-radius: 5px;
+    box-shadow: inset 0 0 0 1px var(--bs-border-color);
+    flex-shrink: 0;
+}
+
+.ColourPickerDlg-bottom-row {
+    display: flex;
+    margin-top: 8px;
+}
+.ColourPickerDlg-bottom-row-split {
+    gap: 20px;
+}
+.ColourPickerDlg-bottom-row-split .btn {
+    flex: 1;
+}
+.ColourPickerDlg-bottom-btn-right {
+    margin-left: auto;
+}
+.ColourPickerDlg-bottom-btn-half {
+    width: calc(50% - 10px);
+}
+.btn.ColourPickerDlg-bottom-btn {
+    color: #fff;
+}
+
+</style>

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -86,7 +86,8 @@
                                                     <div
                                                         v-for="mediaRecordingCommand in mediaRecordingCommands"
                                                         :key="mediaRecordingCommand.description"
-                                                        class="frame-cmd-container text-editing-command"
+                                                        class="frame-cmd-container text-editing-command clickable-command"
+                                                        @click="triggerMediaRecordingFromHint(mediaRecordingCommand.kind)"
                                                     >
                                                         <span class="text-editing-command-keys">
                                                             <template v-for="(key, keyIndex) in mediaRecordingCommand.keys" :key="key.label">
@@ -101,7 +102,8 @@
                                                     <div
                                                         v-for="colourPickerCmd in colourPickerCommand"
                                                         :key="colourPickerCmd.description"
-                                                        class="frame-cmd-container text-editing-command"
+                                                        class="frame-cmd-container text-editing-command clickable-command"
+                                                        @click="triggerColourPickerFromHint"
                                                     >
                                                         <span class="text-editing-command-keys">
                                                             <template v-for="(key, keyIndex) in colourPickerCmd.keys" :key="key.label">
@@ -400,7 +402,7 @@ export default defineComponent({
         // Ctrl-Shift-I/U opens a dialog to record a new image/sound literal from the webcam/
         // microphone. We show those shortcuts here as a hint, mirroring the same gating
         // LabelSlot.vue's onKeyDown uses for the shortcut itself.
-        mediaRecordingCommands(): {keys: ({label: string, title?: string})[]; description: string}[] {
+        mediaRecordingCommands(): {keys: ({label: string, title?: string})[]; description: string; kind: "image" | "sound"}[] {
             const focusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
             if(!this.appStore.isEditing || !focusSlotCursorInfos){
                 return [];
@@ -415,8 +417,8 @@ export default defineComponent({
             const ctrl = {label: this.$t("contextMenu.ctrl")};
             const shift = {label: "⇧", title: this.$t("autoCompletion.shiftKey")};
             return [
-                {keys: [ctrl, shift, {label: "i"}], description: this.$t("autoCompletion.recordImageShortcut")},
-                {keys: [ctrl, shift, {label: "u"}], description: this.$t("autoCompletion.recordSoundShortcut")},
+                {keys: [ctrl, shift, {label: "i"}], description: this.$t("autoCompletion.recordImageShortcut"), kind: "image"},
+                {keys: [ctrl, shift, {label: "u"}], description: this.$t("autoCompletion.recordSoundShortcut"), kind: "sound"},
             ];
         },
 
@@ -940,6 +942,31 @@ export default defineComponent({
             return getAddFrameCmdElementUID(commandType);
         },
 
+        // Clicking these hints should do the same thing as pressing the shortcut they describe,
+        // for users who don't know/remember the shortcut. The tricky part is that they live in a
+        // totally different component to the focused slot -- the wrapping @mousedown.prevent.stop
+        // above stops the click from blurring the focused slot (so appStore.focusSlotCursorInfos
+        // is still valid by the time this runs), and we then dispatch to that specific LabelSlot
+        // instance's own triggerMediaRecording/triggerColourPicker via the shared component API
+        // registry, exactly as if its own keydown handler had fired.
+        triggerMediaRecordingFromHint(kind: "image" | "sound") {
+            const focusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
+            if(!focusSlotCursorInfos){
+                return;
+            }
+            const uid = getLabelSlotUID(focusSlotCursorInfos.slotInfos);
+            vueComponentsAPIHandler.labelSlotComponentAPI?.forInstance[uid]?.triggerMediaRecording(kind);
+        },
+
+        triggerColourPickerFromHint() {
+            const focusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
+            if(!focusSlotCursorInfos){
+                return;
+            }
+            const uid = getLabelSlotUID(focusSlotCursorInfos.slotInfos);
+            vueComponentsAPIHandler.labelSlotComponentAPI?.forInstance[uid]?.triggerColourPicker();
+        },
+
         // Inserts the frame matching this (lowercased) shortcut key -- by its original shortcut, its
         // legacy shortcut (see getLegacyShortcut, editor.ts), or a hidden shorthand -- exactly as the
         // direct top-level dispatch always has. Returns whether a match was found and dispatched, so
@@ -1321,6 +1348,21 @@ export default defineComponent({
 
 .modifed-label-span {
      margin-left: 15px;
+}
+
+// Unlike other .text-editing-command hints (informational only, cursor: default -- see
+// AddFrameCommand.vue), the media-recording/colour-picker hints can also be clicked directly to
+// trigger the same action as their keyboard shortcut, so they get the pointer cursor back plus a
+// hover highlight for affordance.
+.frame-cmd-container.clickable-command,
+.frame-cmd-container.clickable-command .frame-cmd-btn {
+    cursor: pointer;
+}
+.frame-cmd-container.clickable-command {
+    border-radius: 4px;
+}
+.frame-cmd-container.clickable-command:hover {
+    background-color: rgba(0, 0, 0, 0.06);
 }
 
 .project-name {

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -97,6 +97,21 @@
                                                         <span>{{ mediaRecordingCommand.description }}</span>
                                                     </div>
                                                 </p>
+                                                <p v-if="colourPickerCommand.length">
+                                                    <div
+                                                        v-for="colourPickerCmd in colourPickerCommand"
+                                                        :key="colourPickerCmd.description"
+                                                        class="frame-cmd-container text-editing-command"
+                                                    >
+                                                        <span class="text-editing-command-keys">
+                                                            <template v-for="(key, keyIndex) in colourPickerCmd.keys" :key="key.label">
+                                                                <span v-if="keyIndex > 0" class="text-editing-command-keys-plus">+</span>
+                                                                <button class="frame-cmd-btn frame-cmd-btn-large" :title="key.title">{{ key.label }}</button>
+                                                            </template>
+                                                        </span>
+                                                        <span>{{ colourPickerCmd.description }}</span>
+                                                    </div>
+                                                </p>
                                             <!-- this conditional rendering is only used for our code editor to see the closing <div> right -->
                                             <!-- #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE -->
                                             </div>
@@ -402,6 +417,28 @@ export default defineComponent({
             return [
                 {keys: [ctrl, shift, {label: "i"}], description: this.$t("autoCompletion.recordImageShortcut")},
                 {keys: [ctrl, shift, {label: "u"}], description: this.$t("autoCompletion.recordSoundShortcut")},
+            ];
+        },
+
+        // Ctrl-Shift-Y opens the colour-picker dialog. Unlike mediaRecordingCommands above, this is
+        // shown for string slots too, since that's exactly where it's most useful (editing colour
+        // string literals in place); only comments are excluded.
+        colourPickerCommand(): {keys: ({label: string, title?: string})[]; description: string}[] {
+            const focusSlotCursorInfos = this.appStore.focusSlotCursorInfos;
+            if(!this.appStore.isEditing || !focusSlotCursorInfos){
+                return [];
+            }
+
+            const slotInfos = focusSlotCursorInfos.slotInfos;
+            const frameType = this.appStore.frameObjects[slotInfos.frameId]?.frameType.type;
+            if(slotInfos.slotType == SlotType.comment || frameType == AllFrameTypesIdentifier.comment){
+                return [];
+            }
+
+            const ctrl = {label: this.$t("contextMenu.ctrl")};
+            const shift = {label: "⇧", title: this.$t("autoCompletion.shiftKey")};
+            return [
+                {keys: [ctrl, shift, {label: "y"}], description: this.$t("autoCompletion.colourPickerShortcut")},
             ];
         },
 

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -79,7 +79,7 @@ import Cache from "timed-cache";
 import { useStore } from "@/store/store";
 import AutoCompletion from "@/components/AutoCompletion.vue";
 import { bumpCaretRequestSeq, closeBracketCharacters, CustomEventTypes, getACLabelSlotUID, getCaretRequestSeq, getFocusedEditableSlotTextSelectionStartEnd, getFrameHeaderUID, getFrameLabelSlotLiteralCodeAndFocus, getFrameLabelSlotsStructureUID, getFrameUID, getLabelSlotUID, getMatchingBracket, getNumPrecedingBackslashes, getSelectionCursorsComparisonValue, getTextStartCursorPositionOfHTMLElement, keywordOperatorsWithSurroundSpaces, openBracketCharacters, operators, parseCodeLiteral, parseLabelSlotUID, setDocumentSelection, simpleSlotStructureToString, STRING_DOUBLEQUOTE_PLACERHOLDER, STRING_SINGLEQUOTE_PLACERHOLDER, stringDoubleQuoteChar, stringQuoteCharacters, stringSingleQuoteChar, UIDoubleQuotesCharacters, UISingleQuotesCharacters, getGraphemeLength } from "@/helpers/editor";
-import { AllFrameTypesIdentifier, AllowedSlotContent, areSlotCoreInfosEqual, BaseSlot, CaretPosition, CollapsedState, EditImageInDialogFunction, FieldSlot, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, FrameObject, getFrameDefType, isFieldBracketedSlot, isFieldStringSlot, LoadedMedia, MediaSlot, MessageDefinitions, OptionalSlotType, PythonExecRunningState, RecordNewImageInDialogFunction, RecordNewSoundInDialogFunction, SlotCoreInfos, SlotCursorInfos, SlotsStructure, SlotType, StringSlot } from "@/types/types";
+import { AllFrameTypesIdentifier, AllowedSlotContent, areSlotCoreInfosEqual, BaseSlot, CaretPosition, CollapsedState, EditImageInDialogFunction, FieldSlot, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, FrameObject, getFrameDefType, isFieldBracketedSlot, isFieldStringSlot, LoadedMedia, MediaSlot, MessageDefinitions, OpenColourPickerInDialogFunction, OptionalSlotType, PythonExecRunningState, RecordNewImageInDialogFunction, RecordNewSoundInDialogFunction, SlotCoreInfos, SlotCursorInfos, SlotsStructure, SlotType, StringSlot } from "@/types/types";
 import { getCandidatesForAC } from "@/autocompletion/acManager";
 import { mapStores } from "pinia";
 import {evaluateSlotType, getFlatNeighbourFieldSlotInfos, getOutmostDisabledAncestorFrameId, getSlotDefFromInfos, getSlotIdFromParentIdAndIndexSplit, getSlotParentIdAndIndexSplit, isFrameLabelSlotStructWithCodeContent, retrieveParentSlotFromSlotInfos, retrieveSlotFromSlotInfos} from "@/helpers/storeMethods";
@@ -154,7 +154,7 @@ export default defineComponent({
         },
     },
     
-    inject: ["editImageInDialog", "recordNewImageInDialog", "recordNewSoundInDialog"],
+    inject: ["editImageInDialog", "recordNewImageInDialog", "recordNewSoundInDialog", "openColourPickerInDialog"],
 
     mounted(){
         // To make sure the a/c component shows just below the spans, we set its top position here based on the span height.
@@ -417,6 +417,10 @@ export default defineComponent({
 
         doRecordNewSoundInDialog() : RecordNewSoundInDialogFunction {
             return (this as any).recordNewSoundInDialog as RecordNewSoundInDialogFunction;
+        },
+
+        doOpenColourPickerInDialog() : OpenColourPickerInDialogFunction {
+            return (this as any).openColourPickerInDialog as OpenColourPickerInDialogFunction;
         },
     },
 
@@ -948,6 +952,24 @@ export default defineComponent({
                 this.triggerMediaRecording(event.key.toLowerCase() == "i" ? "image" : "sound");
             }
 
+            // Ctrl-Shift-Y opens a colour-picker dialog (Ctrl-Shift-L was already taken by the
+            // project-sharing-link shortcut in Menu.vue; Ctrl-Shift-P is Firefox's reserved Private
+            // Browsing shortcut; Ctrl-Alt-C collides with AltGr on many non-US keyboard layouts;
+            // Ctrl-Shift-K opens Firefox's Web Console regardless of preventDefault, same
+            // unblockable-by-the-page category as Ctrl-Shift-P). Unlike Ctrl-Shift-I/U above, this
+            // one IS allowed inside string slots (it's meant to help build/edit colour string
+            // literals), just not inside comments where a colour string wouldn't make sense.
+            if((event.ctrlKey || event.metaKey) && event.shiftKey
+                    && event.key.toLowerCase() == "y"
+                    && this.slotType != SlotType.comment
+                    && this.frameType != AllFrameTypesIdentifier.comment
+                    && !this.appStore.isModalDlgShown){
+                event.preventDefault();
+                event.stopPropagation();
+                event.stopImmediatePropagation();
+                this.triggerColourPicker();
+            }
+
             // Manage the handling of home/end and page up/page down keys (see macOS case in method details)
             const textHomeEndBehaviourKeys = (isMacOSPlatform() && event.metaKey) ? ["ArrowLeft", "ArrowRight"] : ["Home", "End"];
             if(["PageUp", "PageDown", ...textHomeEndBehaviourKeys].includes(event.key)){
@@ -1039,6 +1061,94 @@ export default defineComponent({
             }
             else {
                 this.doRecordNewSoundInDialog(commitInsertion, restoreOriginalCursor);
+            }
+        },
+
+        // Ctrl-Shift-Y: opens the colour-picker dialog at the current caret position. Two cases,
+        // per the same synchronous-capture approach as triggerMediaRecording above:
+        // - Outside a string: inserts a brand new string literal containing the picked hex code,
+        //   via addNewSlot (mirrors the media-literal-insertion case there).
+        // - Inside a string: seeds the picker from the current string content (if it parses as a
+        //   colour), and on "OK" replaces the WHOLE string content with the picked hex code
+        //   (regardless of whether the original content was a valid colour), via
+        //   setFrameEditableSlotContent. Cancel leaves the string untouched.
+        triggerColourPicker() {
+            const inputSpanField = document.getElementById(this.UID) as HTMLSpanElement;
+            if (!inputSpanField) {
+                return;
+            }
+            const targetSlotInfos = parseLabelSlotUID(this.UID);
+            const isInString = this.slotType == SlotType.string;
+
+            // Suppress the artificial blur about to happen as focus moves to the modal (see
+            // triggerMediaRecording above for why):
+            this.appStore.ignoreBlurEditableSlot = true;
+
+            if (isInString) {
+                const currentCode = (inputSpanField.textContent ?? "").replace(/\u200B/g, "");
+                const restoreOriginalCursor = () => {
+                    const cursorInfo: SlotCursorInfos = {slotInfos: targetSlotInfos, cursorPos: currentCode.length};
+                    nextTick(() => {
+                        setDocumentSelection(cursorInfo, cursorInfo);
+                        this.appStore.setSlotTextCursors(cursorInfo, cursorInfo);
+                        this.appStore.setFocusEditableSlot({
+                            frameSlotInfos: targetSlotInfos,
+                            caretPosition: this.appStore.getAllowedChildren(targetSlotInfos.frameId) ? CaretPosition.body : CaretPosition.below,
+                        });
+                    });
+                };
+
+                const commitReplacement = (hex: string) => {
+                    this.appStore.setFrameEditableSlotContent({...targetSlotInfos, code: hex, initCode: "", isFirstChange: true});
+                    const cursorInfo: SlotCursorInfos = {slotInfos: targetSlotInfos, cursorPos: hex.length};
+                    nextTick(() => {
+                        setDocumentSelection(cursorInfo, cursorInfo);
+                        this.appStore.setSlotTextCursors(cursorInfo, cursorInfo);
+                        this.appStore.setFocusEditableSlot({
+                            frameSlotInfos: targetSlotInfos,
+                            caretPosition: this.appStore.getAllowedChildren(targetSlotInfos.frameId) ? CaretPosition.body : CaretPosition.below,
+                        });
+                    });
+                };
+
+                this.doOpenColourPickerInDialog(currentCode, commitReplacement, restoreOriginalCursor);
+            }
+            else {
+                const {selectionStart, selectionEnd} = getFocusedEditableSlotTextSelectionStartEnd(this.UID);
+                const lhsCode = (inputSpanField.textContent?.substring(0, selectionStart) ?? "").replace(/\u200B/g, "");
+                const rhsCode = (inputSpanField.textContent?.substring(selectionEnd) ?? "").replace(/\u200B/g, "");
+
+                const restoreOriginalCursor = () => {
+                    const anchorCursorInfo: SlotCursorInfos = {slotInfos: targetSlotInfos, cursorPos: selectionStart};
+                    const focusCursorInfo: SlotCursorInfos = {slotInfos: targetSlotInfos, cursorPos: selectionEnd};
+                    nextTick(() => {
+                        setDocumentSelection(anchorCursorInfo, focusCursorInfo);
+                        this.appStore.setSlotTextCursors(anchorCursorInfo, focusCursorInfo);
+                        this.appStore.setFocusEditableSlot({
+                            frameSlotInfos: targetSlotInfos,
+                            caretPosition: this.appStore.getAllowedChildren(targetSlotInfos.frameId) ? CaretPosition.body : CaretPosition.below,
+                        });
+                    });
+                };
+
+                const commitInsertion = (hex: string) => {
+                    this.appStore.addNewSlot(targetSlotInfos, "\"", lhsCode, rhsCode, SlotType.string, false, hex);
+                    // Place the cursor in the new trailing (empty) field right after the inserted
+                    // string, mirroring commitInsertion in triggerMediaRecording above:
+                    const {parentId, slotIndex} = getSlotParentIdAndIndexSplit(targetSlotInfos.slotId);
+                    const rhsSlotInfos: SlotCoreInfos = {...targetSlotInfos, slotId: getSlotIdFromParentIdAndIndexSplit(parentId, slotIndex + 2)};
+                    const cursorInfo: SlotCursorInfos = {slotInfos: rhsSlotInfos, cursorPos: 0};
+                    nextTick(() => {
+                        setDocumentSelection(cursorInfo, cursorInfo);
+                        this.appStore.setSlotTextCursors(cursorInfo, cursorInfo);
+                        this.appStore.setFocusEditableSlot({
+                            frameSlotInfos: rhsSlotInfos,
+                            caretPosition: this.appStore.getAllowedChildren(rhsSlotInfos.frameId) ? CaretPosition.body : CaretPosition.below,
+                        });
+                    });
+                };
+
+                this.doOpenColourPickerInDialog(null, commitInsertion, restoreOriginalCursor);
             }
         },
 

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -115,6 +115,8 @@ export default defineComponent({
         // (we don't set it in setup() because we want to have this accessible, and the component created!)
         const apiMethods = {
             handleUpDown: this.handleUpDown,
+            triggerMediaRecording: this.triggerMediaRecording,
+            triggerColourPicker: this.triggerColourPicker,
         };
         
         if(vueComponentsAPIHandler.labelSlotComponentAPI == null){    

--- a/src/components/RecordImageDlg.vue
+++ b/src/components/RecordImageDlg.vue
@@ -1,5 +1,5 @@
 <template>
-    <ModalDlg :dlgId="dlgId" :dlgTitle="dlgTitle" hideDlgBtns>
+    <ModalDlg dlgId="recordImageDlg" :dlgTitle="$t('media.recordImageTitle')" hideDlgBtns>
         <div v-if="errorMessage" class="RecordImageDlg-error">{{ errorMessage }}</div>
         <div class="RecordImageDlg-video-wrapper">
             <video ref="video" class="RecordImageDlg-video" autoplay muted playsinline></video>
@@ -22,17 +22,15 @@ import { eventBus } from "@/helpers/appContext";
 import { CustomEventTypes } from "@/helpers/editor";
 import { captureVideoFrameToDataURL, stopMediaStreamTracks } from "@/helpers/mediaCapture";
 
+// Only ever one instance of this dialog (see App.vue), so its id is fixed rather than a prop.
+const DLG_ID = "recordImageDlg";
+
 export default defineComponent({
     name: "RecordImageDlg",
 
     components: {
         ModalDlg,
         BButton,
-    },
-
-    props: {
-        dlgId: String,
-        dlgTitle: String,
     },
 
     data: function () {
@@ -68,7 +66,7 @@ export default defineComponent({
 
     methods: {
         onShownModalDlg(event: BvTriggerableEvent) {
-            if (event.componentId != this.dlgId) {
+            if (event.componentId != DLG_ID) {
                 return;
             }
             // Fresh state every time the dialog is (re-)shown, e.g. via "Re-record":
@@ -91,7 +89,7 @@ export default defineComponent({
         },
 
         onHideModalDlg(event: BvTriggerableEvent) {
-            if (event.componentId != this.dlgId) {
+            if (event.componentId != DLG_ID) {
                 return;
             }
             this.clearCountdown();
@@ -124,7 +122,7 @@ export default defineComponent({
             // Release the camera as soon as we have the frame, rather than waiting for the
             // (animated) modal-hide transition to finish:
             this.stopCamera();
-            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "captured", componentId: this.dlgId});
+            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "captured", componentId: DLG_ID});
         },
 
         doRecord() {
@@ -154,7 +152,7 @@ export default defineComponent({
         },
 
         doCancel() {
-            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "cancel", componentId: this.dlgId});
+            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "cancel", componentId: DLG_ID});
         },
     },
 });

--- a/src/components/RecordSoundDlg.vue
+++ b/src/components/RecordSoundDlg.vue
@@ -1,5 +1,5 @@
 <template>
-    <ModalDlg :dlgId="dlgId" :dlgTitle="dlgTitle" hideDlgBtns>
+    <ModalDlg dlgId="recordSoundDlg" :dlgTitle="$t('media.recordSoundTitle')" hideDlgBtns>
         <div v-if="errorMessage" class="RecordSoundDlg-error">{{ errorMessage }}</div>
         <canvas ref="waveformCanvas" class="RecordSoundDlg-waveform" width="600" height="150"></canvas>
         <div class="d-flex justify-content-center align-items-center RecordSoundDlg-button-wrapper">
@@ -25,17 +25,15 @@ import { closeAudioContext, createOrGetAudioContext } from "@/helpers/audioConte
 // startWaveformLoop() below):
 const WAVEFORM_WINDOW_MS = 5000;
 
+// Only ever one instance of this dialog (see App.vue), so its id is fixed rather than a prop.
+const DLG_ID = "recordSoundDlg";
+
 export default defineComponent({
     name: "RecordSoundDlg",
 
     components: {
         ModalDlg,
         BButton,
-    },
-
-    props: {
-        dlgId: String,
-        dlgTitle: String,
     },
 
     data: function () {
@@ -81,7 +79,7 @@ export default defineComponent({
 
     methods: {
         onShownModalDlg(event: BvTriggerableEvent) {
-            if (event.componentId != this.dlgId) {
+            if (event.componentId != DLG_ID) {
                 return;
             }
             // Fresh state every time the dialog is (re-)shown, e.g. via "Re-record":
@@ -128,7 +126,7 @@ export default defineComponent({
         },
 
         onHideModalDlg(event: BvTriggerableEvent) {
-            if (event.componentId != this.dlgId) {
+            if (event.componentId != DLG_ID) {
                 return;
             }
             this.cleanUp();
@@ -252,7 +250,7 @@ export default defineComponent({
                     // Release the microphone as soon as we have the recording, rather than waiting
                     // for the (animated) modal-hide transition to finish:
                     this.cleanUp();
-                    eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "captured", componentId: this.dlgId});
+                    eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "captured", componentId: DLG_ID});
                 }).catch((err) => {
                     console.error("Error decoding recorded audio:", err);
                     this.errorMessage = this.$t("media.recordingProcessingError") as string;
@@ -267,7 +265,7 @@ export default defineComponent({
         },
 
         doCancel() {
-            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "cancel", componentId: this.dlgId});
+            eventBus.emit(CustomEventTypes.hideStrypeModal, {trigger: "cancel", componentId: DLG_ID});
         },
     },
 });

--- a/src/helpers/colour.ts
+++ b/src/helpers/colour.ts
@@ -1,0 +1,209 @@
+// Small colour-conversion helpers used by the colour picker dialog (Ctrl-Shift-L).
+
+// Parses any CSS-recognised colour representation (a hex code such as "#f00"/"#ff0000", a
+// recognised CSS colour name such as "red", or an rgb()/hsl() function) into a normalised
+// "#rrggbb" hex string, or null if the input isn't a colour the browser recognises.
+// We piggy-back on the canvas 2D context's fillStyle setter, which silently ignores invalid
+// assignments (leaving the previous value untouched) and normalises valid ones -- opaque colours
+// always come back as "#rrggbb" in every browser we support, which is exactly what we want without
+// having to ship our own CSS colour name table.
+let parseCanvasCtx: CanvasRenderingContext2D | null = null;
+export function parseColourToHex(input: string): string | null {
+    if (!input || !input.trim()) {
+        return null;
+    }
+    if (!parseCanvasCtx) {
+        parseCanvasCtx = document.createElement("canvas").getContext("2d");
+    }
+    if (!parseCanvasCtx) {
+        return null;
+    }
+    // Sentinel that's vanishingly unlikely to be the actual input, so we can detect a no-op
+    // (i.e. rejected) assignment below:
+    const sentinel = "#010203";
+    parseCanvasCtx.fillStyle = sentinel;
+    parseCanvasCtx.fillStyle = input;
+    const result = parseCanvasCtx.fillStyle;
+    if (result === sentinel && input.trim().toLowerCase() !== sentinel) {
+        return null;
+    }
+    // Colours with alpha come back as "rgba(...)"; we don't support those here (the string literal
+    // we produce is always opaque), so treat them as unparseable rather than losing the alpha silently:
+    if (!/^#[0-9a-f]{6}$/.test(result)) {
+        return null;
+    }
+    return result;
+}
+
+export function hexToHsv(hex: string): { h: number, s: number, v: number } {
+    const r = parseInt(hex.substring(1, 3), 16) / 255;
+    const g = parseInt(hex.substring(3, 5), 16) / 255;
+    const b = parseInt(hex.substring(5, 7), 16) / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+
+    let h = 0;
+    if (delta !== 0) {
+        if (max === r) {
+            h = 60 * (((g - b) / delta) % 6);
+        }
+        else if (max === g) {
+            h = 60 * ((b - r) / delta + 2);
+        }
+        else {
+            h = 60 * ((r - g) / delta + 4);
+        }
+    }
+    if (h < 0) {
+        h += 360;
+    }
+    const s = max === 0 ? 0 : delta / max;
+    const v = max;
+    return { h, s: s * 100, v: v * 100 };
+}
+
+export function hexToHsl(hex: string): { h: number, s: number, l: number } {
+    const r = parseInt(hex.substring(1, 3), 16) / 255;
+    const g = parseInt(hex.substring(3, 5), 16) / 255;
+    const b = parseInt(hex.substring(5, 7), 16) / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+
+    let h = 0;
+    if (delta !== 0) {
+        if (max === r) {
+            h = 60 * (((g - b) / delta) % 6);
+        }
+        else if (max === g) {
+            h = 60 * ((b - r) / delta + 2);
+        }
+        else {
+            h = 60 * ((r - g) / delta + 4);
+        }
+    }
+    if (h < 0) {
+        h += 360;
+    }
+    const l = (max + min) / 2;
+    const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+    return { h, s: s * 100, l: l * 100 };
+}
+
+export function hslToHex(h: number, s: number, l: number): string {
+    h = ((h % 360) + 360) % 360;
+    const sNorm = s / 100;
+    const lNorm = l / 100;
+    const c = (1 - Math.abs(2 * lNorm - 1)) * sNorm;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = lNorm - c / 2;
+    let r = 0, g = 0, b = 0;
+    if (h < 60) {
+        [r, g, b] = [c, x, 0];
+    }
+    else if (h < 120) {
+        [r, g, b] = [x, c, 0];
+    }
+    else if (h < 180) {
+        [r, g, b] = [0, c, x];
+    }
+    else if (h < 240) {
+        [r, g, b] = [0, x, c];
+    }
+    else if (h < 300) {
+        [r, g, b] = [x, 0, c];
+    }
+    else {
+        [r, g, b] = [c, 0, x];
+    }
+    const toHexByteHsl = (n: number) => Math.round((n + m) * 255).toString(16).padStart(2, "0");
+    return "#" + toHexByteHsl(r) + toHexByteHsl(g) + toHexByteHsl(b);
+}
+
+export function hsvToHex(h: number, s: number, v: number): string {
+    const sNorm = s / 100;
+    const vNorm = v / 100;
+    const c = vNorm * sNorm;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = vNorm - c;
+    let r = 0, g = 0, b = 0;
+    if (h < 60) {
+        [r, g, b] = [c, x, 0];
+    }
+    else if (h < 120) {
+        [r, g, b] = [x, c, 0];
+    }
+    else if (h < 180) {
+        [r, g, b] = [0, c, x];
+    }
+    else if (h < 240) {
+        [r, g, b] = [0, x, c];
+    }
+    else if (h < 300) {
+        [r, g, b] = [x, 0, c];
+    }
+    else {
+        [r, g, b] = [c, 0, x];
+    }
+    const toHexByte = (n: number) => Math.round((n + m) * 255).toString(16).padStart(2, "0");
+    return "#" + toHexByte(r) + toHexByte(g) + toHexByte(b);
+}
+
+// Colour-family data for the picker's "pick a family, then a shade" flow (ColourPickerDlg.vue).
+// Hue ranges deliberately overlap neighbouring families (e.g. Red reaches from near-orange to
+// near-purple/magenta) rather than each being a narrow band around one "pure" hue, and saturation/
+// lightness ranges are wide enough that a handful of grid steps land clearly apart rather than
+// clustering together.
+export interface ColourFamily {
+    key: string;
+    nameKey: string; // i18n key for the family's display name
+    hue: [number, number];
+    sat: [number, number];
+    light: [number, number];
+    // Overrides the shared GOOD_CHIP_SAT/GOOD_CHIP_LIGHT used to render this family's hue chips.
+    // Needed for Brown: at the shared vivid tone, Brown's hue chips are indistinguishable from
+    // Orange's -- Brown only reads as brown at low saturation and lowish lightness.
+    chipSat?: number;
+    chipLight?: number;
+}
+
+export const COLOUR_FAMILIES: ColourFamily[] = [
+    { key: "red", nameKey: "colourPicker.familyRed", hue: [-60, 30], sat: [40, 95], light: [25, 70] },
+    { key: "orange", nameKey: "colourPicker.familyOrange", hue: [5, 55], sat: [50, 95], light: [35, 68] },
+    { key: "yellow", nameKey: "colourPicker.familyYellow", hue: [35, 70], sat: [55, 98], light: [40, 72] },
+    { key: "green", nameKey: "colourPicker.familyGreen", hue: [80, 165], sat: [20, 80], light: [18, 62] },
+    { key: "teal", nameKey: "colourPicker.familyTeal", hue: [150, 205], sat: [25, 85], light: [18, 58] },
+    { key: "blue", nameKey: "colourPicker.familyBlue", hue: [195, 250], sat: [30, 90], light: [22, 68] },
+    { key: "purple", nameKey: "colourPicker.familyPurple", hue: [245, 300], sat: [20, 80], light: [22, 68] },
+    { key: "pink", nameKey: "colourPicker.familyPink", hue: [285, 345], sat: [30, 90], light: [42, 82] },
+    { key: "brown", nameKey: "colourPicker.familyBrown", hue: [5, 55], sat: [15, 65], light: [10, 50], chipSat: 48, chipLight: 30 },
+    { key: "grey", nameKey: "colourPicker.familyGrey", hue: [0, 0], sat: [0, 0], light: [0, 100] },
+];
+
+export const HUE_CHIP_COUNT = 5;
+export const GOOD_CHIP_SAT = 72;
+export const GOOD_CHIP_LIGHT = 52;
+
+// Row-by-row saturation-option counts for a family's shade grid, light end to dark end: full
+// choice near the light end, narrowing toward the dark end where saturation stops making a
+// visible difference (in HSL, lightness 0 is black regardless of saturation).
+export const SHADE_ROW_SAT_COUNTS = [4, 4, 2, 1];
+
+// Greyscale bands, light end to dark end: same shape as SHADE_ROW_SAT_COUNTS, but each "column" is
+// a finer lightness step within the band (there's no saturation axis for grey), and the bottom
+// band collapses to exactly one swatch: true black.
+export const GREY_SHADE_BANDS: { light: [number, number], count: number }[] = [
+    { light: [80, 100], count: 4 },
+    { light: [52, 78], count: 4 },
+    { light: [20, 46], count: 2 },
+    { light: [0, 0], count: 1 },
+];
+
+export function familyHasHueChoice(family: ColourFamily): boolean {
+    return family.hue[1] - family.hue[0] > 3;
+}
+
+export function midOfRange(range: [number, number]): number {
+    return (range[0] + range[1]) / 2;
+}

--- a/src/helpers/vueComponentAPI.ts
+++ b/src/helpers/vueComponentAPI.ts
@@ -1,4 +1,4 @@
-import { AppComponentAPI, AutoCompletionComponentAPI, CaretContainerComponentAPI, CloudDriveHandlerComponentAPI, CommandsComponentAPI, EditImageDlgComponentAPI, EditSoundDlgComponentAPI, FrameComponentAPI, FrameHeaderComponentAPI, GoogleDriveFilePickerComponentAPI, LabelSlotComponentAPI, LabelSlotsStructureComponentAPI, MediaPreviewPopupComponentAPI, MenuComponentAPI, OpenDemoDlgComponentAPI, PEAComponentAPI, RecordImageDlgComponentAPI, RecordSoundDlgComponentAPI } from "@/types/vue-component-api-types";
+import { AppComponentAPI, AutoCompletionComponentAPI, CaretContainerComponentAPI, CloudDriveHandlerComponentAPI, ColourPickerDlgComponentAPI, CommandsComponentAPI, EditImageDlgComponentAPI, EditSoundDlgComponentAPI, FrameComponentAPI, FrameHeaderComponentAPI, GoogleDriveFilePickerComponentAPI, LabelSlotComponentAPI, LabelSlotsStructureComponentAPI, MediaPreviewPopupComponentAPI, MenuComponentAPI, OpenDemoDlgComponentAPI, PEAComponentAPI, RecordImageDlgComponentAPI, RecordSoundDlgComponentAPI } from "@/types/vue-component-api-types";
 
 /** Application-wide exposed Vue Components methods and accessors to data/computer props ( --> "API")
  * Done here because some of those Components are ALSO used in the store and in helpers scripts,
@@ -22,6 +22,7 @@ export const vueComponentsAPIHandler = {
     frameComponentAPI: null as null | FrameComponentAPI,
     frameHeaderComponentAPI: null as null | FrameHeaderComponentAPI,
     autoCompletionComponentAPI: null as null | AutoCompletionComponentAPI,
+    colourPickerDlgComponentAPI: null as null | ColourPickerDlgComponentAPI,
     // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
     peaComponentAPI: null as null | PEAComponentAPI,
     mediaPreviewPopupComponentAPI:null as null | MediaPreviewPopupComponentAPI,

--- a/src/localisation/en/en_main.json
+++ b/src/localisation/en/en_main.json
@@ -260,7 +260,8 @@
     "wrapSingleQuotes": "Wrap in '",
     "shiftKey": "Shift",
     "recordImageShortcut": "Record image",
-    "recordSoundShortcut": "Record sound"
+    "recordSoundShortcut": "Record sound",
+    "colourPickerShortcut": "Colour picker"
   },
   "commandTabs": {
     "0": "Add Frame"
@@ -321,7 +322,25 @@
     "micPermissionDenied": "Microphone access was denied. Please allow microphone access to record a sound.",
     "noCameraFound": "No camera was found on this device.",
     "noMicFound": "No microphone was found on this device.",
-    "recordingProcessingError": "There was a problem processing the recording. Please try again."
+    "recordingProcessingError": "There was a problem processing the recording. Please try again.",
+    "colourPickerTitle": "Pick a colour"
+  },
+  "colourPicker": {
+    "familyRed": "Red",
+    "familyOrange": "Orange",
+    "familyYellow": "Yellow",
+    "familyGreen": "Green",
+    "familyTeal": "Teal",
+    "familyBlue": "Blue",
+    "familyPurple": "Purple",
+    "familyPink": "Pink",
+    "familyBrown": "Brown",
+    "familyGrey": "Greyscale",
+    "allColours": "All colours",
+    "hue": "Hue",
+    "shade": "Shade",
+    "fineGrainedSelector": "Fine-grained selector…",
+    "tiles": "Tiles"
   },
   "book": {
     "dialogTitle": "Strype textbook"

--- a/src/localisation/fr/fr_main.json
+++ b/src/localisation/fr/fr_main.json
@@ -259,7 +259,8 @@
     "wrapSingleQuotes": "Entourer de '",
     "shiftKey": "Maj",
     "recordImageShortcut": "Enregistrer une image",
-    "recordSoundShortcut": "Enregistrer un son"
+    "recordSoundShortcut": "Enregistrer un son",
+    "colourPickerShortcut": "Sélecteur de couleur"
   },
   "commandTabs": {
     "0": "Ajoute un cadre"
@@ -320,7 +321,25 @@
     "micPermissionDenied": "L'accès au microphone a été refusé. Veuillez autoriser l'accès au microphone pour enregistrer un son.",
     "noCameraFound": "Aucune caméra n'a été trouvée sur cet appareil.",
     "noMicFound": "Aucun microphone n'a été trouvé sur cet appareil.",
-    "recordingProcessingError": "Un problème est survenu lors du traitement de l'enregistrement. Veuillez réessayer."
+    "recordingProcessingError": "Un problème est survenu lors du traitement de l'enregistrement. Veuillez réessayer.",
+    "colourPickerTitle": "Choisir une couleur"
+  },
+  "colourPicker": {
+    "familyRed": "Rouge",
+    "familyOrange": "Orange",
+    "familyYellow": "Jaune",
+    "familyGreen": "Vert",
+    "familyTeal": "Sarcelle",
+    "familyBlue": "Bleu",
+    "familyPurple": "Violet",
+    "familyPink": "Rose",
+    "familyBrown": "Marron",
+    "familyGrey": "Niveaux de gris",
+    "allColours": "Toutes les couleurs",
+    "hue": "Teinte",
+    "shade": "Nuance",
+    "fineGrainedSelector": "Sélecteur précis…",
+    "tiles": "Tuiles"
   },
   "book": {
     "dialogTitle": "Manuel Strype"

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1369,3 +1369,9 @@ export type EditSoundInDialogFunction = (sound: AudioBuffer, callback: (replacem
 export type RecordNewImageInDialogFunction = (callback: (replacement: { code: string, mediaType: string }) => void, onCancelled: () => void) => void;
 export type RecordNewSoundInDialogFunction = (callback: (replacement: { code: string, mediaType: string }) => void, onCancelled: () => void) => void;
 
+// Opens the colour picker dialog (Ctrl-Shift-L). initialColour, if given, seeds the picker (a hex
+// code or recognised CSS colour name); otherwise the picker starts from an arbitrary default.
+// callback receives the picked colour as a "#rrggbb" hex string only on "OK"; onCancelled is called
+// instead if the user cancels -- exactly one of the two is ever called.
+export type OpenColourPickerInDialogFunction = (initialColour: string | null, callback: (hex: string) => void, onCancelled: () => void) => void;
+

--- a/src/types/vue-component-api-types.ts
+++ b/src/types/vue-component-api-types.ts
@@ -151,6 +151,10 @@ export type AutoCompletionComponentAPI = {
   },
 }
 
+export type ColourPickerDlgComponentAPI = {
+  getHexValue: () => string | null,
+}
+
 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
 export type PEAComponentAPI = {
   togglePEALayout:(layoutMode: StrypePEALayoutMode, userTriggeredAction?: boolean) => void,

--- a/src/types/vue-component-api-types.ts
+++ b/src/types/vue-component-api-types.ts
@@ -116,6 +116,11 @@ export type LabelSlotComponentAPI = {
   forInstance: {
     [componentInstanceKey: string]: {
       handleUpDown: (event: KeyboardEvent) => boolean,
+      // Exposed so the clickable shortcut hints in Commands.vue can trigger these on whichever
+      // slot is currently focused, the same as if its own Ctrl-Shift-I/U/Y keyboard shortcut had
+      // been pressed directly.
+      triggerMediaRecording: (kind: "image" | "sound") => void,
+      triggerColourPicker: () => void,
     },
   }
 }

--- a/tests/playwright/e2e/colour-picker.spec.ts
+++ b/tests/playwright/e2e/colour-picker.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect, Page } from "@playwright/test";
+import { setupStrypeTest } from "../support/general";
+import { pressFrameShortcut, waitForEditorSettled } from "../support/editor";
+import { checkFrameErrorCount, checkConsoleContent, runToFinish } from "../support/execution";
+
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    // One test in this file (the U+200B regression test below) actually runs the program, so
+    // Pyodide can't be skipped for the whole file the way most dialog-only tests here otherwise
+    // would want -- matches check-error-locations.spec.ts's convention for the same reason.
+    await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 90000});
+});
+
+// Opens an "if" frame and leaves the caret in its (empty) expression slot -- same helper as
+// media-recording.spec.ts uses for its own shortcut-gating/insertion tests.
+async function openIfFrame(page: Page) {
+    await pressFrameShortcut(page, "i");
+    await waitForEditorSettled(page);
+}
+
+// Reads the raw (unstripped -- deliberately keeping any stray U+200B placeholder rather than
+// filtering it out like editor.ts's assertStateOfIfFrame helper does) text of the first new
+// top-level frame's header. A fresh page's default insertion caret sits above the default
+// project's own content, so as long as a test's very first action inserts exactly one new frame
+// (as openIfFrame/pressFrameShortcut do here), "#frameContainer_-3" always refers to that new
+// frame -- the same assumption editor.ts's assertStateOfIfFrame/assertStateOfVarAssignFrame make.
+async function getRawFrameHeaderText(page: Page): Promise<string> {
+    const scssVars = await page.evaluate(() => (window as any)["StrypeSCSSVarsGlobals"]);
+    return page.locator("#frameContainer_-3 ." + scssVars.frameHeaderClassName).first()
+        .locator(`.${scssVars.labelSlotInputClassName}, .${scssVars.frameColouredLabelClassName}`)
+        .evaluateAll((parts) => parts.map((p) => (p as any).value || p.textContent || "").join(""));
+}
+
+async function getGraphicsCenterPixel(page: Page): Promise<[number, number, number, number]> {
+    return page.evaluate(() => {
+        const canvas = document.getElementById("pythonGraphicsCanvas") as HTMLCanvasElement;
+        const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+        const {width, height} = canvas;
+        const d = ctx.getImageData(Math.floor(width / 2), Math.floor(height / 2), 1, 1).data;
+        return [d[0], d[1], d[2], d[3]];
+    });
+}
+
+function visibleCancelButton(page: Page) {
+    return page.locator(".btn.btn-secondary", {hasText: "Cancel"}).filter({visible: true});
+}
+
+function visibleOKButton(page: Page) {
+    return page.locator(".btn.btn-primary", {hasText: "OK"}).filter({visible: true});
+}
+
+test.describe("Colour picker shortcut gating", () => {
+    test("Ctrl-Shift-Y does nothing inside a comment frame", async ({page}) => {
+        await page.keyboard.press("#");
+        await waitForEditorSettled(page);
+        await page.keyboard.type("hello");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        // No good positive signal for "nothing happened", so just give it a moment then assert
+        // absence -- the dialog stays mounted (but hidden) in the DOM even when "closed", so we
+        // must check visibility, not mere presence (same pattern as media-recording.spec.ts):
+        await page.waitForTimeout(300);
+        await expect(page.locator("#colourPickerDlg")).not.toBeVisible();
+    });
+
+    test("Ctrl-Shift-Y opens the dialog in a plain expression slot", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await expect(page.locator("#colourPickerDlg")).toBeVisible();
+        await visibleCancelButton(page).click();
+    });
+
+    test("Ctrl-Shift-Y opens the dialog inside a string slot too, unlike the media-recording shortcuts", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.type("\"notacolour");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await expect(page.locator("#colourPickerDlg")).toBeVisible();
+        await visibleCancelButton(page).click();
+    });
+});
+
+test.describe("Family grid / tinker view / fine-grained selector navigation", () => {
+    test("Selecting a family switches to the tinker view with hue chips and a shade grid", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await page.locator(".ColourPickerDlg-family-btn", {hasText: "Green"}).click();
+        await expect(page.locator(".ColourPickerDlg-chip").first()).toBeVisible();
+        await expect(page.locator(".ColourPickerDlg-shade-cell").first()).toBeVisible();
+        await visibleCancelButton(page).click();
+    });
+
+    test("Fine-grained selector shows the hue slider, SV square and hex input, and Tiles returns to the grid", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        await expect(page.locator(".ColourPickerDlg-hue-slider")).toBeVisible();
+        await expect(page.locator(".ColourPickerDlg-sv-square")).toBeVisible();
+        await expect(page.locator("#ColourPickerDlg-hex-input")).toBeVisible();
+
+        // Fresh insert (no family was picked first) -- toggling away from the fine-grained
+        // selector goes back to the family grid, not the tinker view:
+        await page.locator("button", {hasText: "Tiles"}).click();
+        await expect(page.locator(".ColourPickerDlg-family-btn").first()).toBeVisible();
+        await visibleCancelButton(page).click();
+    });
+});
+
+test.describe("Graphics preview", () => {
+    test("Does not flood-fill until a colour is actually picked, then reflects the choice", async ({page}) => {
+        await openIfFrame(page);
+        const before = await getGraphicsCenterPixel(page);
+
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await expect(page.locator("#colourPickerDlg")).toBeVisible();
+        // Fresh insert, family grid showing, nothing picked yet -- the graphics area must be
+        // untouched (this is the bug that was reported: a default red flood-fill appeared here
+        // before any colour had been chosen):
+        await page.waitForTimeout(300);
+        expect(await getGraphicsCenterPixel(page)).toEqual(before);
+
+        await page.locator(".ColourPickerDlg-family-btn", {hasText: "Green"}).click();
+        await expect.poll(() => getGraphicsCenterPixel(page)).not.toEqual(before);
+
+        await visibleCancelButton(page).click();
+    });
+
+    test("Typing an exact hex value in the fine-grained selector previews that exact colour", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        await page.locator("#ColourPickerDlg-hex-input").fill("#3366cc");
+        await expect.poll(() => getGraphicsCenterPixel(page)).toEqual([0x33, 0x66, 0xcc, 255]);
+        await visibleCancelButton(page).click();
+    });
+});
+
+test.describe("Inserting and editing colour string literals", () => {
+    test("Typing a hex value and confirming inserts that literal string into an empty expression slot", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        await page.locator("#ColourPickerDlg-hex-input").fill("#3366cc");
+        await visibleOKButton(page).click();
+        await waitForEditorSettled(page);
+
+        const text = await getRawFrameHeaderText(page);
+        expect(text).toContain("#3366cc");
+        // A bare condition consisting of just a string literal is valid Python (truthy check), so
+        // this should never show a syntax error:
+        await checkFrameErrorCount(page, 0);
+    });
+
+    test("Invoking the picker inside an existing string replaces its whole content with the picked hex", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.type("\"notacolour");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await expect(page.locator("#colourPickerDlg")).toBeVisible();
+        // Editing existing (invalid) string content jumps straight into the fine-grained selector
+        // (see onShownModalDlg in ColourPickerDlg.vue), so the "Fine-grained selector..." toggle
+        // button isn't shown here -- only click it if we're not already there:
+        if (!(await page.locator("#ColourPickerDlg-hex-input").isVisible())) {
+            await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        }
+        await page.locator("#ColourPickerDlg-hex-input").fill("#996633");
+        await visibleOKButton(page).click();
+        await waitForEditorSettled(page);
+
+        const text = await getRawFrameHeaderText(page);
+        expect(text).toContain("#996633");
+        expect(text).not.toContain("notacolour");
+        await checkFrameErrorCount(page, 0);
+    });
+
+    // Regression test for the original "invalid input character" bug: a zero-width-space
+    // placeholder character (U+200B) -- used internally as the empty-slot DOM placeholder, and
+    // legitimately present cosmetically all over a frame's raw DOM text (e.g. around brackets/
+    // labels, confirmed empirically while writing this test) -- was being captured un-stripped
+    // into the actual generated code whenever the colour picker's target field was otherwise
+    // empty and had a structural sibling immediately after it (most easily reproduced on a
+    // function call's own empty argument slot, immediately followed by its closing bracket). The
+    // bug was a broken regex (missing the \u escape) in LabelSlot.vue that matched the literal
+    // text "200B" instead of the actual placeholder character, so it was never actually being
+    // stripped -- Skulpt's tokenizer then choked on the leftover character at run time with a
+    // cryptic "invalid input character" error. Since the placeholder is harmless in the DOM by
+    // itself, the only way to genuinely tell the fixed and broken behaviour apart is to actually
+    // run the result: the fixed version prints a clean hex string, the broken one crashes.
+    test("Replacing an empty argument slot never leaves a stray placeholder that breaks execution", async ({page}) => {
+        // Typing "print(" directly at the top-level "insert new frame" caret starts a func-call
+        // frame named "print" (see "Typing a character at the bare frame caret starts a func-call
+        // frame" in editor.ts), then leaves the caret in its own (empty) argument slot, immediately
+        // followed by the call's closing-bracket sibling field -- the same shape as the original bug:
+        await page.keyboard.type("print(");
+        await waitForEditorSettled(page);
+
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await expect(page.locator("#colourPickerDlg")).toBeVisible();
+        await page.locator(".ColourPickerDlg-family-btn", {hasText: "Blue"}).click();
+        await page.locator(".ColourPickerDlg-shade-cell").first().dblclick();
+        await waitForEditorSettled(page);
+
+        await checkFrameErrorCount(page, 0);
+        await runToFinish(page, true);
+        // Our new print(...) is inserted above the default project's own "print(myString)" line,
+        // so its output comes first, followed by the pre-existing "Hello from Strype" -- the key
+        // thing being tested is that a clean hex string appears at all, rather than a crash:
+        await checkConsoleContent(page, /^#[0-9a-f]{6}\nHello from Strype\s*$/i);
+    });
+});


### PR DESCRIPTION
## Summary
- The colour picker's hex text field is now always visible (previously only shown in the fine-grained selector), and editing it re-runs the same "just opened" logic: an exact tile match jumps to that tile in the tinker view, otherwise it falls through to the fine-grained selector.
- Fixed a bug where picking a colour family never highlighted a shade tile: the default sat/light was the family range's raw midpoint, which doesn't land on any actual grid cell (rows/columns sit at fixed fractions of the range). Now it snaps to the real cell closest in RGB terms to the colour shown at the top of the tinker view (the selected hue chip, or the family swatch for hue-less families like grey).

## Test plan
- [x] `vue-tsc --noEmit` passes
- [ ] Manually open the colour picker (Ctrl+Shift+Y), click through several families and confirm a shade tile is highlighted each time
- [ ] Type a hex value while in tile view and confirm it switches views/selects correctly
- [ ] Run `npm run test:playwright` for `colour-picker.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)