### PR TITLE
Fix required status check to work with the Cypress test matrix

### DIFF
--- a/.github/workflows/run-cypress-tests.yml
+++ b/.github/workflows/run-cypress-tests.yml
@@ -16,7 +16,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 jobs:
-  Build-And-Run-Tests:
+  Build-And-Run-Tests-Matrix:
     # See the branches-ignore comment above -- this is the pull_request-side equivalent (head_ref
     # is only set for pull_request events; a push that reaches this point already isn't excluded):
     if: ${{ !startsWith(github.head_ref, 'no-ci-') }}
@@ -67,4 +67,20 @@ jobs:
               tests/cypress/screenshots
               tests/cypress/videos
             if-no-files-found: ignore
+
+  # Branch protection requires a single check named "Build-And-Run-Tests" to pass, but the matrix
+  # above produces one check per combination (e.g. "Build-And-Run-Tests-Matrix (python,
+  # ubuntu-latest, 0)"), none of which is ever named exactly that -- so the required check would
+  # sit pending forever. This gate job depends on the whole matrix via a single job id, so it
+  # stays correct as matrix entries are added or removed, and reports the aggregate result under
+  # the exact name branch protection expects.
+  Build-And-Run-Tests:
+    name: Build-And-Run-Tests
+    needs: Build-And-Run-Tests-Matrix
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        if: ${{ needs.Build-And-Run-Tests-Matrix.result != 'success' && needs.Build-And-Run-Tests-Matrix.result != 'skipped' }}
+        run: exit 1
 


### PR DESCRIPTION
## Summary
- Branch protection on `main` requires a single status check literally named `Build-And-Run-Tests`, but the Cypress workflow's matrix job produces one check per combination (e.g. `Build-And-Run-Tests (python, ubuntu-latest, 0)`) -- none of which is ever named exactly `Build-And-Run-Tests`. The required check therefore never reports success and just sits pending forever (this is what blocked #1048's auto-merge despite every actual job passing).
- Renames the matrix job to `Build-And-Run-Tests-Matrix` and adds a small gate job named exactly `Build-And-Run-Tests` that `needs` it and fails if the matrix didn't succeed. Since the gate depends on the matrix job by id (not by enumerating each combination), it stays correct if matrix entries are added or removed in future.

## Follow-up (not in this PR)
- Someone with admin rights on the repo still needs to confirm/re-save the required status check in Settings -> Branches -> main (it should already match by name, but GitHub sometimes needs the check re-selected after a job rename).

## Test plan
- [ ] CI on this PR passes, including the new `Build-And-Run-Tests` gate job
- [ ] Confirm the gate job shows up as satisfying the required check once merged