### PR TITLE
Add colour literals: auto-detect/convert hex-colour strings to a colour swatch

### DIFF
--- a/docs/claude-colour-literals/PLAN.md
+++ b/docs/claude-colour-literals/PLAN.md
@@ -1,0 +1,268 @@
+# Colour literals — implementation plan
+
+Status: **not started**. Written up during planning (high effort), ready to execute
+(intended to be run at low effort, picking up straight from this file).
+
+## Goal
+
+Add a third kind of literal alongside the existing image/sound media literals:
+a colour literal. Unlike image/sound, it has no function-call underlying code —
+its underlying Python code is just a plain quoted string matching `#aabbcc`
+(6 hex digits). It should:
+
+- show a preview dialog (on hover) with a filled rectangle of the colour, plus
+  an Edit button that opens the existing colour-picker dialog (`ColourPickerDlg.vue`,
+  already wired up to Ctrl+Shift+Y)
+- auto-convert from a plain string to a colour literal when the user types a
+  matching pattern into a string **and the cursor leaves that string** (not
+  while still typing/partway through)
+- auto-convert when loading existing `.py` programs that contain a matching
+  plain string literal
+- generate Python identical to the underlying code (the bare quoted string),
+  exactly like image/sound literals already do
+- behave like existing media literals otherwise: single-character-wide in the
+  editor, same navigation/deletion/copy-paste behaviour
+
+## Core design decision
+
+A colour literal is a `MediaSlot` (`src/types/types.ts`) with `mediaType: "colour"`
+and `code` equal to the bare quoted string itself (e.g. `"#aabbcc"`), **not** a
+function call. All the generic `SlotType.media` machinery (1-char-wide navigation,
+flattening via `generateFlatSlotBases`, undo/redo, Python codegen in `parser.ts`/
+`editor.ts`, copy/paste round-trip via `data-code`/`data-mediaType` attributes) is
+already `mediaType`-agnostic and needs **no changes**. The work is entirely about:
+(a) detecting/converting a plain string into this shape at the right moments, and
+(b) colour-specific preview/edit UI.
+
+Existing prior art already on this branch:
+- `MediaSlot`/`isFieldMediaSlot` (`src/types/types.ts:59-95`) — image/sound literals.
+- The colour picker dialog itself: `ColourPickerDlg.vue`, `helpers/colour.ts`
+  (`parseColourToHex`, `hexToHsv`/`hsvToHex`/etc., `COLOUR_FAMILIES`), already
+  wired to Ctrl+Shift+Y via `triggerColourPicker()` in `LabelSlot.vue` (~line 1076),
+  which today inserts/replaces a **plain string literal** (`SlotType.string`) with
+  the picked hex — this plan changes that to insert/convert to the new colour
+  `MediaSlot` instead (see §3).
+
+---
+
+## 1. Detection helper — `src/helpers/colour.ts`
+
+Add:
+```ts
+export function isHexColourLiteral(s: string): boolean {
+    return /^#[0-9a-fA-F]{6}$/.test(s);
+}
+```
+Keep this separate from the existing, more lenient `parseColourToHex` (accepts CSS
+names, `rgb()`, etc. — used only to *seed* the picker from arbitrary content).
+`isHexColourLiteral` is the strict predicate used for auto-detection (typing-blur
+and python-load). Wherever a match becomes stored `code`, normalise the hex digits
+to lowercase (matches `parseColourToHex`'s own canvas-based normalisation).
+
+## 2. Data model — `src/types/types.ts`
+
+No new interface needed. Reuse `MediaSlot`/`isFieldMediaSlot` unchanged. Add a
+one-line comment near the existing "For MediaSlot, code contains: load_image(...)"
+comment (~line 63) noting `mediaType: "colour"` is the exception where `code` is a
+bare quoted string, not a function call.
+
+## 3. Ctrl+Shift+Y insertion — `src/components/LabelSlot.vue` `triggerColourPicker()` (~line 1076)
+
+Two branches, **both now produce a colour `MediaSlot` immediately** (no reliance
+on §4's blur mechanism):
+
+- **Not-in-string branch** (~line 1135, `commitInsertion`): replace
+  `this.appStore.addNewSlot(targetSlotInfos, "\"", lhsCode, rhsCode, SlotType.string, false, hex)`
+  with the media form:
+  `addNewSlot(targetSlotInfos, "colour", lhsCode, rhsCode, SlotType.media, false, "\"" + hex + "\"")`.
+  This is the existing generic `addNewSlot` `SlotType.media` branch
+  (`store.ts:967-990`) — no store changes needed here. Cursor placement into the
+  trailing sibling field (`slotIndex + 2` after the splice) already works exactly
+  as today (see the existing `commitInsertion` cursor-placement code, mirrored
+  from `triggerMediaRecording`).
+
+- **In-string branch** (~line 1102, `commitReplacement`): **per discussion,
+  converts and places the cursor in the adjacent field**, rather than leaving the
+  cursor "inside" the (now atomic) literal. Concretely:
+  - New store action in `src/store/store.ts`, e.g.
+    `convertStringSlotToColourLiteral(slotInfos: SlotCoreInfos, hex: string)`:
+    - resolve the parent fields array + index via `getSlotParentIdAndIndexSplit`
+      (same pattern `addNewSlot` already uses, `store.ts:945-948`)
+    - read the *existing* `StringSlot.quote` before overwriting (preserves `'`
+      vs `"`)
+    - snapshot state (`cloneDeep(this.$state)`), replace
+      `parentFieldSlot.fields[index] = {mediaType: "colour", code: quote + hex.toLowerCase() + quote} as MediaSlot`
+      **in place at the same index** (no splice needed — a string slot is always
+      already flanked by its own lhs/rhs sibling fields from whenever it was
+      originally created, since `addNewSlot`'s string branch always wraps
+      `[lhs, string, rhs]`, so "adjacent" already exists structurally)
+    - `saveStateChanges(stateBeforeChanges)` (single undo step)
+  - `commitReplacement` calls this instead of `setFrameEditableSlotContent`, then
+    places the cursor at position 0 of the sibling field at `slotIndex + 1`
+    (same `setDocumentSelection`/`setSlotTextCursors`/`setFocusEditableSlot`
+    triple pattern already used in `commitInsertion` elsewhere in this file).
+
+## 4. Organic typing + blur conversion
+
+The "user typed `#aabbcc` by hand and the cursor left the string" case. Reuses the
+existing reparse pipeline rather than a bespoke mutation, so cursor repositioning,
+undo/redo, and "structural change" re-rendering (`majorChange`/`refactorCount`)
+all come for free.
+
+- `parseCodeLiteral`'s string-handling branch (`src/helpers/editor.ts:1717-1746`)
+  is the single place every string literal becomes a `StringSlot` (line 1740:
+  `const structOfString: StringSlot = {code: stringContentCode, quote: openingQuoteValue};`).
+  Right before building it, compute:
+  - `cursorInsideThisString = flags?.cursorPos !== undefined && flags.cursorPos >= openingQuoteIndex && flags.cursorPos <= closingQuoteIndex`
+    (inclusive bounds — ambiguous/boundary cases default to "still inside", i.e.
+    don't convert).
+  - `hasPrefix`: heuristic check that `beforeStringCode`'s tail isn't a bare
+    `f`/`r`/`b` (or 2-letter combo, case-insensitive) directly touching the
+    opening quote with no separating space/operator. Guards against converting
+    `f"#aabbcc"`/`r"#aabbcc"`/`b"#aabbcc"` — these are constructed live exactly
+    the same way a plain string is (via `addNewSlot`'s string branch taking
+    whatever `lhsCode` preceded the typed quote character).
+  - If `!cursorInsideThisString && !hasPrefix && isHexColourLiteral(stringContentCode)`,
+    build a `MediaSlot` (`{mediaType: "colour", code: quote + stringContentCode.toLowerCase() + quote}`)
+    instead of the `StringSlot`. Everything downstream is already generic:
+    `checkSlotRefactoring`'s `$nextTick` cursor-repositioning block already
+    special-cases `labelSlotMediaClassName` as 1-char-wide
+    (`LabelSlotsStructure.vue:572-577`).
+
+- **Trigger**: mere cursor movement (Tab / click-away / arrow-out) never fires
+  `onInput`, so `checkSlotRefactoring` never runs on blur today — this needs a new
+  trigger. In `LabelSlot.vue onLoseCaret` (~line 712), when
+  `this.slotType === SlotType.string`, emit the existing `requestSlotsRefactoring`
+  event (already listened to at `LabelSlotsStructure.vue:36`,
+  `@requestSlotsRefactoring="checkSlotRefactoring"`) with a new option:
+  `{useFlatMediaDataCode: true, treatAsBlurred: true}`.
+
+- **New plumbing needed** (the one real wrinkle found while planning): add
+  `treatAsBlurred?: boolean` to `checkSlotRefactoring`'s options type
+  (`LabelSlotsStructure.vue:508`). At line 541, change the `cursorPos` computation
+  to:
+  `cursorPos: (options?.skipCursorSetAndStateSave || options?.treatAsBlurred) ? undefined : focusCursorAbsPos`
+  — deliberately *not* reusing `skipCursorSetAndStateSave` alone, since that flag
+  also skips `saveStateChanges`, which must still run (the conversion needs to be
+  a real undo step). Also skip the `$nextTick` cursor-repositioning block under
+  `treatAsBlurred` (nothing to reposition into — we're leaving the slot). With
+  `cursorPos` forced `undefined`, every string in the label reads as "cursor not
+  inside" for that one reparse pass, which is exactly correct for a
+  blur-triggered pass.
+
+## 5. Rendering & preview UI
+
+- **`LabelSlot.vue loadMediaPreview()`** (~line 2070): add a
+  `mediaType === "colour"` branch that draws a filled square on an offscreen
+  canvas from the hex (stripped of quotes) and returns
+  `{mediaType: "colour", imageDataURL: canvas.toDataURL()}`. Reuses the existing
+  `<img v-if="isMediaSlot">` template branch (~line 37) and the
+  `.limited-height-inline-image` CSS (`max-height: 1.5em`, ~line 2270) — no
+  template/CSS changes needed; the swatch will render at roughly
+  one-character-width automatically.
+- **`MediaPreviewPopup.vue`**: inject `openColourPickerInDialog` alongside the
+  existing `editImageInDialog`/`editSoundInDialog`. In `doEdit()` (~line 192),
+  branch on `mediaType === "colour"` to call it instead of the image/sound edit
+  dialogs. Per spec ("just shows the colour in a filled rectangle, then an edit
+  button"), hide the Preview/Download buttons and the image/sound header link for
+  colour (`v-if="mediaType !== 'colour'"` or similar) — show the hex text itself
+  as the header instead (may avoid needing a new i18n key).
+
+## 6. Loading existing Python programs — `src/helpers/pythonToFrames.ts`
+
+In `toSlots()`'s terminal-string branch (~line 890-901), where `strMatch` already
+separates prefix (`strMatch[1]`), quote (`strMatch[2]`), and content — the single
+place plain string tokens are constructed (f-strings are a different, compound
+parse-tree node and never reach this branch, so no separate f-string guard is
+needed here, unlike in §4). When `strMatch[1] === ""` (no prefix) and
+`isHexColourLiteral(content)`, return a `MediaSlot` field instead of the
+`StringSlot`, in the same `{fields:[blank, X, blank], operators:[blank, blank]}`
+shape already used for both cases. No need to touch
+`replaceMediaLiteralsAndInvalidOps` (~line 777) — that function's pattern
+(ident-then-bracket, for `load_image(...)`/`load_sound(...)`) doesn't apply to a
+bare string token.
+
+## 7. Python codegen / round-trip — verify only, likely no changes
+
+`parser.ts` (~line 829, `getSlotStartsLengthsAndCodeForFrameLabel`) and
+`editor.ts slotStructureParserToString` (~line 2385) already emit `field.code`
+as-is for any `SlotType.media`/`isFieldMediaSlot` field, generic over
+`mediaType` — a colour literal's `code` (`"#aabbcc"`) comes out correctly
+unchanged.
+
+Minor polish item (low priority, optional): `parser.ts`'s `omitMediaLiterals`
+truncation (~line 832, used for lightweight autocomplete/TigerPython parsing)
+does `flatSlot.code.replace(/"[^"]+"/, "\"\"")`, which would blank a colour
+literal's short hex string for no real benefit (it exists to strip huge base64
+blobs, not 9-character strings). Consider gating it on `mediaType !== "colour"`
+if it turns out to cause any visible issue; otherwise leave as-is.
+
+## 8. Copy/paste & drag/drop within Strype — verify only, likely no changes
+
+The generic `data-code`/`data-mediaType` round-trip in
+`getFrameLabelSlotLiteralCodeAndFocus` (`editor.ts:410-416`) already treats any
+`SlotType.media` uniformly — copying/pasting frames containing a colour literal
+within Strype should work with no new code, same as images/sounds today. Confirm
+with a manual/e2e test rather than code changes.
+
+## 9. i18n
+
+Add any new popup-header string (§5) to `src/localisation/en/en_main.json` under
+`media` (existing keys `media.edit`/`media.preview` etc. are reusable as-is for
+non-colour branches). Ideally also add to `fr/fr_main.json` (the colour picker
+already has French strings under `colourPicker.*`). Other locales (`de`, `el`,
+`es`, `zh`) fall back to English for missing keys — not blocking.
+
+## 10. Edge cases to handle deliberately
+
+- Prefixed strings (`f"..."`, `r"..."`, `b"..."`) must never auto-convert (§4 and
+  §6 guards).
+- Only exactly 6 hex digits after `#` — no 3-digit shorthand, no alpha channel,
+  no CSS colour names auto-converting (only via the explicit picker, §3).
+- Accept upper/lower/mixed case on input; normalise stored `code` to lowercase.
+- Both `"` and `'` must be preserved through conversion (the `quote` field
+  already carries the real character, not a UI glyph).
+- Blur-conversion must be a single undo step (`saveStateChanges`); undo should
+  cleanly restore the original string (automatic — whole-state snapshot).
+- Typing `#aabbcc_foo` (i.e. no longer matching at blur time) must leave it as a
+  plain string — the check only fires once, at blur, against the final content.
+- Race condition: typing the last hex digit then immediately blurring in the same
+  tick — verify ordering between the in-flight `onInput`-triggered reparse and
+  the new blur-triggered one.
+- A colour-looking string that is the *last* field in its label vs. not — confirm
+  the inclusive cursor-bounds guard behaves correctly either way.
+
+## 11. Testing
+
+- Vitest unit tests: `isHexColourLiteral`; `pythonToFrames.ts` load-time
+  conversion (plain string → colour; `f`/`r`/`b`-prefixed → unchanged;
+  non-matching content → unchanged).
+- Cypress/Playwright e2e:
+  - type `#aabbcc` in a string, tab/click away → becomes a swatch
+  - same but `f"#aabbcc"` → stays a plain string
+  - Ctrl+Shift+Y outside a string → inserts swatch, cursor lands adjacent after it
+  - Ctrl+Shift+Y inside an existing string → converts immediately, cursor lands
+    adjacent after it (§3)
+  - hover swatch → popup shows rectangle + Edit button → Edit reopens colour
+    picker seeded correctly
+  - load a `.py` file containing a bare `"#aabbcc"` string → renders as a colour
+    literal
+  - copy/paste a frame containing a colour literal (within Strype)
+  - undo/redo across the auto-conversion
+  - Python-export round-trip (`getFullCode()`) reproduces the exact original
+    quoted string
+
+## Suggested implementation order
+
+1. `helpers/colour.ts` — `isHexColourLiteral` (§1).
+2. `checkSlotRefactoring`/`parseCodeLiteral` — `treatAsBlurred` plumbing +
+   conversion logic at `editor.ts:1740`, `onLoseCaret` trigger (§4) — the core
+   new mechanic; everything else is comparatively mechanical once this exists.
+3. New store action (`convertStringSlotToColourLiteral`) +
+   `triggerColourPicker`'s two branches (§3).
+4. `loadMediaPreview` swatch rendering (§5).
+5. `MediaPreviewPopup.vue` colour branch + colour-picker injection (§5).
+6. `pythonToFrames.ts` load-time detection (§6).
+7. i18n strings (§9).
+8. Manual verification of §7/§8 (should need no code changes), then the full
+   test pass (§11).

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -2083,7 +2083,19 @@ export default defineComponent({
 
         async loadMediaPreview(): Promise<LoadedMedia> {
             let slot = retrieveSlotFromSlotInfos(this.coreSlotInfo) as MediaSlot;
-            if (slot.mediaType.startsWith("image") && !slot.mediaType.startsWith("image/svg+xml")) {
+            if (slot.mediaType === "colour") {
+                const hex = slot.code.replace(/["']/g, "");
+                const canvas = document.createElement("canvas");
+                canvas.width = 32;
+                canvas.height = 32;
+                const ctx = canvas.getContext("2d");
+                if (ctx) {
+                    ctx.fillStyle = hex;
+                    ctx.fillRect(0, 0, canvas.width, canvas.height);
+                }
+                return {mediaType: slot.mediaType, imageDataURL: canvas.toDataURL()};
+            }
+            else if (slot.mediaType.startsWith("image") && !slot.mediaType.startsWith("image/svg+xml")) {
                 return {mediaType: slot.mediaType, imageDataURL: "data:" + slot.mediaType + ";" + /base64,[^"']+/.exec(slot.code)?.[0]};
             }
             else if (slot.mediaType.startsWith("audio")) {

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -1110,14 +1110,18 @@ export default defineComponent({
                 };
 
                 const commitReplacement = (hex: string) => {
-                    this.appStore.setFrameEditableSlotContent({...targetSlotInfos, code: hex, initCode: "", isFirstChange: true});
-                    const cursorInfo: SlotCursorInfos = {slotInfos: targetSlotInfos, cursorPos: hex.length};
+                    // Converts the whole string to a colour literal (now an atomic, 1-char-wide field), so
+                    // rather than leaving the cursor "inside" it, we place it in the adjacent sibling field.
+                    this.appStore.convertStringSlotToColourLiteral(targetSlotInfos, hex);
+                    const {parentId, slotIndex} = getSlotParentIdAndIndexSplit(targetSlotInfos.slotId);
+                    const rhsSlotInfos: SlotCoreInfos = {...targetSlotInfos, slotId: getSlotIdFromParentIdAndIndexSplit(parentId, slotIndex + 1)};
+                    const cursorInfo: SlotCursorInfos = {slotInfos: rhsSlotInfos, cursorPos: 0};
                     nextTick(() => {
                         setDocumentSelection(cursorInfo, cursorInfo);
                         this.appStore.setSlotTextCursors(cursorInfo, cursorInfo);
                         this.appStore.setFocusEditableSlot({
-                            frameSlotInfos: targetSlotInfos,
-                            caretPosition: this.appStore.getAllowedChildren(targetSlotInfos.frameId) ? CaretPosition.body : CaretPosition.below,
+                            frameSlotInfos: rhsSlotInfos,
+                            caretPosition: this.appStore.getAllowedChildren(rhsSlotInfos.frameId) ? CaretPosition.body : CaretPosition.below,
                         });
                     });
                 };
@@ -1143,9 +1147,9 @@ export default defineComponent({
                 };
 
                 const commitInsertion = (hex: string) => {
-                    this.appStore.addNewSlot(targetSlotInfos, "\"", lhsCode, rhsCode, SlotType.string, false, hex);
+                    this.appStore.addNewSlot(targetSlotInfos, "colour", lhsCode, rhsCode, SlotType.media, false, "\"" + hex + "\"");
                     // Place the cursor in the new trailing (empty) field right after the inserted
-                    // string, mirroring commitInsertion in triggerMediaRecording above:
+                    // colour literal, mirroring commitInsertion in triggerMediaRecording above:
                     const {parentId, slotIndex} = getSlotParentIdAndIndexSplit(targetSlotInfos.slotId);
                     const rhsSlotInfos: SlotCoreInfos = {...targetSlotInfos, slotId: getSlotIdFromParentIdAndIndexSplit(parentId, slotIndex + 2)};
                     const cursorInfo: SlotCursorInfos = {slotInfos: rhsSlotInfos, cursorPos: 0};

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -736,6 +736,16 @@ export default defineComponent({
                         keepEditingModeOn
                     );
                 }
+                // Give a plain string one last check as we leave it: if its content now matches a hex
+                // colour literal (e.g. the user just typed "#aabbcc"), auto-convert it to a colour swatch.
+                // Mere cursor movement (Tab/click-away/arrow-out) never fires onInput, so this is the only
+                // point such a conversion can happen -- reusing the same reparse pipeline as organic typing
+                // gets cursor repositioning, undo/redo and structural re-rendering for free.
+                if (this.slotType === SlotType.string) {
+                    const stateBeforeChanges = cloneDeep(this.appStore.$state);
+                    this.$emit(CustomEventTypes.requestSlotsRefactoring, this.UID, stateBeforeChanges, {useFlatMediaDataCode: true, treatAsBlurred: true});
+                }
+
                 //reset the flag for first code change
                 this.isFirstChange = true;
 

--- a/src/components/LabelSlot.vue
+++ b/src/components/LabelSlot.vue
@@ -2093,7 +2093,7 @@ export default defineComponent({
                     ctx.fillStyle = hex;
                     ctx.fillRect(0, 0, canvas.width, canvas.height);
                 }
-                return {mediaType: slot.mediaType, imageDataURL: canvas.toDataURL()};
+                return {mediaType: slot.mediaType, imageDataURL: canvas.toDataURL(), hex: hex};
             }
             else if (slot.mediaType.startsWith("image") && !slot.mediaType.startsWith("image/svg+xml")) {
                 return {mediaType: slot.mediaType, imageDataURL: "data:" + slot.mediaType + ";" + /base64,[^"']+/.exec(slot.code)?.[0]};

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -505,7 +505,7 @@ export default defineComponent({
             return true;
         },
 
-        checkSlotRefactoring(slotUID: string, stateBeforeChanges: any, options?: {skipCursorSetAndStateSave?: boolean, skipStateSaveOnly?: boolean, doAfterCursorSet?: VoidFunction, useFlatMediaDataCode?: boolean, ignoreBlurEditableSlot?: boolean, triggeredByEnter?: boolean}) {
+        checkSlotRefactoring(slotUID: string, stateBeforeChanges: any, options?: {skipCursorSetAndStateSave?: boolean, skipStateSaveOnly?: boolean, doAfterCursorSet?: VoidFunction, useFlatMediaDataCode?: boolean, ignoreBlurEditableSlot?: boolean, triggeredByEnter?: boolean, treatAsBlurred?: boolean}) {
             // Slot errors will be check later again. We clear off the notification on the parent (frame header) for slot errors so it can reset the triangle error indicator
             vueComponentsAPIHandler.frameHeaderComponentAPI?.forInstance[this.frameId].setHasErroneousSlot(false);
             // Comments do not need to be checked, so we do nothing special for them, but just enforce the caret to be placed at the right place and the code value to be updated
@@ -538,7 +538,7 @@ export default defineComponent({
                 // As we will need to reposition the cursor, we keep a reference to the "absolute" position in this label's slots,
                 // so we find that out while getting through all the slots to get the literal code.
                 let {uiLiteralCode, focusSpanPos: focusCursorAbsPos, hasStringSlots, mediaLiterals} = getFrameLabelSlotLiteralCodeAndFocus(labelDiv, slotUID, {useFlatMediaDataCode: options?.useFlatMediaDataCode});
-                const parsedCodeRes = parseCodeLiteral(uiLiteralCode, {frameType: this.appStore.frameObjects[this.frameId].frameType.type, isInsideString: false, cursorPos: options?.skipCursorSetAndStateSave ? undefined : focusCursorAbsPos, skipStringEscape: hasStringSlots, imageLiterals: mediaLiterals});
+                const parsedCodeRes = parseCodeLiteral(uiLiteralCode, {frameType: this.appStore.frameObjects[this.frameId].frameType.type, isInsideString: false, cursorPos: (options?.skipCursorSetAndStateSave || options?.treatAsBlurred) ? undefined : focusCursorAbsPos, skipStringEscape: hasStringSlots, imageLiterals: mediaLiterals});
                 const majorChange = this.majorChange(this.appStore.frameObjects[this.frameId].labelSlotsDict[this.labelIndex].slotStructures, parsedCodeRes.slots);
                 // Chrome triggers a loss and reset of focus when the slots structure (and only structurally speaking) are changed in the store, typically when inserting operators
                 // so might want to ignore the events in this situation (ignore blur fully, and partially ignore refocus as some things in focus() should not be done).
@@ -554,6 +554,13 @@ export default defineComponent({
                     this.refactorCount += 1;
                 }
                 this.$forceUpdate();
+                if (options?.treatAsBlurred) {
+                    // We're leaving the slot (e.g. a string just auto-converted to a colour literal on
+                    // blur), so there's no cursor position to restore into -- just persist the change as
+                    // its own undo step.
+                    this.$nextTick(() => this.appStore.saveStateChanges(stateBeforeChanges));
+                    return;
+                }
                 this.$nextTick(() => {
                     // If it was a major change, our entire old div element may have been removed
                     // from the tree and re-added, so it's crucial we refetch the new element in

--- a/src/components/MediaPreviewPopup.vue
+++ b/src/components/MediaPreviewPopup.vue
@@ -10,8 +10,8 @@
             <span class="MediaPreviewPopup-header-text" v-html="mediaInfo"></span>
         </div>
         <div class="MediaPreviewPopup-controls">
-            <BButton size="sm" variant="outline-success" class="MediaPreviewPopup-header-preview-button" @click="doPreview">{{$t("media.preview")}}</BButton>
-            <BButton size="sm" variant="outline-success" class="MediaPreviewPopup-header-download-button" @click="doDownload"><i class="fa fa-download"></i></BButton>
+            <BButton v-if="mediaType !== 'colour'" size="sm" variant="outline-success" class="MediaPreviewPopup-header-preview-button" @click="doPreview">{{$t("media.preview")}}</BButton>
+            <BButton v-if="mediaType !== 'colour'" size="sm" variant="outline-success" class="MediaPreviewPopup-header-download-button" @click="doDownload"><i class="fa fa-download"></i></BButton>
             <BButton size="sm" variant="outline-danger" class="MediaPreviewPopup-header-edit-button" @click="doEdit">{{$t("media.edit")}}</BButton>
         </div>
         <div class="MediaPreviewPopup-img-container-wrapper">
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import {EditImageInDialogFunction, EditSoundInDialogFunction, LoadedMedia} from "@/types/types";
+import {EditImageInDialogFunction, EditSoundInDialogFunction, LoadedMedia, OpenColourPickerInDialogFunction} from "@/types/types";
 import {getDateTimeFormatted} from "@/helpers/common";
 import {saveAs} from "file-saver";
 import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
@@ -62,13 +62,14 @@ export default defineComponent({
             imgDataURL: "",
             mediaInfo: "",
             mediaType: "",
+            hex: "",
             audioBuffer: undefined as AudioBuffer | undefined,
             stopPreviewOnHide : () => {},
             replaceAfterEdit : (() => {}) as ((replacement: {code: string, mediaType: string}) => void),
         };
     },
 
-    inject: ["editImageInDialog", "editSoundInDialog"],
+    inject: ["editImageInDialog", "editSoundInDialog", "openColourPickerInDialog"],
     
     methods: {
         showPopup(event : MouseEvent, media: LoadedMedia, replaceMedia: (replacement: {code: string, mediaType: string}) => void) {
@@ -82,7 +83,12 @@ export default defineComponent({
 
             this.mediaType = media.mediaType;
             this.audioBuffer = media.audioBuffer;
-            if (media.audioBuffer) {
+            this.hex = media.hex ?? "";
+            if (media.mediaType === "colour") {
+                this.imgDataURL = media.imageDataURL;
+                this.mediaInfo = media.hex ?? "";
+            }
+            else if (media.audioBuffer) {
                 // This is not translated because it's a class name:
                 this.mediaInfo = `${HTMLSoundClass}<br>${media.audioBuffer.duration.toFixed(2)} ${this.$t("media.soundSeconds")}`;
                 this.imgDataURL = media.imageDataURL;
@@ -190,7 +196,12 @@ export default defineComponent({
             }
         },
         doEdit() {
-            if (this.audioBuffer) {
+            if (this.mediaType === "colour") {
+                this.doOpenColourPickerInDialog(this.hex, (hex : string) => {
+                    this.replaceAfterEdit({code: "\"" + hex + "\"", mediaType: "colour"});
+                }, () => {});
+            }
+            else if (this.audioBuffer) {
                 this.doEditSoundInDialog(this.audioBuffer, (replacement : {code: string, mediaType: string}) => {
                     this.replaceAfterEdit(replacement);
                 });
@@ -217,6 +228,9 @@ export default defineComponent({
         },
         doEditSoundInDialog() : EditSoundInDialogFunction {
             return (this as any).editSoundInDialog as EditSoundInDialogFunction;
+        },
+        doOpenColourPickerInDialog() : OpenColourPickerInDialogFunction {
+            return (this as any).openColourPickerInDialog as OpenColourPickerInDialogFunction;
         },
     },
 });

--- a/src/helpers/colour.ts
+++ b/src/helpers/colour.ts
@@ -35,6 +35,13 @@ export function parseColourToHex(input: string): string | null {
     return result;
 }
 
+// Strict predicate used for auto-detection (typing-blur and python-load) of a colour literal:
+// exactly 6 hex digits after "#", unlike parseColourToHex's lenient CSS-colour parsing (which is
+// only used to seed the picker from arbitrary content).
+export function isHexColourLiteral(s: string): boolean {
+    return /^#[0-9a-fA-F]{6}$/.test(s);
+}
+
 export function hexToHsv(hex: string): { h: number, s: number, v: number } {
     const r = parseInt(hex.substring(1, 3), 16) / 255;
     const g = parseInt(hex.substring(3, 5), 16) / 255;

--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -15,6 +15,7 @@ import {toUnicodeEscapes} from "@/parser/parser";
 import { fromUnicodeEscapes, pasteMixedPython } from "@/helpers/pythonToFrames";
 import { vueComponentsAPIHandler } from "@/helpers/vueComponentAPI";
 import { eventBus } from "@/helpers/appContext";
+import { isHexColourLiteral } from "@/helpers/colour";
 
 export const undoMaxSteps = 50;
 export const autoSaveFreqMins = 2; // The number of minutes between each autosave action.
@@ -1737,7 +1738,16 @@ export const parseCodeLiteral = (codeLiteral: string, flags?: {isInsideString?: 
             // When we construct the parts before and after the string, we need to internally set the cursor "fake" position, that is, the cursor offset by the bits we are evaluating
             const {slots: structBeforeString, cursorOffset: beforeStringCursortOffset} = parseCodeLiteral(beforeStringCode, {isInsideString: false, cursorPos: flags?.cursorPos, skipStringEscape: flags?.skipStringEscape, imageLiterals: imageLiterals});
             cursorOffset += beforeStringCursortOffset;
-            const structOfString: StringSlot = {code: stringContentCode, quote: openingQuoteValue};
+            // Auto-convert a plain string matching a hex colour literal (e.g. "#aabbcc") into a colour
+            // MediaSlot, but only once the cursor has genuinely left the string (cursorPos undefined, or
+            // outside the quotes -- inclusive bounds, so a boundary position is still treated as "inside"
+            // and doesn't convert), and only for unprefixed strings (f/r/b-prefixed strings are excluded,
+            // since those are constructed live the same way as a plain string via addNewSlot's string branch).
+            const cursorInsideThisString = flags?.cursorPos !== undefined && flags.cursorPos >= openingQuoteIndex && flags.cursorPos <= closingQuoteIndex;
+            const hasStringPrefix = /(^|[^a-zA-Z0-9_])[fFrRbB]{1,2}$/.test(beforeStringCode);
+            const structOfString: StringSlot | MediaSlot = (!cursorInsideThisString && !hasStringPrefix && isHexColourLiteral(stringContentCode))
+                ? {mediaType: "colour", code: openingQuoteValue + stringContentCode.toLowerCase() + openingQuoteValue} as MediaSlot
+                : {code: stringContentCode, quote: openingQuoteValue};
             const {slots: structAfterString, cursorOffset: afterStringCursorOffset} = parseCodeLiteral(afterStringCode, {isInsideString: false, cursorPos: flags?.cursorPos !== undefined ? flags?.cursorPos - closingQuoteIndex + (2*(quoteTokenLength -1)) + stringPlaceholder.length : undefined, skipStringEscape: flags?.skipStringEscape, imageLiterals: imageLiterals});
             cursorOffset += afterStringCursorOffset;
             (structAfterString.fields[0] as BaseSlot).code = removePossibleFieldPlaceholderFromStart((structAfterString.fields[0] as BaseSlot).code);

--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -1,4 +1,5 @@
-import { AllFrameTypesIdentifier, BaseSlot, CaretPosition, CollapsedState, ContainerTypesIdentifiers, CurrentFrame, EditorFrameObjects, FrameObject, getFrameDefType, isFieldBaseSlot, isFieldBracketedSlot, isFieldStringSlot, LabelSlotsContent, SlotsStructure, StringSlot, MessageDefinitions, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, FrozenState } from "@/types/types";
+import { AllFrameTypesIdentifier, BaseSlot, CaretPosition, CollapsedState, ContainerTypesIdentifiers, CurrentFrame, EditorFrameObjects, FrameObject, getFrameDefType, isFieldBaseSlot, isFieldBracketedSlot, isFieldStringSlot, LabelSlotsContent, MediaSlot, SlotsStructure, StringSlot, MessageDefinitions, FormattedMessage, FormattedMessageArgKeyValuePlaceholders, FrozenState } from "@/types/types";
+import { isHexColourLiteral } from "@/helpers/colour";
 import {useStore} from "@/store/store";
 import {checkCodeErrors} from "@/helpers/storeMethods";
 import {CustomEventTypes, getLastCaretPosInsideParent, operators, trimmedKeywordOperators} from "@/helpers/editor";
@@ -897,7 +898,14 @@ function toSlots(p: ParsedConcreteTree) : SlotsStructure {
         // ([\s\S] matches any char, including newlines, which might be present if it's triple quoted):
         const strMatch = /^([rbfRBF]*)(["'])([\s\S]+)$/.exec(val);
         if (strMatch) {
-            const str : StringSlot = {code: strMatch[3].slice(0, strMatch[3].length - strMatch[2].length), quote: strMatch[2]};
+            const content = strMatch[3].slice(0, strMatch[3].length - strMatch[2].length);
+            // Unprefixed strings matching a hex colour (e.g. "#aabbcc") load as a colour literal rather
+            // than a plain string, mirroring the organic typing/blur auto-conversion (editor.ts parseCodeLiteral):
+            if (strMatch[1] === "" && isHexColourLiteral(content)) {
+                const colour : MediaSlot = {mediaType: "colour", code: strMatch[2] + content.toLowerCase() + strMatch[2]};
+                return {fields: [{code: ""}, colour, {code: ""}], operators: [{code: ""}, {code: ""}]};
+            }
+            const str : StringSlot = {code: content, quote: strMatch[2]};
             return {fields: [{code: strMatch[1]}, str, {code: ""}], operators: [{code: ""}, {code: ""}]};
         }
         else {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1017,6 +1017,22 @@ export const useStore = defineStore("app", {
             }
         },
 
+        // Converts an existing string slot (e.g. the one the colour picker was opened from, via Ctrl-Shift-Y)
+        // into a colour MediaSlot in place, at the same field index. This relies on a string slot always being
+        // already flanked by its own lhs/rhs sibling fields (addNewSlot's string branch above always wraps
+        // [lhs, string, rhs]), so there's no need to splice new siblings in -- "adjacent" fields already exist.
+        convertStringSlotToColourLiteral(slotInfos: SlotCoreInfos, hex: string) {
+            const {parentId, slotIndex} = getSlotParentIdAndIndexSplit(slotInfos.slotId);
+            const parentFieldSlot = (parentId.length > 0)
+                ? retrieveSlotFromSlotInfos({...slotInfos, slotId: parentId}) as SlotsStructure
+                : this.frameObjects[slotInfos.frameId].labelSlotsDict[slotInfos.labelSlotsIndex].slotStructures;
+            const quote = (parentFieldSlot.fields[slotIndex] as StringSlot).quote;
+
+            const stateBeforeChanges = cloneDeep(this.$state);
+            parentFieldSlot.fields[slotIndex] = {mediaType: "colour", code: quote + hex.toLowerCase() + quote} as MediaSlot;
+            this.saveStateChanges(stateBeforeChanges);
+        },
+
         /**
          * This method is called if we need to delete an operator, bracket or string (i.e. the deletion is not solely
          * contained neatly in one slot).  We envisage this as being in a particular slot (the current slot) and deleting

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -66,6 +66,8 @@ export interface StringSlot extends BaseSlot {
 // and we can infer the function is "load_image" from the media type.
 // None of this can be edited after the image is initially inserted into the code
 // so there are no problems with keeping the different parts in sync
+// Exception: mediaType "colour" has code equal to a bare quoted string (e.g. "#aabbcc"),
+// not a function call -- there is no underlying function for colour literals.
 export interface MediaSlot extends BaseSlot {
     mediaType: string;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1345,6 +1345,8 @@ export interface LoadedMedia {
     imageDataURL: string,
     // But only sounds have this item:
     audioBuffer?: AudioBuffer,
+    // Only colour literals have this item -- the hex code itself, shown as the popup header text:
+    hex?: string,
 }
 
 export interface MediaDataAndDim {

--- a/tests/playwright/e2e/colour-literal-copy-paste.spec.ts
+++ b/tests/playwright/e2e/colour-literal-copy-paste.spec.ts
@@ -46,6 +46,11 @@ function colourSwatch(page: import("@playwright/test").Page) {
 async function insertColourSwatch(page: import("@playwright/test").Page, hex: string) {
     await page.keyboard.press("ControlOrMeta+Shift+Y");
     await page.locator("button", {hasText: "Fine-grained selector"}).click();
+    // ColourPickerDlg.vue's own hexText seeding (onShownModalDlg) runs on bootstrap-vue's async
+    // "shown" modal event, which can fire after the dialog is already interactable -- filling
+    // immediately can race it and get silently overwritten. See colour-picker.spec.ts's
+    // waitForColourPickerSeeded for the full explanation (this hit a real, reproducible CI failure).
+    await page.waitForTimeout(500);
     await page.locator("#ColourPickerDlg-hex-input").fill(hex);
     await page.locator(".btn.btn-primary", {hasText: "OK"}).filter({visible: true}).click();
     await waitForEditorSettled(page);

--- a/tests/playwright/e2e/colour-literal-copy-paste.spec.ts
+++ b/tests/playwright/e2e/colour-literal-copy-paste.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "@playwright/test";
+import { pressFrameShortcut, waitForEditorSettled, doPagePaste } from "../support/editor";
+import { setupStrypeTest } from "../support/general";
+
+// Covers §8 of the plan: copy/paste of a colour literal within Strype. Unlike image/sound
+// literals (structured-expressions-media.spec.ts), a colour literal's underlying code is just a
+// bare quoted string (e.g. "#aabbcc"), not a load_image(...)/load_sound(...) call, so there's no
+// dedicated binary-clipboard path for it -- copying one puts its quoted hex text on the clipboard
+// like any other text selection, and pasting it goes through the same paste-then-reparse pipeline
+// as typing/loading it would.
+//
+// Copying uses a real Ctrl-C against Playwright's fake clipboard (see setupStrypeTest's
+// fakeClipboard option) and reads it back via navigator.clipboard.readText() -- no clipboard
+// infrastructure of our own needed there, it's a genuine OS-level (faked) round-trip. Pasting,
+// however, still goes through doPagePaste() (dispatching a paste DOM event with explicit
+// clipboardData) rather than a real Ctrl-V keypress: confirmed empirically while writing this
+// test that a real Ctrl-V here does nothing at all (the shortcut doesn't read from the fake
+// clipboard) -- structured-expressions-copy-paste.spec.ts's CUT_REPASTE case hits the same
+// limitation and documents it the same way, reusing the confirmed clipboard content from the
+// preceding real copy rather than a shortcut for the paste half.
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    await setupStrypeTest(page, browserName, testInfo, {
+        timeoutMs: 60000,
+        skipPyodide: true,
+        fakeClipboard: true,
+        gotoWaitUntil: "domcontentloaded",
+        skipWindowsWebkitReason: "Skipping on WebKit + Windows due to clipboard permission issues.",
+    });
+});
+
+async function openIfFrame(page: import("@playwright/test").Page) {
+    await pressFrameShortcut(page, "i");
+    await waitForEditorSettled(page);
+}
+
+function colourSwatch(page: import("@playwright/test").Page) {
+    return page.locator("img[data-mediatype='colour']");
+}
+
+// Inserts a colour literal via the picker (not-in-string branch, see colour-picker.spec.ts's own
+// cursor-placement tests) rather than the typed-string blur-conversion route: that route
+// deliberately leaves nothing focused after converting (there's no cursor to restore into once
+// the slot has left edit mode -- see checkSlotRefactoring's treatAsBlurred branch in
+// LabelSlotsStructure.vue), whereas the picker explicitly places the cursor in the empty sibling
+// field right after the swatch, which this test needs a live selection anchor to select from.
+async function insertColourSwatch(page: import("@playwright/test").Page, hex: string) {
+    await page.keyboard.press("ControlOrMeta+Shift+Y");
+    await page.locator("button", {hasText: "Fine-grained selector"}).click();
+    await page.locator("#ColourPickerDlg-hex-input").fill(hex);
+    await page.locator(".btn.btn-primary", {hasText: "OK"}).filter({visible: true}).click();
+    await waitForEditorSettled(page);
+}
+
+test.describe("Copying a colour literal", () => {
+    test("Selecting just the swatch puts its quoted hex text on the clipboard", async ({page}) => {
+        await openIfFrame(page);
+        await insertColourSwatch(page, "#aabbcc");
+        await expect(colourSwatch(page)).toHaveCount(1);
+
+        // Cursor is in the empty field right after the swatch (see insertColourSwatch's comment);
+        // one shift-left selects exactly it (media literals are one character wide):
+        await page.keyboard.press("Shift+ArrowLeft");
+        await page.keyboard.press("ControlOrMeta+c");
+        await expect.poll(() => page.evaluate("navigator.clipboard.readText()")).toEqual("\"#aabbcc\"");
+    });
+});
+
+test.describe("Pasting a copied colour literal", () => {
+    // Unlike image/sound literals (whose pasted flat text is recognised immediately via a
+    // load_image(...)/load_sound(...) regex match in getFrameLabelSlotLiteralCodeAndFocus's
+    // useFlatMediaDataCode handling), a colour literal has no distinctive call-shape to spot in
+    // flat pasted text -- it's just a quoted hex string, indistinguishable at that point from any
+    // other pasted string. It still ends up converted immediately here, though, not via that
+    // media-specific path: pasting the *whole* quoted string "#aabbcc" into an empty slot leaves
+    // the cursor right after the closing quote (onCodePasteImpl places it at the end of the
+    // inserted text), which already satisfies the blur-conversion's "cursor outside the string"
+    // condition (§4) on the very same reparse the paste itself triggers -- confirmed empirically;
+    // no separate arrow-out step needed, unlike typing the same content character-by-character.
+    test("Pasting the copied text recreates a colour literal", async ({page}) => {
+        await openIfFrame(page);
+        await insertColourSwatch(page, "#aabbcc");
+        await page.keyboard.press("Shift+ArrowLeft");
+        await page.keyboard.press("ControlOrMeta+c");
+        await expect.poll(() => page.evaluate("navigator.clipboard.readText()")).toEqual("\"#aabbcc\"");
+
+        // Paste into a second, fresh if-frame's empty slot:
+        await page.keyboard.press("End");
+        await openIfFrame(page);
+        await doPagePaste(page, "\"#aabbcc\"");
+
+        await expect(colourSwatch(page)).toHaveCount(2);
+        await expect(colourSwatch(page).last()).toHaveAttribute("data-code", "\"#aabbcc\"");
+    });
+});

--- a/tests/playwright/e2e/colour-literals.spec.ts
+++ b/tests/playwright/e2e/colour-literals.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect, Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
 import { setupStrypeTest } from "../support/general";
 import { pressFrameShortcut, waitForEditorSettled, typeIndividually, pressN } from "../support/editor";
 import { checkFrameErrorCount } from "../support/execution";
+import { loadContent, save } from "../support/loading-saving";
 
 // Covers the auto-conversion mechanic (colour-literals plan §4): a plain string whose content
 // matches a hex colour (e.g. "#aabbcc") converts to a colour literal (rendered the same way as
@@ -90,6 +92,81 @@ test.describe("Auto-conversion of typed hex strings to colour literals", () => {
 
         await page.keyboard.press("ControlOrMeta+Z");
         await waitForEditorSettled(page);
+        await expect(colourSwatch(page)).toHaveCount(0);
+    });
+
+    test("Redo after undoing an auto-conversion re-applies it", async ({page}) => {
+        await openIfFrame(page);
+        await typeStringThenLeaveIt(page, "#aabbcc");
+        await page.keyboard.press("ControlOrMeta+Z");
+        await waitForEditorSettled(page);
+        await expect(colourSwatch(page)).toHaveCount(0);
+
+        // Redo in this app is Ctrl/Cmd-Y, not the more common Ctrl-Shift-Z (see Commands.vue's
+        // undo/redo keydown handling):
+        await page.keyboard.press("ControlOrMeta+y");
+        await waitForEditorSettled(page);
+        await expect(colourSwatch(page)).toHaveAttribute("data-code", "\"#aabbcc\"");
+    });
+});
+
+// Covers §6/§7 of the plan: loading a saved (.spy) project whose Main section contains a bare hex
+// string renders it as a colour literal, and saving straight back out reproduces the exact same
+// text -- proving parser.ts/editor.ts's generic SlotType.media codegen round-trips a colour
+// literal's code unchanged, same as load-save-specific.spec.ts does for other unusual constructs.
+test.describe("Loading and saving colour literals", () => {
+    test.beforeEach(async ({ page, browserName }, testInfo) => {
+        // Override the outer beforeEach's skipPyodide: true default with skipPyodide -- loading
+        // doesn't need Python execution, matching load-save-specific.spec.ts's own setup:
+        await setupStrypeTest(page, browserName, testInfo, {skipPyodide: true});
+    });
+
+    async function testLoadSaveMainLines(page: Page, content: string) {
+        const spySource = [
+            "#(=> Strype:1:std",
+            "#(=> Section:Imports",
+            "#(=> Section:Definitions",
+            "#(=> Section:Main",
+            content,
+            "#(=> Section:End",
+            "",
+        ].join("\n");
+        await loadContent(page, spySource);
+        const output = readFileSync(await save(page, false), "utf8").replace(/\r\n/g, "\n");
+        expect(output).toEqual(spySource);
+    }
+
+    test("Loading a bare hex string renders it as a colour literal", async ({page}) => {
+        await loadContent(page, [
+            "#(=> Strype:1:std",
+            "#(=> Section:Imports",
+            "#(=> Section:Definitions",
+            "#(=> Section:Main",
+            "myColour  = \"#aabbcc\" ",
+            "#(=> Section:End",
+            "",
+        ].join("\n"));
+        await expect(colourSwatch(page)).toHaveAttribute("data-code", "\"#aabbcc\"");
+    });
+
+    test("Loading then saving a colour literal reproduces the exact original text", async ({page}) => {
+        await testLoadSaveMainLines(page, "myColour  = \"#3366cc\" ");
+    });
+
+    test("Loading then saving a single-quoted colour literal preserves the quote character", async ({page}) => {
+        await testLoadSaveMainLines(page, "myColour  = '#3366cc' ");
+    });
+
+    test("A prefixed string that happens to look like a colour is loaded as a plain string, not converted", async ({page}) => {
+        await loadContent(page, [
+            "#(=> Strype:1:std",
+            "#(=> Section:Imports",
+            "#(=> Section:Definitions",
+            "#(=> Section:Main",
+            "myString  = f\"#aabbcc\" ",
+            "#(=> Section:End",
+            "",
+        ].join("\n"));
         await expect(colourSwatch(page)).toHaveCount(0);
     });
 });

--- a/tests/playwright/e2e/colour-literals.spec.ts
+++ b/tests/playwright/e2e/colour-literals.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, Page } from "@playwright/test";
+import { setupStrypeTest } from "../support/general";
+import { pressFrameShortcut, waitForEditorSettled, typeIndividually, pressN } from "../support/editor";
+import { checkFrameErrorCount } from "../support/execution";
+
+// Covers the auto-conversion mechanic (colour-literals plan §4): a plain string whose content
+// matches a hex colour (e.g. "#aabbcc") converts to a colour literal (rendered the same way as
+// image/sound media literals -- see media-recording.spec.ts) once the cursor leaves the string,
+// but not while still typing/partway through it. Picker-driven insertion/replacement (Ctrl-Shift-Y)
+// is covered separately in colour-picker.spec.ts.
+test.beforeEach(async ({ page, browserName }, testInfo) => {
+    await setupStrypeTest(page, browserName, testInfo, {timeoutMs: 60000, skipPyodide: true});
+});
+
+async function openIfFrame(page: Page) {
+    await pressFrameShortcut(page, "i");
+    await waitForEditorSettled(page);
+}
+
+// Types the given hex string as a plain string literal's content, then moves the caret out past
+// the closing quote (arrow-out), which is what triggers the blur-conversion check (mere cursor
+// movement doesn't fire onInput, see LabelSlot.vue's onLoseCaret) -- same pattern
+// structured-expressions-navigation.spec.ts uses to move past a string's full width.
+async function typeStringThenLeaveIt(page: Page, hex: string) {
+    await typeIndividually(page, "\"" + hex);
+    await waitForEditorSettled(page);
+    await pressN("ArrowRight", 1 + hex.length, true)(page);
+}
+
+function colourSwatch(page: Page) {
+    return page.locator("img[data-mediatype='colour']");
+}
+
+test.describe("Auto-conversion of typed hex strings to colour literals", () => {
+    test("Typing a hex colour then moving out of the string converts it to a colour literal", async ({page}) => {
+        await openIfFrame(page);
+        await typeStringThenLeaveIt(page, "#aabbcc");
+        await expect(colourSwatch(page)).toHaveAttribute("data-code", "\"#aabbcc\"");
+        await checkFrameErrorCount(page, 0);
+    });
+
+    test("Uppercase/mixed-case hex is normalised to lowercase on conversion", async ({page}) => {
+        await openIfFrame(page);
+        await typeStringThenLeaveIt(page, "#AaBbCc");
+        await expect(colourSwatch(page)).toHaveAttribute("data-code", "\"#aabbcc\"");
+    });
+
+    test("Single-quoted strings convert too, preserving the quote character", async ({page}) => {
+        await openIfFrame(page);
+        await typeIndividually(page, "'#aabbcc");
+        await waitForEditorSettled(page);
+        await pressN("ArrowRight", 1 + "#aabbcc".length, true)(page);
+        await expect(colourSwatch(page)).toHaveAttribute("data-code", "'#aabbcc'");
+    });
+
+    test("Does not convert while the cursor is still inside the string", async ({page}) => {
+        await openIfFrame(page);
+        await typeIndividually(page, "\"#aabbcc");
+        await waitForEditorSettled(page);
+        // Deliberately not moving the cursor out -- still inside/at the end of the string content:
+        await expect(colourSwatch(page)).toHaveCount(0);
+    });
+
+    test("f-prefixed strings never auto-convert", async ({page}) => {
+        await openIfFrame(page);
+        await typeIndividually(page, "f\"#aabbcc");
+        await waitForEditorSettled(page);
+        await pressN("ArrowRight", 1 + "#aabbcc".length, true)(page);
+        await expect(colourSwatch(page)).toHaveCount(0);
+    });
+
+    test("r-prefixed strings never auto-convert", async ({page}) => {
+        await openIfFrame(page);
+        await typeIndividually(page, "r\"#aabbcc");
+        await waitForEditorSettled(page);
+        await pressN("ArrowRight", 1 + "#aabbcc".length, true)(page);
+        await expect(colourSwatch(page)).toHaveCount(0);
+    });
+
+    test("Content that doesn't match a hex colour is left as a plain string", async ({page}) => {
+        await openIfFrame(page);
+        await typeStringThenLeaveIt(page, "not a colour");
+        await expect(colourSwatch(page)).toHaveCount(0);
+    });
+
+    test("Undo after auto-conversion restores the original plain string", async ({page}) => {
+        await openIfFrame(page);
+        await typeStringThenLeaveIt(page, "#aabbcc");
+        await expect(colourSwatch(page)).toHaveAttribute("data-code", "\"#aabbcc\"");
+
+        await page.keyboard.press("ControlOrMeta+Z");
+        await waitForEditorSettled(page);
+        await expect(colourSwatch(page)).toHaveCount(0);
+    });
+});

--- a/tests/playwright/e2e/colour-picker.spec.ts
+++ b/tests/playwright/e2e/colour-picker.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 import { setupStrypeTest } from "../support/general";
-import { pressFrameShortcut, waitForEditorSettled } from "../support/editor";
+import { pressFrameShortcut, waitForEditorSettled, checkTextSlotCursorPos, typeIndividually } from "../support/editor";
 import { checkFrameErrorCount, checkConsoleContent, runToFinish } from "../support/execution";
 
 test.beforeEach(async ({ page, browserName }, testInfo) => {
@@ -210,5 +210,96 @@ test.describe("Inserting and editing colour string literals", () => {
         // so its output comes first, followed by the pre-existing "Hello from Strype" -- the key
         // thing being tested is that a clean hex string appears at all, rather than a crash:
         await checkConsoleContent(page, /^#[0-9a-f]{6}\nHello from Strype\s*$/i);
+    });
+});
+
+test.describe("Cursor placement after picker-driven insertion/conversion", () => {
+    // §3 of the plan: both the not-in-string (fresh insert) and in-string (convert-in-place)
+    // branches place the cursor in the empty sibling field right after the now-atomic colour
+    // literal, rather than leaving it "inside" the swatch (which has no text content to be inside
+    // of). Confirmed two ways: checkTextSlotCursorPos (position 0 of whichever field is now
+    // focused) and that subsequently typed text lands as a plain sibling, not merged into the swatch.
+    test("Ctrl-Shift-Y outside a string places the cursor in the empty field right after the new swatch", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await page.locator(".ColourPickerDlg-family-btn", {hasText: "Blue"}).click();
+        await page.locator(".ColourPickerDlg-shade-cell").first().dblclick();
+        await waitForEditorSettled(page);
+
+        await expect(page.locator("img[data-mediatype='colour']")).toHaveCount(1);
+        await checkTextSlotCursorPos(page, 0);
+
+        await typeIndividually(page, "9");
+        // The swatch itself must be untouched, and the "9" must land as separate sibling text --
+        // not merged into (or replacing) the media literal:
+        await expect(page.locator("img[data-mediatype='colour']")).toHaveCount(1);
+        const text = await getRawFrameHeaderText(page);
+        expect(text).toContain("9");
+    });
+
+    test("Ctrl-Shift-Y inside a string places the cursor in the empty field right after the converted swatch", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.type("\"notacolour");
+        await waitForEditorSettled(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        if (!(await page.locator("#ColourPickerDlg-hex-input").isVisible())) {
+            await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        }
+        await page.locator("#ColourPickerDlg-hex-input").fill("#112233");
+        await visibleOKButton(page).click();
+        await waitForEditorSettled(page);
+
+        await expect(page.locator("img[data-mediatype='colour']")).toHaveAttribute("data-code", "\"#112233\"");
+        await checkTextSlotCursorPos(page, 0);
+
+        await typeIndividually(page, "9");
+        await expect(page.locator("img[data-mediatype='colour']")).toHaveAttribute("data-code", "\"#112233\"");
+        const text = await getRawFrameHeaderText(page);
+        expect(text).toContain("9");
+    });
+});
+
+test.describe("Hover preview popup and edit round-trip", () => {
+    // §5 of the plan: hovering the swatch shows a filled-rectangle preview with the hex as the
+    // header text (not the image dimensions text used for actual images/sounds), the
+    // Preview/Download buttons are hidden (colour literals have neither a sensible world-preview
+    // nor a downloadable file), and Edit reopens the colour picker seeded with the current hex.
+    test("Hovering a colour swatch shows the hex as the popup header, with Preview/Download hidden", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await page.locator(".ColourPickerDlg-family-btn", {hasText: "Green"}).click();
+        await page.locator(".ColourPickerDlg-shade-cell").first().dblclick();
+        await waitForEditorSettled(page);
+        const dataCode = await page.locator("img[data-mediatype='colour']").getAttribute("data-code");
+        const hex = (dataCode as string).replace(/"/g, "");
+
+        await page.locator("img[data-mediatype='colour']").hover();
+        await expect(page.locator(".MediaPreviewPopup-header-text")).toHaveText(hex);
+        await expect(page.locator(".MediaPreviewPopup-header-preview-button")).not.toBeVisible();
+        await expect(page.locator(".MediaPreviewPopup-header-download-button")).not.toBeVisible();
+        await expect(page.locator(".MediaPreviewPopup-header-edit-button")).toBeVisible();
+    });
+
+    test("Edit from the hover popup reopens the picker seeded with the current hex and updates the swatch on OK", async ({page}) => {
+        await openIfFrame(page);
+        await page.keyboard.press("ControlOrMeta+Shift+Y");
+        await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        await page.locator("#ColourPickerDlg-hex-input").fill("#445566");
+        await visibleOKButton(page).click();
+        await waitForEditorSettled(page);
+        await expect(page.locator("img[data-mediatype='colour']")).toHaveAttribute("data-code", "\"#445566\"");
+
+        await page.locator("img[data-mediatype='colour']").hover();
+        await page.locator(".MediaPreviewPopup-header-edit-button").click();
+        await expect(page.locator("#colourPickerDlg")).toBeVisible();
+        // Editing an existing colour literal jumps straight into the fine-grained selector, seeded
+        // with its current hex (same as editing an in-progress string, see onShownModalDlg):
+        await expect(page.locator("#ColourPickerDlg-hex-input")).toHaveValue("#445566");
+
+        await page.locator("#ColourPickerDlg-hex-input").fill("#778899");
+        await visibleOKButton(page).click();
+        await waitForEditorSettled(page);
+        await expect(page.locator("img[data-mediatype='colour']")).toHaveAttribute("data-code", "\"#778899\"");
+        await checkFrameErrorCount(page, 0);
     });
 });

--- a/tests/playwright/e2e/colour-picker.spec.ts
+++ b/tests/playwright/e2e/colour-picker.spec.ts
@@ -48,6 +48,21 @@ function visibleOKButton(page: Page) {
     return page.locator(".btn.btn-primary", {hasText: "OK"}).filter({visible: true});
 }
 
+// ColourPickerDlg.vue's own hexText seeding (onShownModalDlg) runs on bootstrap-vue's async
+// "shown" modal event, which fires strictly after the dialog is already visible/interactable --
+// there's no DOM signal available to poll for it directly. Filling the hex input immediately after
+// opening (skipping the "Fine-grained selector" button click, which happens when editing an
+// existing colour jumps straight there) races that handler: it can fire *after* the fill and
+// silently overwrite it back to the seeded value. A toHaveValue() check right after opening isn't
+// a reliable guard either -- the input can still be showing a stale leftover value from before the
+// dialog opened that happens to equal the correctly-seeded one, passing the check without the
+// handler having actually run yet (this is exactly what caused a real, reproducible CI failure).
+// Matches the same kind of buffer used elsewhere in this codebase for an async-settle race that
+// has no better observable signal (see media-recording.spec.ts's waitForImageCropperReady).
+async function waitForColourPickerSeeded(page: Page) {
+    await page.waitForTimeout(500);
+}
+
 test.describe("Colour picker shortcut gating", () => {
     test("Ctrl-Shift-Y does nothing inside a comment frame", async ({page}) => {
         await page.keyboard.press("#");
@@ -128,6 +143,7 @@ test.describe("Graphics preview", () => {
         await openIfFrame(page);
         await page.keyboard.press("ControlOrMeta+Shift+Y");
         await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        await waitForColourPickerSeeded(page);
         await page.locator("#ColourPickerDlg-hex-input").fill("#3366cc");
         await expect.poll(() => getGraphicsCenterPixel(page)).toEqual([0x33, 0x66, 0xcc, 255]);
         await visibleCancelButton(page).click();
@@ -145,6 +161,7 @@ test.describe("Inserting and editing colour string literals", () => {
         await openIfFrame(page);
         await page.keyboard.press("ControlOrMeta+Shift+Y");
         await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        await waitForColourPickerSeeded(page);
         await page.locator("#ColourPickerDlg-hex-input").fill("#3366cc");
         await visibleOKButton(page).click();
         await waitForEditorSettled(page);
@@ -167,6 +184,7 @@ test.describe("Inserting and editing colour string literals", () => {
         if (!(await page.locator("#ColourPickerDlg-hex-input").isVisible())) {
             await page.locator("button", {hasText: "Fine-grained selector"}).click();
         }
+        await waitForColourPickerSeeded(page);
         await page.locator("#ColourPickerDlg-hex-input").fill("#996633");
         await visibleOKButton(page).click();
         await waitForEditorSettled(page);
@@ -245,6 +263,7 @@ test.describe("Cursor placement after picker-driven insertion/conversion", () =>
         if (!(await page.locator("#ColourPickerDlg-hex-input").isVisible())) {
             await page.locator("button", {hasText: "Fine-grained selector"}).click();
         }
+        await waitForColourPickerSeeded(page);
         await page.locator("#ColourPickerDlg-hex-input").fill("#112233");
         await visibleOKButton(page).click();
         await waitForEditorSettled(page);
@@ -284,6 +303,7 @@ test.describe("Hover preview popup and edit round-trip", () => {
         await openIfFrame(page);
         await page.keyboard.press("ControlOrMeta+Shift+Y");
         await page.locator("button", {hasText: "Fine-grained selector"}).click();
+        await waitForColourPickerSeeded(page);
         await page.locator("#ColourPickerDlg-hex-input").fill("#445566");
         await visibleOKButton(page).click();
         await waitForEditorSettled(page);
@@ -292,6 +312,7 @@ test.describe("Hover preview popup and edit round-trip", () => {
         await page.locator("img[data-mediatype='colour']").hover();
         await page.locator(".MediaPreviewPopup-header-edit-button").click();
         await expect(page.locator("#colourPickerDlg")).toBeVisible();
+        await waitForColourPickerSeeded(page);
         // Editing an existing colour literal jumps straight into the fine-grained selector, seeded
         // with its current hex (same as editing an in-progress string, see onShownModalDlg):
         await expect(page.locator("#ColourPickerDlg-hex-input")).toHaveValue("#445566");

--- a/tests/playwright/e2e/colour-picker.spec.ts
+++ b/tests/playwright/e2e/colour-picker.spec.ts
@@ -135,7 +135,13 @@ test.describe("Graphics preview", () => {
 });
 
 test.describe("Inserting and editing colour string literals", () => {
-    test("Typing a hex value and confirming inserts that literal string into an empty expression slot", async ({page}) => {
+    // Since the colour-literals feature (see colour-literals.spec.ts), confirming the picker no
+    // longer inserts/replaces a plain string -- it produces a colour MediaSlot, rendered as an
+    // <img class="...labelSlotMediaClassName..." data-mediatype="colour" data-code='"#hex"'>,
+    // the same way image/sound literals are (media-recording.spec.ts), so we assert via that
+    // element's data-code attribute rather than the raw frame header text (which no longer
+    // contains the hex as visible text).
+    test("Typing a hex value and confirming inserts a colour literal into an empty expression slot", async ({page}) => {
         await openIfFrame(page);
         await page.keyboard.press("ControlOrMeta+Shift+Y");
         await page.locator("button", {hasText: "Fine-grained selector"}).click();
@@ -143,14 +149,13 @@ test.describe("Inserting and editing colour string literals", () => {
         await visibleOKButton(page).click();
         await waitForEditorSettled(page);
 
-        const text = await getRawFrameHeaderText(page);
-        expect(text).toContain("#3366cc");
-        // A bare condition consisting of just a string literal is valid Python (truthy check), so
+        await expect(page.locator("img[data-mediatype='colour']")).toHaveAttribute("data-code", "\"#3366cc\"");
+        // A bare condition consisting of just a colour literal is valid Python (truthy check), so
         // this should never show a syntax error:
         await checkFrameErrorCount(page, 0);
     });
 
-    test("Invoking the picker inside an existing string replaces its whole content with the picked hex", async ({page}) => {
+    test("Invoking the picker inside an existing string replaces the whole string with a colour literal", async ({page}) => {
         await openIfFrame(page);
         await page.keyboard.type("\"notacolour");
         await waitForEditorSettled(page);
@@ -166,8 +171,8 @@ test.describe("Inserting and editing colour string literals", () => {
         await visibleOKButton(page).click();
         await waitForEditorSettled(page);
 
+        await expect(page.locator("img[data-mediatype='colour']")).toHaveAttribute("data-code", "\"#996633\"");
         const text = await getRawFrameHeaderText(page);
-        expect(text).toContain("#996633");
         expect(text).not.toContain("notacolour");
         await checkFrameErrorCount(page, 0);
     });


### PR DESCRIPTION
## Summary
- Adds a third media-literal kind alongside images/sounds: a colour literal. Unlike those, its underlying Python code is just a plain quoted hex string (`"#aabbcc"`), reusing the existing generic `MediaSlot`/`SlotType.media` machinery (1-char-wide navigation, codegen, copy/paste, undo/redo) with `mediaType: "colour"`.
- Auto-converts a plain string to a colour literal when its content matches `#rrggbb` and the cursor leaves the string (typing-blur), and on loading/pasting a matching bare string.
- Ctrl+Shift+Y (existing colour-picker shortcut) now inserts/converts directly to a colour literal instead of a plain string, with the cursor landing in the adjacent field afterwards.
- Hovering a swatch shows a filled-rectangle preview with the hex as the header text and an Edit button (Preview/Download hidden, unlike images/sounds); Edit reopens the picker seeded with the current hex.
- Loading a `.spy`/`.py` program with a bare hex string renders it as a colour literal; saving round-trips the exact original text.

## Test plan
- [x] `tests/playwright/e2e/colour-literals.spec.ts` — typing/blur auto-conversion (case normalisation, both quote styles, cursor-still-inside guard, `f`/`r`/`b`-prefix guard, non-matching content, undo/redo), and load/save round-trip.
- [x] `tests/playwright/e2e/colour-picker.spec.ts` — updated existing insertion/replacement tests for the new `MediaSlot` shape, plus new cursor-placement and hover-popup/edit-round-trip coverage.
- [x] `tests/playwright/e2e/colour-literal-copy-paste.spec.ts` — copy puts the bare quoted hex text on the clipboard; paste recreates the swatch.
- [x] Full Playwright suite run twice on this branch's CI: only pre-existing, unrelated flaky tests (`scroll-into-view.spec.ts` etc.) remain red; all colour-literal-specific tests pass.
- [x] Cypress suite green.