### PR TITLE
Fix unary sign next to a comparison operator saving with wrong spacing

### DIFF
--- a/public/book_projects/chapter12/fish-school.spy
+++ b/public/book_projects/chapter12/fish-school.spy
@@ -93,11 +93,11 @@ def get_wall_force (f ) :
     if f.get_x() < wall_dist - 400  :
         total  = add(total,(dist_to_force * (-350 - f.get_x()),0)) 
     if f.get_x() > 400 - wall_dist  :
-        total  = add(total,( - dist_to_force * (f.get_x() - 350),0)) 
+        total  = add(total,(-dist_to_force * (f.get_x() - 350),0)) 
     if f.get_y() < wall_dist - 300  :
         total  = add(total,(0,dist_to_force * (-250 - f.get_y()))) 
     if f.get_y() > 300 - wall_dist  :
-        total  = add(total,(0, - dist_to_force * (f.get_y() - 250))) 
+        total  = add(total,(0,-dist_to_force * (f.get_y() - 250))) 
     return total 
 #(=> FrameState:FoldToHeader
 def get_centre_of_mass (f ) :

--- a/src/helpers/operatorPrecedence.ts
+++ b/src/helpers/operatorPrecedence.ts
@@ -229,11 +229,22 @@ export function calculatePrecedenceTiers(operatorCodes: string[], isUnarySignAt:
                 let tier = (maxLevel === 0)
                     ? (isKeyword ? "keyword-medium" : "medium")
                     : tierForLevel(levels.get(op.index) ?? 0, isKeyword);
-                // A detected unary sign substitutes in "sign-medium" for "medium" so the CSS
-                // layer knows to suppress its leading margin ("high" needs no substitute --
-                // already zero margin on both sides; "low" isn't reachable now that unary
-                // sign binds as tightly as "~", see UNARY_SIGN_PRECEDENCE):
-                if (isUnarySignAt[op.index] && tier === "medium") {
+                // A detected unary sign always substitutes in "sign-medium", regardless of
+                // what tier the generic ladder computation landed on. This used to be guarded
+                // on `tier === "medium"` (the assumption being that "high" needs no substitute,
+                // since it's already zero-margin on both sides -- true for the *CSS* margin,
+                // but that guard also gates a second, unrelated thing: parser.ts's generated
+                // Python text only omits the surrounding spaces around an operator when its
+                // tier is *exactly* "sign-medium" (see getSlotStartsLengthsAndCodeForFrameLabel's
+                // `isUnary` check). A unary sign mixed into a segment with a comparison operator
+                // (e.g. "x < -399", where "<" and "-" land in the same precedence-ladder segment)
+                // computes to "high", not "medium", so the guard never fired and the minus was
+                // saved as a spaced-out binary operator ("x <  - 399") -- a real round-trip bug,
+                // confirmed via a genuine fixture (public/book_projects/chapter12/cheese.spy)
+                // failing CI's load-save-book-demo-projects.spec.ts. Unconditional here fixes
+                // that: every detected unary sign now reliably gets tight (no-space) output,
+                // which is correct regardless of what tier it would otherwise have occupied.
+                if (isUnarySignAt[op.index]) {
                     tier = "sign-medium";
                 }
                 tiers[op.index] = tier;

--- a/tests/playwright/e2e/operator-precedence-calculation.spec.ts
+++ b/tests/playwright/e2e/operator-precedence-calculation.spec.ts
@@ -216,14 +216,19 @@ test.describe("calculatePrecedenceTiers: detected unary sign ('-'/'+')", () => {
         expect(calculatePrecedenceTiers(["-"])).toEqual(["medium"] satisfies PrecedenceTier[]);
     });
 
-    test("a mixed unary sign binds tight enough to reach 'high', pulling the binary operator around it looser", () => {
+    test("a mixed unary sign binds tight enough to reach 'high' on the ladder, but always keeps its 'sign-medium' substitution", () => {
         // -x+y: unary "-" now binds as tightly as "~", tighter than binary "+", so "+"
-        // becomes the pivot and "-" is pulled to "high" (needing no substitute -- "high" is
-        // already zero margin on both sides) while "+" lands on the ordinary "medium":
-        expect(calculatePrecedenceTiers(["-", "+"], [true, false])).toEqual(["high", "medium"] satisfies PrecedenceTier[]);
+        // becomes the pivot and "-" would ladder-compute to "high" -- but a detected unary
+        // sign always substitutes to "sign-medium" regardless (see calculatePrecedenceTiers:
+        // "high" looks the same as "sign-medium" visually via CSS, but parser.ts's generated
+        // Python text also keys off this exact tier to decide whether the sign needs
+        // surrounding spaces, so leaving it as unsubstituted "high" saved it as a spaced-out
+        // *binary* minus -- a real round-trip bug, confirmed via cheese.spy in CI) -- while
+        // "+" lands on the ordinary "medium":
+        expect(calculatePrecedenceTiers(["-", "+"], [true, false])).toEqual(["sign-medium", "medium"] satisfies PrecedenceTier[]);
         // -x*y: same story against '*', which is tighter than binary +/- but still looser
         // than a unary sign:
-        expect(calculatePrecedenceTiers(["-", "*"], [true, false])).toEqual(["high", "medium"] satisfies PrecedenceTier[]);
+        expect(calculatePrecedenceTiers(["-", "*"], [true, false])).toEqual(["sign-medium", "medium"] satisfies PrecedenceTier[]);
     });
 
     test("two adjacent unary operators of tied precedence both get the neutral default", () => {
@@ -240,8 +245,10 @@ test.describe("calculatePrecedenceTiers: detected unary sign ('-'/'+')", () => {
     });
 
     test("a unary sign among multiple binary operators still resolves per-operator correctly", () => {
-        // -x+y*z: unary "-" (tight) and "*" (tighter than binary +/-) both end up "high",
-        // while the loosest operator present, binary "+", is pulled to "medium":
-        expect(calculatePrecedenceTiers(["-", "+", "*"], [true, false, false])).toEqual(["high", "medium", "high"] satisfies PrecedenceTier[]);
+        // -x+y*z: unary "-" (tight) would ladder-compute to "high" same as "*" (tighter than
+        // binary +/-), but always substitutes to "sign-medium" since it's a detected unary
+        // sign; "*" is unaffected (stays "high"); the loosest operator present, binary "+",
+        // is pulled to "medium":
+        expect(calculatePrecedenceTiers(["-", "+", "*"], [true, false, false])).toEqual(["sign-medium", "medium", "high"] satisfies PrecedenceTier[]);
     });
 });

--- a/tests/playwright/e2e/operator-precedence-spacing.spec.ts
+++ b/tests/playwright/e2e/operator-precedence-spacing.spec.ts
@@ -125,13 +125,20 @@ const EXPRESSION_CASES: [string, string, OpTierInfo[]][] = [
     // an ordinary solo binary '-' would get, but with the leading margin suppressed:
     ["lambda n: -n (pass-through lambda, unary '-' after colon)", "lambda n: -n", [op("lambda", "keyword-medium", true), op(":", "colon"), op("-", "medium", true)]],
     ["-a (detected unary minus, no leading margin)", "-a", [op("-", "medium", true)]],
-    // Once '-' is pulled to 'high' by mixing with a tighter/looser sibling, "high" already
-    // has zero margin on both sides -- no separate unary-prefix marker is needed or applied
-    // (see LabelSlot.vue: the marker is only set when the tier is exactly "sign-medium"):
-    ["-a+b (unary '-' binds tighter than binary '+', pulled to 'high')", "-a+b", [op("-", "high"), op("+", "medium")]],
-    ["-a*b (unary '-' still tighter than '*', pulled to 'high')", "-a*b", [op("-", "high"), op("*", "medium")]],
+    // A detected unary sign always tags "sign-medium" (suppressed leading margin), regardless
+    // of what tier the generic precedence ladder would otherwise have computed for it (here,
+    // "high", from binding tighter than the sibling binary operator). This used to be narrower
+    // (only substituted when the ladder-computed tier was exactly "medium"), on the mistaken
+    // assumption that "high" already looks fine unsubstituted (true for the CSS margin, but
+    // parser.ts's generated Python text also keys off this same tier to decide whether an
+    // operator needs surrounding spaces -- so an unsubstituted "high" unary sign was being
+    // saved as a spaced-out *binary* minus, e.g. "x < -399" round-tripping to "x <  - 399".
+    // Confirmed as a real bug via public/book_projects/chapter12/cheese.spy failing CI, not
+    // just a hypothetical.) See calculatePrecedenceTiers() in operatorPrecedence.ts.
+    ["-a+b (unary '-' binds tighter than binary '+', pulled to 'high' then tagged sign-medium)", "-a+b", [op("-", "medium", true), op("+", "medium")]],
+    ["-a*b (unary '-' still tighter than '*', pulled to 'high' then tagged sign-medium)", "-a*b", [op("-", "medium", true), op("*", "medium")]],
     ["-a**b (unary '-' looser than '**', matches Python's -a**b == -(a**b))", "-a**b", [op("-", "medium", true), op("**", "high")]],
-    ["+a-b*c (unary '+' tight -> 'high' with no marker needed; binary '-' unaffected)", "+a-b*c", [op("+", "high"), op("-", "medium"), op("*", "high")]],
+    ["+a-b*c (unary '+' tight -> 'high' then tagged sign-medium; binary '-' unaffected)", "+a-b*c", [op("+", "medium", true), op("-", "medium"), op("*", "high")]],
     ["a+b*c**d (all three real tiers at once)", "a+b*c**d", [op("+", "low"), op("*", "medium"), op("**", "high")]],
 ];
 
@@ -386,9 +393,12 @@ test.describe("Editing an expression changes tiers dynamically", () => {
         expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);
 
         await typeIndividually(page, "+b");
-        // '-' still binds tighter than binary '+' so it's pulled to "high" -- already zero
-        // margin both sides, so the marker is dropped (nothing left to suppress):
-        expect(await getOperatorTierInfo(page)).toEqual([op("-", "high"), op("+", "medium")]);
+        // '-' still binds tighter than binary '+', pulling its ladder-computed tier to "high"
+        // -- but a detected unary sign always keeps the "sign-medium" substitution (reported
+        // here as "medium", the CSS class the two share) and its marker regardless, since the
+        // marker is also what parser.ts's generated Python text relies on to keep a unary sign
+        // tight against its operand (see calculatePrecedenceTiers()):
+        expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true), op("+", "medium")]);
 
         await pressN("Backspace", 2, true)(page);
         expect(await getOperatorTierInfo(page)).toEqual([op("-", "medium", true)]);


### PR DESCRIPTION
## Summary

Split out from the tree-sitter parser migration branch as a standalone fix -- this is a dormant
bug in `operatorPrecedence.ts` that predates that migration and exists on main today; it's
unrelated to the parser work.

- `calculatePrecedenceTiers()` only substituted a detected unary sign's "sign-medium" tier when
  the generic precedence-ladder computation happened to land on "medium". When a unary sign sits
  in the same ladder segment as a comparison operator (e.g. `x < -399`, where `<` and `-` are
  classified into the same segment), the ladder computes "high" instead, so the substitution
  never fired.
- `parser.ts`'s generated Python text only omits the spaces around an operator when its tier is
  *exactly* "sign-medium", so an unsubstituted "high" unary sign got saved as a spaced-out
  *binary* minus: `x < -399` round-tripped to `x <  - 399`.
- Fixed by making the "sign-medium" substitution unconditional on `isUnarySignAt`, regardless of
  what tier the ladder computed. Visually harmless -- "sign-medium" reuses the same CSS class as
  "medium" (see `LabelSlot.vue`), just adding the leading-margin suppression a unary sign always
  wants anyway.

Updates the 9 existing `operator-precedence-calculation.spec.ts`/`operator-precedence-spacing.spec.ts`
assertions that had pinned the old (buggy) "unsubstituted high" behaviour as the expected/intended
result, and corrects `public/book_projects/chapter12/fish-school.spy` -- a real book-project
fixture whose checked-in content baked in this same bug's buggy output ("( - dist_to_force"
instead of "(-dist_to_force") when it was originally saved.

## Test plan

- [x] `npm run type:check`
- [ ] CI (lint/type-check, Cypress, Playwright) -- just pushed, awaiting results