### PR TITLE
Add aggregate gate job so Playwright Tests can be a required status check

### DIFF
--- a/.github/workflows/run-playwright-tests.yml
+++ b/.github/workflows/run-playwright-tests.yml
@@ -200,3 +200,23 @@ jobs:
         path: resource-monitor.log
         retention-days: 30
         if-no-files-found: ignore
+
+  # Branch protection requires a single check named "Playwright-Tests" to pass, but the matrix
+  # above produces one check per combination (e.g. "test (ubuntu-latest, chromium)"), none of
+  # which is ever named exactly that -- so a required check on any individual combination would
+  # sit pending forever whenever that particular combination is skipped, and no combination on
+  # its own represents "the whole suite passed" anyway. Mirrors run-cypress-tests.yml's
+  # Build-And-Run-Tests gate job. This job depends on the whole matrix via a single job id, so
+  # it stays correct as matrix entries are added or removed, and reports the aggregate result
+  # under the exact name branch protection expects -- without this, GitHub's auto-merge (and any
+  # required-checks gate) only waits for whatever checks *are* required, so a PR could merge
+  # while these jobs were still running (confirmed: this is what happened for PR #1054).
+  Playwright-Tests:
+    name: Playwright-Tests
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        if: ${{ needs.test.result != 'success' && needs.test.result != 'skipped' }}
+        run: exit 1


### PR DESCRIPTION
## Summary

`main`'s branch protection only requires **`Build-And-Run-Tests`** (Cypress's own aggregate gate
job, added in `936426bf` for exactly this reason). The Playwright Tests workflow's jobs are
matrix-based too (e.g. `test (ubuntu-latest, chromium)`), but it never got an equivalent
aggregate job -- so none of its checks are required at all.

That's not just a theoretical gap: GitHub's auto-merge only waits for whatever checks *are*
required, so PR #1054 merged while two of its Playwright jobs were still `in_progress`
(re-running after an "Install Playwright Browsers" hang) -- it wasn't skipped by mistake, it was
simply never wired into branch protection as a gate.

This adds a `Playwright-Tests` job that `needs:` the whole matrix, checks its aggregate result,
and reports under one fixed name -- mirroring `Build-And-Run-Tests`' pattern exactly, so it stays
correct as matrix entries are added or removed.

**Follow-up needed outside this diff:** the workflow change alone doesn't change gating
behaviour -- `main`'s branch protection required-status-checks list also needs `Playwright-Tests`
added alongside `Build-And-Run-Tests`. That's a repo settings change, not something a workflow
file can do on its own.

## Test plan

- [ ] CI (lint/type-check, Cypress, Playwright, and the new `Playwright-Tests` gate job itself)