### PR TITLE
Make an unbalanced-brace f-string round-trip through save/load

### DIFF
--- a/src/helpers/pythonToFrames.ts
+++ b/src/helpers/pythonToFrames.ts
@@ -228,6 +228,39 @@ export const STRYPE_INVALID_SLOT = "___strype_invalid_";
 
 export const STRYPE_INVALID_OPS_WRAPPER = "___strype_opsinvalid";
 export const STRYPE_INVALID_OP = "___strype_operator_";
+// Wraps an f-string whose content can't be emitted as valid Python (an unmatched "{"/"}" --
+// which is a genuine SyntaxError in real Python too, e.g. f"{x", not just a parsing artefact).
+// See replaceMediaLiteralsAndInvalidOps() below and transformSlotLevel() in parser.ts.
+// Deliberately NOT prefixed with STRYPE_INVALID_SLOT ("___strype_invalid_") -- that prefix is
+// stripped from any identifier that starts with it (terminalToSlots() below), which would
+// silently mangle this name too if it were a prefix match (confirmed as a real bug live
+// in-browser: the call was displayed/reloaded as bare "fstring(...)").
+export const STRYPE_INVALID_FSTRING_WRAPPER = "___strype_fstring_wrap";
+
+// A minimal, self-contained escape/unescape pair (1-char-lookahead, so unescaping is unambiguous
+// in a single left-to-right pass) used only for STRYPE_INVALID_FSTRING_WRAPPER's argument: the
+// generic string-slot generation path (parser.ts's getSlotStartsLengthsAndCodeForFrameLabel)
+// emits a StringSlot's .code completely verbatim between its quote chars (Strype's normal typed
+// input never contains an unescaped matching quote char, since typing one just closes the field
+// rather than inserting a literal character -- so there's normally nothing to escape). Here we
+// deliberately construct a StringSlot.code containing the original quote char programmatically,
+// so -- unlike normal typed input -- it must be escaped ourselves before emission.
+export function escapeForPlainStringLiteral(raw: string): string {
+    return raw.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+}
+export function unescapeFromPlainStringLiteral(escaped: string): string {
+    let result = "";
+    for (let i = 0; i < escaped.length; i++) {
+        if (escaped[i] === "\\" && i + 1 < escaped.length) {
+            result += escaped[i + 1];
+            i++;
+        }
+        else {
+            result += escaped[i];
+        }
+    }
+    return result;
+}
 
 export interface SavedFrameState {
     collapsed?: CollapsedState;
@@ -818,6 +851,29 @@ function replaceMediaLiteralsAndInvalidOps(s : SlotsStructure) : SlotsStructure 
                         replaced = true;
                     }
                     // Otherwise don't substitute
+                }
+            }
+            else if (curField.code === STRYPE_INVALID_FSTRING_WRAPPER) {
+                // The single argument holds the original prefix+quote+content+quote as an ordinary
+                // (non-f) string, safely re-parsed here with the same regex toSlots() uses for a
+                // terminal string node, to reconstruct the [prefix, StringSlot, blank] triple a
+                // real string literal would have produced (see transformSlotLevel() in parser.ts
+                // for the save side):
+                if (sub.fields.length == 3
+                    && sub.openingBracketValue == "("
+                    && isFieldBaseSlot(sub.fields[0]) && !(sub.fields[0] as BaseSlot).code
+                    && !sub.operators[0].code
+                    && isFieldStringSlot(sub.fields[1])
+                    && !sub.operators[1].code
+                    && isFieldBaseSlot(sub.fields[2]) && !(sub.fields[2] as BaseSlot).code) {
+                    const raw = unescapeFromPlainStringLiteral((sub.fields[1] as StringSlot).code);
+                    const strMatch = /^([rbfRBF]*)(["'])([\s\S]*)$/.exec(raw);
+                    if (strMatch) {
+                        const quote = strMatch[2];
+                        const code = strMatch[3].slice(0, strMatch[3].length - quote.length);
+                        s.fields.splice(i, 2, {code: strMatch[1]}, {code, quote} as StringSlot, {code: ""});
+                        s.operators.splice(i, 1, {code: ""}, {code: ""});
+                    }
                 }
             }
             else if (curField.code === STRYPE_INVALID_OPS_WRAPPER) {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -10,7 +10,7 @@ import {AppSPYFullPrefix} from "@/helpers/appContext";
 // #v-ifdef STRYPE_PLATFORM == VITE_STANDARD_PYTHON_MODE
 import { actOnGraphicsImport } from "@/helpers/editor";
 // #v-endif
-import {STRYPE_DUMMY_FIELD, STRYPE_EXPRESSION_BLANK, STRYPE_INVALID_OP, STRYPE_INVALID_OPS_WRAPPER, STRYPE_INVALID_SLOT} from "@/helpers/pythonToFrames";
+import {STRYPE_DUMMY_FIELD, STRYPE_EXPRESSION_BLANK, STRYPE_INVALID_FSTRING_WRAPPER, STRYPE_INVALID_OP, STRYPE_INVALID_OPS_WRAPPER, STRYPE_INVALID_SLOT, escapeForPlainStringLiteral} from "@/helpers/pythonToFrames";
 
 const INDENT = "    ";
 const DISABLEDFRAMES_FLAG =  "\"\"\"";
@@ -106,10 +106,65 @@ function interleave<T>(a: T[], b: T[]): T[] {
     return result;
 }
 
+// An f-string's content is stored as plain text (see toSlots() in pythonToFrames.ts -- there's
+// no separate structure for the {expr} substitutions), so nothing stops a user typing an
+// unmatched "{" or "}" into one. That's not just a parsing artefact: it's a genuine SyntaxError
+// in real Python too (e.g. f"{x" fails to compile), so it can never be emitted as a real
+// f-string literal. This checks the same brace-balancing rule Python itself applies (an
+// unescaped "{{"/"}}" pair is literal, anything else must nest to zero) to detect that case
+// before it happens, rather than after a failed round-trip:
+function isWellFormedFString(code: string): boolean {
+    let depth = 0;
+    for (let i = 0; i < code.length; i++) {
+        const c = code[i];
+        if (c === "{") {
+            if (depth === 0 && code[i + 1] === "{") {
+                i++;
+                continue;
+            }
+            depth++;
+        }
+        else if (c === "}") {
+            if (depth === 0) {
+                if (code[i + 1] === "}") {
+                    i++;
+                    continue;
+                }
+                return false;
+            }
+            depth--;
+        }
+    }
+    return depth === 0;
+}
+
+// Replaces any [prefix, StringSlot, blank] triple (the shape toSlots() produces for a string
+// terminal) that is an f-string with unbalanced braces with a call to
+// STRYPE_INVALID_FSTRING_WRAPPER, so saving never emits Python that's guaranteed to fail to
+// re-parse. The prefix+quote+content is preserved verbatim as an ordinary (non-f) string
+// argument -- braces have no special meaning there, so it's always safely representable -- and
+// unwrapped again on load by replaceMediaLiteralsAndInvalidOps() in pythonToFrames.ts.
+function escapeUnrepresentableFStrings(slots: SlotsStructure): SlotsStructure {
+    for (let i = 0; i + 1 < slots.fields.length; i++) {
+        const prefixField = slots.fields[i];
+        const strField = slots.fields[i + 1];
+        if (isFieldBaseSlot(prefixField) && /^[rRbB]*[fF][rRbB]*$/.test(prefixField.code)
+            && slots.operators[i]?.code === ""
+            && isFieldStringSlot(strField) && !isWellFormedFString(strField.code)) {
+            const raw = prefixField.code + strField.quote + strField.code + strField.quote;
+            slots.fields[i] = {code: STRYPE_INVALID_FSTRING_WRAPPER};
+            slots.fields[i + 1] = {openingBracketValue: "(", operators: [{code: ""}, {code: ""}],
+                fields: [{code: ""}, {code: escapeForPlainStringLiteral(raw), quote: "\""} as StringSlot, {code: ""}]};
+        }
+    }
+    return slots;
+}
+
 // Checks if the level will parse as-is given the arrangement of operators and operands
 // If not, it transforms it into a special call ___strype_invalid_ops([]) where each
 // item in the list is an operand, or a ___strype_operator_uXXXX escaped operator.
 function transformSlotLevel(slots: SlotsStructure, topLevel?: {frameType: string, slotIndex: number}): SlotsStructure {
+    slots = escapeUnrepresentableFStrings(slots);
     // Here's what prevents parsing:
     // - A unary operator (like "not", "~") with something non-blank before it.
     // - Commas at the top-level of most constructs (only assignments, return, for and global allow it)

--- a/tests/cypress/fixtures/format-strings.spy
+++ b/tests/cypress/fixtures/format-strings.spy
@@ -6,6 +6,6 @@ print(f"Hi there")
 x  = 7 + 3 
 print(f"X is: {x} (double quotes)") 
 print(f'X is: {x} (single quotes)') 
-print(1 + F"Invalid as missing closing: {x") 
+print(1 + ___strype_fstring_wrap("F\"Invalid as missing closing: {x\"")) 
 y  = B'1' - r'2' + rF'3' + print(f"''") - br"1" 
 #(=> Section:End

--- a/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
+++ b/tests/playwright/e2e/load-save-frozen-collapsed.spec.ts
@@ -413,6 +413,21 @@ def foo (name,ID ) :
 foo("Anon",7) 
 #(=> Section:End
 `;
+    // The mismatched-brace f-string above loads fine (Skulpt is lenient about it), but saving it
+    // back out now goes through the new escapeUnrepresentableFStrings() check in parser.ts (see
+    // "Make an unbalanced-brace f-string round-trip through save/load"), which wraps it in
+    // ___strype_fstring_wrap(...) rather than re-emitting Python that's guaranteed to fail to
+    // re-parse -- so the *saved* content differs from what was loaded:
+    const expectedSaveWithTigerPythonError = `#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def foo (name,ID ) :
+    # Mismatched format string:
+    print(___strype_fstring_wrap("f\\"Student: {name} ({ID)\\"")) 
+#(=> Section:Main
+foo("Anon",7) 
+#(=> Section:End
+`;
 
     test("Cannot freeze if there is a syntax error #2", async ({page}) => {
         await loadContent(page, inputWithTigerPythonError);
@@ -422,7 +437,7 @@ foo("Anon",7)
         // Menu remains though so we need to dismiss it:
         await page.keyboard.press("Escape");
         // We should then not be frozen, so should be unmodified state:
-        await saveAndCheck(page, inputWithTigerPythonError);
+        await saveAndCheck(page, expectedSaveWithTigerPythonError);
     });
 });
 
@@ -475,6 +490,17 @@ def foo (name,ID ) :
 foo("Anon",7) 
 #(=> Section:End
 `;
+    // See expectedSaveWithTigerPythonError's comment in the describe block above -- same reason:
+    const expectedSaveWithTigerPythonError = `#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+def foo (name,ID ) :
+    # Mismatched format string:
+    print(___strype_fstring_wrap("f\\"Student: {name} ({ID)\\"")) 
+#(=> Section:Main
+foo("Anon",7) 
+#(=> Section:End
+`;
 
     test("Cannot fold if there is a syntax error #2", async ({page}) => {
         await loadContent(page, inputWithTigerPythonError);
@@ -485,9 +511,9 @@ foo("Anon",7)
         await page.keyboard.press("Escape");
         await clickFoldFor(page, "def");
         // We should then not be folded, so should be unmodified state:
-        await saveAndCheck(page, inputWithTigerPythonError);
+        await saveAndCheck(page, expectedSaveWithTigerPythonError);
     });
-    
+
     const inputWithNestedTigerPythonError = `#(=> Strype:1:std
 #(=> Section:Imports
 #(=> Section:Definitions
@@ -500,6 +526,19 @@ class Alpha  :
 Alpha(None) 
 #(=> Section:End
 `;
+    // See expectedSaveWithTigerPythonError's comment above -- same reason, different wrapped f-string:
+    const expectedSaveWithNestedTigerPythonError = `#(=> Strype:1:std
+#(=> Section:Imports
+#(=> Section:Definitions
+class Alpha  :
+    def hasNoError (self, ) :
+        return 42 
+    def __init__ (self,y ) :
+        self.x  = ___strype_fstring_wrap("f\\"{len(y)\\"") 
+#(=> Section:Main
+Alpha(None) 
+#(=> Section:End
+`;
 
     test("Cannot fold if there is a syntax error #3", async ({page}) => {
         await loadContent(page, inputWithNestedTigerPythonError);
@@ -507,7 +546,7 @@ Alpha(None)
         // Folding all children should not fold it:
         await clickFoldChildrenFor(page, "class");
         // We should then only have folded the one without an error:
-        await saveAndCheck(page, testState({"hasNoError": "FoldToHeader"}, inputWithNestedTigerPythonError));
+        await saveAndCheck(page, testState({"hasNoError": "FoldToHeader"}, expectedSaveWithNestedTigerPythonError));
     });
 });
 


### PR DESCRIPTION
## Summary

Split out from the tree-sitter parser migration branch as a standalone fix -- the underlying bug
is independent of which parser Strype uses.

An f-string with unmatched braces (e.g. `F"...{x"`, missing the closing `}`) is a genuine
SyntaxError in real Python, not a parser quirk -- but a user can trivially type this into a
string slot live today (f-string interpolation braces are just part of a StringSlot's flat
`.code`, not a separate editable sub-structure). Strype must never *save* Python that's
guaranteed to fail to re-parse, so this needed a real fix rather than a fixture adjustment.

- `transformSlotLevel()` in `parser.ts` now detects an f-string whose content has unbalanced
  braces (checking the same brace-escaping rule Python itself applies -- an unescaped `{{`/`}}`
  pair is literal, anything else must nest to zero) and saves it as
  `___strype_fstring_wrap("<prefix+quote+content+quote, escaped>")` instead -- an ordinary
  (non-f) string argument, always safely representable since braces have no special meaning
  there.
- `replaceMediaLiteralsAndInvalidOps()` in `pythonToFrames.ts` unwraps it again on load,
  reconstructing the original `[prefix, StringSlot, blank]` triple.
- Two escaping details needed getting right, found by testing the actual round-trip live in the
  browser: the wrapper's string argument needs its own escaping (`escapeForPlainStringLiteral()`/
  `unescapeFromPlainStringLiteral()`), and the wrapper's name must avoid the
  `STRYPE_INVALID_SLOT` prefix, which is silently stripped from identifiers elsewhere in this
  module.

`format-strings.spy` updated to the new saved form, confirmed byte-for-byte against the app's own
regenerated output.

## Test plan

- [x] `npm run type:check` / `npm run lint:check`
- [x] `load-save.cy.ts` (Cypress) -- 39/39 passing, exercises this fixture
- [x] `load-save-share.spec.ts` (Playwright) -- 28/28 on chromium/firefox (webkit failures are a
      local missing-browser-binary issue, unrelated), exercises this fixture too