### PR TITLE
Remove unused @types/splitpanes devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "@types/object-hash": "^3.0.6",
                 "@types/path-browserify": "^1.0.3",
                 "@types/sortablejs": "^1.10.6",
-                "@types/splitpanes": "^2.2.6",
                 "@vitejs/plugin-vue": "6.0.7",
                 "@wsfe/vue-tree": "^4.1.1",
                 "audiobuffer-to-wav": "^1.0.0",
@@ -3683,48 +3682,6 @@
             "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
             "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
             "license": "MIT"
-        },
-        "node_modules/@types/splitpanes": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/@types/splitpanes/-/splitpanes-2.2.6.tgz",
-            "integrity": "sha512-3dV5sO1Ht74iER4jJU03mreL3f+Q2h47ZqXS6Sfbqc6hkCvsDrX1GA0NbYWRdNvZemPyTDzUoApWKeoGbALwkQ==",
-            "license": "MIT",
-            "dependencies": {
-                "vue": "^2.0.0"
-            }
-        },
-        "node_modules/@types/splitpanes/node_modules/@vue/compiler-sfc": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-            "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
-            "dependencies": {
-                "@babel/parser": "^7.23.5",
-                "postcss": "^8.4.14",
-                "source-map": "^0.6.1"
-            },
-            "optionalDependencies": {
-                "prettier": "^1.18.2 || ^2.0.0"
-            }
-        },
-        "node_modules/@types/splitpanes/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@types/splitpanes/node_modules/vue": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-            "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-            "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-sfc": "2.7.16",
-                "csstype": "^3.1.0"
-            }
         },
         "node_modules/@types/strip-bom": {
             "version": "3.0.0",
@@ -13310,22 +13267,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/prettier": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
         "@types/object-hash": "^3.0.6",
         "@types/path-browserify": "^1.0.3",
         "@types/sortablejs": "^1.10.6",
-        "@types/splitpanes": "^2.2.6",
         "@vitejs/plugin-vue": "6.0.7",
         "@wsfe/vue-tree": "^4.1.1",
         "audiobuffer-to-wav": "^1.0.0",


### PR DESCRIPTION
Probably the shortest simplest PR you'll get!  The Github Dependabot security thing was complaining and it seems because of an old @types/splitpanes dependency that isn't needed now splitpanes ships its own types.

Claude says: The dependency only existed to type an old, no-longer-imported package and pulls in a nested, EOL Vue 2.7.16 as a transitive dependency, which is the sole source of the one open Dependabot alert (GHSA-5j4c-8p2g-v4jx, ReDoS in Vue 2's parseHTML — Strype itself runs Vue 3.5.40, unaffected). splitpanes 4.1.2 ships its own .d.ts types, so the separate @types package is redundant; vue-tsc --noEmit still passes without it.