### PR TITLE
Strype metrics fixes

### DIFF
--- a/src/components/AddFrameCommand.vue
+++ b/src/components/AddFrameCommand.vue
@@ -57,6 +57,7 @@ export default defineComponent({
                 const addFrameCommandType = findAddCommandFrameType(this.shortcut, this.index);
                 if(addFrameCommandType != null){
                     this.appStore.addFrameWithCommand(addFrameCommandType);
+                    this.appStore.trackFrameInsert(addFrameCommandType.type, "shortcut");
                 }
             }
         },

--- a/src/components/AddFrameCommand.vue
+++ b/src/components/AddFrameCommand.vue
@@ -51,13 +51,27 @@ export default defineComponent({
     },
 
     methods: {
-        onClick(): void {
+        onClick(event: MouseEvent): void {
             //add the frame in the editor if the panel is not disabled
             if(!this.isPythonExecuting) {
                 const addFrameCommandType = findAddCommandFrameType(this.shortcut, this.index);
                 if(addFrameCommandType != null){
                     this.appStore.addFrameWithCommand(addFrameCommandType);
-                    this.appStore.trackFrameInsert(addFrameCommandType.type, "shortcut");
+                    // This same button is reached three different ways: a genuine mouse click, Enter
+                    // confirming whichever button the frame commands pane currently has focused
+                    // (Commands.vue's keyup handler deliberately blocks the native keydown auto-click --
+                    // see its own comment -- and instead calls activeElement.click() itself once the
+                    // key's lifecycle is otherwise finished), and the "Insert frame" context-menu item
+                    // (CaretContainer.vue), which also ultimately calls .click() on this element
+                    // programmatically. Only the first is a real user-generated click -- the other two
+                    // are JS-invoked, so the browser marks them event.isTrusted === false -- which is a
+                    // reliable, native way to tell them apart without needing to plumb an explicit
+                    // origin through two otherwise-unrelated call sites. Both indirect triggers are
+                    // reported as "shortcut_key" rather than getting a third category of their own: the
+                    // context-menu item is arguably mouse-driven too, but it's a rare path and lumping
+                    // it in keeps the split to the two categories that actually matter (deliberately
+                    // choosing a frame type vs. organically typing one -- see trackFrameInsert's comment).
+                    this.appStore.trackFrameInsert(addFrameCommandType.type, event.isTrusted ? "shortcut_mouse" : "shortcut_key");
                 }
             }
         },

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -866,7 +866,7 @@ export default defineComponent({
                                 this.appStore.addFrameWithCommand(getFrameDefType(AllFrameTypesIdentifier.funccall)).then(() => {
                                     document.activeElement?.dispatchEvent(new KeyboardEvent("keydown",{key: " ", ctrlKey: true}));
                                 });
-                                this.appStore.trackFrameInsert(AllFrameTypesIdentifier.funccall, "shortcut");
+                                this.appStore.trackFrameInsert(AllFrameTypesIdentifier.funccall, "shortcut_key");
                             }
                         }
                     }
@@ -989,7 +989,7 @@ export default defineComponent({
                 // Adding a shorthand frame required to 1) add the frame itself
                 const shorthandDef = hiddenShorthandFrames[eventKeyLowCase];
                 this.appStore.addFrameWithCommand(shorthandDef.type, shorthandDef);
-                this.appStore.trackFrameInsert(shorthandDef.type.type, "shortcut");
+                this.appStore.trackFrameInsert(shorthandDef.type.type, "shortcut_key");
             }
             else{
                 // We can add the frame by its original shortcut or legacy one
@@ -998,7 +998,7 @@ export default defineComponent({
                     ? this.addFrameCommands[eventKeyLowCase][0].type
                     : (Object.values(this.addFrameCommands).find((addFrameCmdDef) => getLegacyShortcut(addFrameCmdDef[0]) == eventKeyLowCase) as AddFrameCommandDef[])[0].type;
                 this.appStore.addFrameWithCommand(resolvedType);
-                this.appStore.trackFrameInsert(resolvedType.type, "shortcut");
+                this.appStore.trackFrameInsert(resolvedType.type, "shortcut_key");
             }
             return true;
         },

--- a/src/components/Commands.vue
+++ b/src/components/Commands.vue
@@ -866,6 +866,7 @@ export default defineComponent({
                                 this.appStore.addFrameWithCommand(getFrameDefType(AllFrameTypesIdentifier.funccall)).then(() => {
                                     document.activeElement?.dispatchEvent(new KeyboardEvent("keydown",{key: " ", ctrlKey: true}));
                                 });
+                                this.appStore.trackFrameInsert(AllFrameTypesIdentifier.funccall, "shortcut");
                             }
                         }
                     }
@@ -986,16 +987,18 @@ export default defineComponent({
 
             if(isHiddenShorthandFrameCommand) {
                 // Adding a shorthand frame required to 1) add the frame itself
-                this.appStore.addFrameWithCommand(hiddenShorthandFrames[eventKeyLowCase].type, hiddenShorthandFrames[eventKeyLowCase]);
+                const shorthandDef = hiddenShorthandFrames[eventKeyLowCase];
+                this.appStore.addFrameWithCommand(shorthandDef.type, shorthandDef);
+                this.appStore.trackFrameInsert(shorthandDef.type.type, "shortcut");
             }
             else{
                 // We can add the frame by its original shortcut or legacy one
                 const isOriginalShortcut = (this.addFrameCommands[eventKeyLowCase] != undefined);
-                this.appStore.addFrameWithCommand(
-                    (isOriginalShortcut)
-                        ? this.addFrameCommands[eventKeyLowCase][0].type
-                        : (Object.values(this.addFrameCommands).find((addFrameCmdDef) => getLegacyShortcut(addFrameCmdDef[0]) == eventKeyLowCase) as AddFrameCommandDef[])[0].type
-                );
+                const resolvedType = (isOriginalShortcut)
+                    ? this.addFrameCommands[eventKeyLowCase][0].type
+                    : (Object.values(this.addFrameCommands).find((addFrameCmdDef) => getLegacyShortcut(addFrameCmdDef[0]) == eventKeyLowCase) as AddFrameCommandDef[])[0].type;
+                this.appStore.addFrameWithCommand(resolvedType);
+                this.appStore.trackFrameInsert(resolvedType.type, "shortcut");
             }
             return true;
         },
@@ -1018,6 +1021,7 @@ export default defineComponent({
             // the user is just typing (e.g. the start of "if"/"while"/"return"), and the frame may well
             // get converted away from func-call entirely once LabelSlotsStructure.vue's funccall->
             // keyword-frame/varassign conversion kicks in -- see skipFuncCallBrackets's own comment.
+            this.appStore.trackFrameInsert(AllFrameTypesIdentifier.funccall, "typed");
             this.appStore.addFrameWithCommand(getFrameDefType(AllFrameTypesIdentifier.funccall), undefined, true).then((newFrameId: number) => {
                 // Target the new frame's name slot explicitly (rather than document.activeElement):
                 // its own name slot isn't necessarily what ends up focused by the time this promise

--- a/src/components/LabelSlotsStructure.vue
+++ b/src/components/LabelSlotsStructure.vue
@@ -680,6 +680,7 @@ export default defineComponent({
                                         // Change the type of frame to varassign and adapt the content
                                         // (when we change the state in this next line, we need to COPY the FrameType object otherwise undo/redo makes weird changes in the commands)
                                         this.appStore.frameObjects[this.frameId].frameType = cloneDeep(getFrameDefType(AllFrameTypesIdentifier.varassign));
+                                        this.appStore.trackFrameConvert(AllFrameTypesIdentifier.varassign);
                                         const newContent: { [index: number]: LabelSlotsContent} = {
                                             // LHS
                                             0: {
@@ -995,6 +996,7 @@ export default defineComponent({
             // Change the type of frame (when we change the state in this next line, we need to COPY
             // the FrameType object otherwise undo/redo makes weird changes in the commands)
             this.appStore.frameObjects[this.frameId].frameType = cloneDeep(getFrameDefType(def.targetType));
+            this.appStore.trackFrameConvert(def.targetType);
 
             const rawRemainder = uiLiteralCode.slice(keywordLen + separatorLength);
 

--- a/src/helpers/analyticsConstants.ts
+++ b/src/helpers/analyticsConstants.ts
@@ -5,7 +5,7 @@ export const Analytics_session_tick_ms = 30_000;
 export const Analytics_session_idle_threshold_ms = 5 * 60_000;
 
 /** Periodic flush interval for the analytics event queue. */
-export const Analytics_batch_flush_ms = 60_000;
+export const Analytics_batch_flush_ms = 20_000;
 
 /** Size cap that triggers an immediate flush when the queue grows past it. */
 export const Analytics_batch_max_events = 100;

--- a/src/helpers/initialiseAnalytics.ts
+++ b/src/helpers/initialiseAnalytics.ts
@@ -1,5 +1,5 @@
 import { settingsStore } from "@/store/store";
-import { onAnalyticsPageUnload, startSessionTracking } from "@/helpers/sessionTracker";
+import { onAnalyticsPageHidden, onAnalyticsPageUnload, startSessionTracking } from "@/helpers/sessionTracker";
 import { Analytics_batch_flush_ms } from "@/helpers/analyticsConstants";
 import {
     analyticsState,
@@ -35,7 +35,7 @@ export function initialiseAnalytics(): void {
     window.addEventListener("pagehide", onAnalyticsPageUnload);
     document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "hidden") {
-            onAnalyticsPageUnload();
+            onAnalyticsPageHidden();
         }
     });
 }

--- a/src/helpers/initialiseAnalytics.ts
+++ b/src/helpers/initialiseAnalytics.ts
@@ -32,7 +32,20 @@ export function initialiseAnalytics(): void {
     setInterval(() => flushAnalyticsQueue("interval"), Analytics_batch_flush_ms);
 
     window.addEventListener("beforeunload", onAnalyticsPageUnload);
-    window.addEventListener("pagehide", onAnalyticsPageUnload);
+    // event.persisted true means the page is being frozen into the back/forward cache, not actually
+    // unloading -- it can be fully restored later (e.g. via the Back button) with this same JS state
+    // intact, so that case is routed through the non-final "hidden" checkpoint instead (see
+    // onAnalyticsPageHidden's own comment): treating it as final here would permanently block any
+    // further session_end for a page that's still genuinely in use, the same class of bug the
+    // "hidden" checkpoint itself was added to fix.
+    window.addEventListener("pagehide", (event) => {
+        if (event.persisted) {
+            onAnalyticsPageHidden();
+        }
+        else {
+            onAnalyticsPageUnload();
+        }
+    });
     document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "hidden") {
             onAnalyticsPageHidden();

--- a/src/helpers/sessionTracker.ts
+++ b/src/helpers/sessionTracker.ts
@@ -3,7 +3,7 @@ import { analyticsState, enqueueAnalyticsEvent, flushAnalyticsQueue } from "@/st
 import { Analytics_session_idle_threshold_ms, Analytics_session_tick_ms } from "@/helpers/analyticsConstants";
 
 let runFinalSessionTick: (() => void) | null = null;
-let pageUnloadHandled = false;
+let finalUnloadHandled = false;
 
 export function startSessionTracking(): void {
     let lastActivityTime = Date.now();
@@ -34,13 +34,9 @@ export function startSessionTracking(): void {
     setInterval(tick, Analytics_session_tick_ms);
 }
 
-/** Runs once per page hide/unload: final tick, session_end event, then flush the queue. */
-export function onAnalyticsPageUnload(): void {
-    if (pageUnloadHandled) {
-        return;
-    }
-    pageUnloadHandled = true;
-
+/** Final tick, session_end event, then flush the queue -- shared by the "genuinely gone for good"
+ * and "merely hidden for now" callers below. */
+function sendSessionEndSnapshot(): void {
     runFinalSessionTick?.();
 
     const store = useStore();
@@ -50,4 +46,32 @@ export function onAnalyticsPageUnload(): void {
         frameCount: analyticsState.frameCount,
     });
     flushAnalyticsQueue("unload");
+}
+
+/** Runs once per genuine page unload (beforeunload/pagehide): final tick, session_end event, then
+ * flush the queue. Guarded against double-firing since both events can fire for the same navigation,
+ * and against firing again after a "hidden" checkpoint (below) -- once the page is genuinely gone,
+ * nothing will observe a further event anyway. */
+export function onAnalyticsPageUnload(): void {
+    if (finalUnloadHandled) {
+        return;
+    }
+    finalUnloadHandled = true;
+    sendSessionEndSnapshot();
+}
+
+/** Tab merely hidden (switched away from, minimized, backgrounded) -- NOT necessarily final: unlike
+ * beforeunload/pagehide, this fires on an ordinary tab switch and the page can easily still be
+ * revisited hours or days later if the user just leaves it open in the background (confirmed via a
+ * DB query: ~17% of sessions had real activity events timestamped after their own session_end, with
+ * gaps averaging ~4 hours and reaching over two weeks -- consistent with long-lived backgrounded tabs,
+ * not genuinely-ended sessions). So this sends a checkpoint session_end (the server upserts sessions
+ * to the latest values it receives, so a later, more accurate one still wins) without setting
+ * finalUnloadHandled -- unlike onAnalyticsPageUnload, it deliberately doesn't self-guard against
+ * repeat calls, so it can keep checkpointing every time the tab goes back into the background. */
+export function onAnalyticsPageHidden(): void {
+    if (finalUnloadHandled) {
+        return;
+    }
+    sendSessionEndSnapshot();
 }

--- a/src/helpers/sessionTracker.ts
+++ b/src/helpers/sessionTracker.ts
@@ -48,10 +48,11 @@ function sendSessionEndSnapshot(): void {
     flushAnalyticsQueue("unload");
 }
 
-/** Runs once per genuine page unload (beforeunload/pagehide): final tick, session_end event, then
- * flush the queue. Guarded against double-firing since both events can fire for the same navigation,
- * and against firing again after a "hidden" checkpoint (below) -- once the page is genuinely gone,
- * nothing will observe a further event anyway. */
+/** Runs once per genuine page unload (beforeunload, or pagehide with event.persisted false --
+ * see initialiseAnalytics.ts's pagehide listener): final tick, session_end event, then flush the
+ * queue. Guarded against double-firing since beforeunload and a non-persisted pagehide can both fire
+ * for the same navigation, and against firing again after a "hidden"/persisted-pagehide checkpoint
+ * (below) -- once the page is genuinely gone, nothing will observe a further event anyway. */
 export function onAnalyticsPageUnload(): void {
     if (finalUnloadHandled) {
         return;
@@ -60,15 +61,18 @@ export function onAnalyticsPageUnload(): void {
     sendSessionEndSnapshot();
 }
 
-/** Tab merely hidden (switched away from, minimized, backgrounded) -- NOT necessarily final: unlike
- * beforeunload/pagehide, this fires on an ordinary tab switch and the page can easily still be
- * revisited hours or days later if the user just leaves it open in the background (confirmed via a
- * DB query: ~17% of sessions had real activity events timestamped after their own session_end, with
- * gaps averaging ~4 hours and reaching over two weeks -- consistent with long-lived backgrounded tabs,
- * not genuinely-ended sessions). So this sends a checkpoint session_end (the server upserts sessions
- * to the latest values it receives, so a later, more accurate one still wins) without setting
+/** The page is merely hidden/suspended for now, NOT genuinely gone -- covers both an ordinary tab
+ * switch (visibilitychange -> "hidden") and a pagehide with event.persisted true (the page is being
+ * frozen into the browser's back/forward cache, not destroyed, and can be fully restored later --
+ * e.g. via the Back button -- with this same JS state, including finalUnloadHandled, intact). Either
+ * way the page can easily still be revisited (in the tab-switch case, potentially hours or days
+ * later if the user just leaves it open in the background: confirmed via a DB query, ~17% of
+ * sessions had real activity events timestamped after their own session_end, with gaps averaging
+ * ~4 hours and reaching over two weeks -- consistent with long-lived backgrounded tabs, not
+ * genuinely-ended sessions). So this sends a checkpoint session_end (the server upserts sessions to
+ * the latest values it receives, so a later, more accurate one still wins) without setting
  * finalUnloadHandled -- unlike onAnalyticsPageUnload, it deliberately doesn't self-guard against
- * repeat calls, so it can keep checkpointing every time the tab goes back into the background. */
+ * repeat calls, so it can keep checkpointing every time the page goes back into the background. */
 export function onAnalyticsPageHidden(): void {
     if (finalUnloadHandled) {
         return;

--- a/src/store/analytics.ts
+++ b/src/store/analytics.ts
@@ -197,6 +197,22 @@ export function trackUsedBookProject(projectName: string, chapter: string): void
     enqueueAnalyticsEvent("book_project_used", {projectName: cleanName, chapter});
 }
 
+// How a frame was inserted: an explicit shortcut/command choice (keyboard shortcut key, frame
+// commands pane, or a click on an AddFrameCommand button) vs. organic typing at the bare frame caret
+// (which creates an empty func-call frame -- frameType is always "funccall" for this method; its
+// eventual real type, if any, shows up separately via trackFrameConvert).
+export function trackFrameInsert(frameType: string, method: "shortcut" | "typed"): void {
+    enqueueAnalyticsEvent("frame_insert", {frameType, method});
+}
+
+// A func-call frame silently converted to another frame type because its typed content matched a
+// recognised keyword (keywordFrameConversions, LabelSlotsStructure.vue) or a variable assignment.
+// Virtually always follows a "typed" frame_insert -- a func-call created via its own explicit
+// shortcut and then retyped into another keyword is possible but rare enough not to distinguish here.
+export function trackFrameConvert(toType: string): void {
+    enqueueAnalyticsEvent("frame_convert", {toType});
+}
+
 export function trackStorageLocation(target: StrypeSyncTarget): void {
     let storageLocation: "local" | "cloud" | null = null;
     if (target == StrypeSyncTarget.fs) {

--- a/src/store/analytics.ts
+++ b/src/store/analytics.ts
@@ -197,11 +197,15 @@ export function trackUsedBookProject(projectName: string, chapter: string): void
     enqueueAnalyticsEvent("book_project_used", {projectName: cleanName, chapter});
 }
 
-// How a frame was inserted: an explicit shortcut/command choice (keyboard shortcut key, frame
-// commands pane, or a click on an AddFrameCommand button) vs. organic typing at the bare frame caret
-// (which creates an empty func-call frame -- frameType is always "funccall" for this method; its
-// eventual real type, if any, shows up separately via trackFrameConvert).
-export function trackFrameInsert(frameType: string, method: "shortcut" | "typed"): void {
+// How a frame was inserted: an explicit shortcut/command choice -- either "shortcut_key" (a direct
+// keyboard shortcut at the bare frame caret, or a letter shortcut typed while the frame commands pane
+// is focused -- see insertFrameForShortcutKey, Commands.vue) or "shortcut_mouse" (a genuine mouse
+// click on an AddFrameCommand button -- see its own onClick for how Enter-confirm and the "Insert
+// frame" context-menu item, which both also end up clicking that same button programmatically, are
+// folded into "shortcut_key" instead) -- vs. "typed", organic typing at the bare frame caret (which
+// creates an empty func-call frame -- frameType is always "funccall" for this method; its eventual
+// real type, if any, shows up separately via trackFrameConvert).
+export function trackFrameInsert(frameType: string, method: "shortcut_key" | "shortcut_mouse" | "typed"): void {
     enqueueAnalyticsEvent("frame_insert", {frameType, method});
 }
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -25,6 +25,8 @@ import {
     initAnalyticsSession,
     initAnalyticsUserId,
     trackAnalyticsLocaleChange,
+    trackFrameConvert,
+    trackFrameInsert,
     trackInputCall,
     trackMenuAction,
     trackOutputChars,
@@ -722,6 +724,14 @@ export const useStore = defineStore("app", {
 
         trackStorageLocation(target: StrypeSyncTarget) {
             trackStorageLocation(target);
+        },
+
+        trackFrameInsert(frameType: string, method: "shortcut" | "typed") {
+            trackFrameInsert(frameType, method);
+        },
+
+        trackFrameConvert(toType: string) {
+            trackFrameConvert(toType);
         },
 
         updateKeyModifiers(e: KeyboardEvent | MouseEvent) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -726,7 +726,7 @@ export const useStore = defineStore("app", {
             trackStorageLocation(target);
         },
 
-        trackFrameInsert(frameType: string, method: "shortcut" | "typed") {
+        trackFrameInsert(frameType: string, method: "shortcut_key" | "shortcut_mouse" | "typed") {
             trackFrameInsert(frameType, method);
         },
 


### PR DESCRIPTION
A small PR to adjust some metrics issues.  Mainly this adds some tracking for how frames are inserted (shortcut keys or just typing) and how many are later converted, so we will be able to tell how many users use shortcut keys vs just type their frames in.  That's in this PR but while doing it I found that there was actually a bug in session ending that meant sessions appeared shorter than they were because we were assuming "visibilitychange" meant page closure, but actually it can just mean switching away from the tab.  Similarly, we assumed "pagehide" meant page closure but actually we need to check the persisted flag.  So I've fixed those issues too.